### PR TITLE
Refactor style guide controller

### DIFF
--- a/app/controllers/styleguide_controller.rb
+++ b/app/controllers/styleguide_controller.rb
@@ -2,18 +2,18 @@ class StyleguideController < ApplicationController
   layout 'styleguide/full_width'
 
   def pages_homepage
-    render layout: 'styleguide/full_width', template: 'styleguide/pages/homepage'
+    render template: 'styleguide/pages/homepage'
   end
 
   def pages_guide
-    render layout: 'styleguide/full_width', template: 'styleguide/pages/guide'
+    render template: 'styleguide/pages/guide'
   end
 
   def pages_journey_index
-    render layout: 'styleguide/full_width', template: 'styleguide/pages/journey_index'
+    render template: 'styleguide/pages/journey_index'
   end
 
   def pages_journey_page
-    render layout: 'styleguide/full_width', template: 'styleguide/pages/journey_page'
+    render template: 'styleguide/pages/journey_page'
   end
 end


### PR DESCRIPTION
Don't need to repeat the layout name in the calls to `render`