### PR TITLE
Remove Rack::Timeout

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,6 @@ gem 'newrelic_rpm'
 gem 'puma'
 gem 'rack-contrib'
 gem 'rails', '4.2.0'
-gem 'rack-timeout'
 gem 'sass-rails', '~> 4.0'
 gem 'sprockets', '~> 2.11.0' # 2.12.x breaks sass-rails
 gem 'uglifier', '>= 1.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,7 +112,6 @@ GEM
       rack (>= 0.9.1)
     rack-test (0.6.3)
       rack (>= 1.0)
-    rack-timeout (0.1.1)
     rails (4.2.0)
       actionmailer (= 4.2.0)
       actionpack (= 4.2.0)
@@ -220,7 +219,6 @@ DEPENDENCIES
   newrelic_rpm
   puma
   rack-contrib
-  rack-timeout
   rails (= 4.2.0)
   rails_12factor
   rspec-rails (~> 3.0)

--- a/config/initializers/timeout.rb
+++ b/config/initializers/timeout.rb
@@ -1,2 +1,0 @@
-rack_timeout_in_seconds = Integer(ENV['RACK_TIMEOUT_SECONDS']) rescue 20
-Rack::Timeout.timeout = rack_timeout_in_seconds


### PR DESCRIPTION
It's causing massive instability on Heroku