### PR TITLE
Configure Puma minimum threads from environment

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,6 +1,5 @@
 workers Integer(ENV['WEB_CONCURRENCY'] || 2)
-threads_count = Integer(ENV['MAX_THREADS'] || 5)
-threads threads_count, threads_count
+threads Integer(ENV['MIN_THREADS'] || 1), Integer(ENV['MAX_THREADS'] || 5)
 
 preload_app!
 


### PR DESCRIPTION
Allows Puma’s minimum threads to be configured through the environmental
variable `MIN_THREADS`. On Heroku this is preferable as the server has
fixed resources available to it.