### PR TITLE
Add staging environment

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,9 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
-  http_basic_authenticate_with name: ENV['AUTH_USERNAME'], password: ENV['AUTH_PASSWORD'] if Rails.env.production?
+
+  if ENV['AUTH_USERNAME'] && ENV['AUTH_PASSWORD']
+    http_basic_authenticate_with name: ENV['AUTH_USERNAME'], password: ENV['AUTH_PASSWORD']
+  end
 
   layout 'govuk_template'
 end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -1,0 +1,5 @@
+require_relative './production'
+
+Rails.application.configure do
+  # Settings specified here will take precedence over those in config/production.rb.
+end

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -16,6 +16,11 @@ development:
 test:
   secret_key_base: a6b22291774a6d03e15feb6a686e1b675d090188b9a30c4778a341d4480dfc7991fdbd777be005a2b8acc64d532e38874af425534d36822360661f1c666483e8
 
+# Do not keep staging secrets in the repository,
+# instead read values from the environment.
+staging:
+  secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
+
 # Do not keep production secrets in the repository,
 # instead read values from the environment.
 production:


### PR DESCRIPTION
Introduces a new environment - staging - that inherits from production. This is primarily so that we can run a staging application with `RAILS_ENV=staging` and differentiate log streams, performance monitoring etc.

Removes any `Rails.env.production?` anti-patterns.