### PR TITLE
Prevent "invalid byte sequence in UTF-8" errors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem 'sass-rails', '~> 4.0'
 gem 'sprockets', '~> 2.11.0' # 2.12.x breaks sass-rails
 gem 'uglifier', '>= 1.3.0'
 gem 'unicorn'
+gem 'utf8-cleaner'
 
 group :development do
   gem 'rubocop', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -206,6 +206,7 @@ GEM
       kgio (~> 2.6)
       rack
       raindrops (~> 0.7)
+    utf8-cleaner (0.0.9)
     xpath (2.0.0)
       nokogiri (~> 1.3)
 
@@ -233,3 +234,4 @@ DEPENDENCIES
   sprockets (~> 2.11.0)
   uglifier (>= 1.3.0)
   unicorn
+  utf8-cleaner


### PR DESCRIPTION
Removes invalid UTF-8 characters from the environment so the app doesn't choke on them.