### PR TITLE
Provide an empty session if CSRF is invalid

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,5 @@
 class ApplicationController < ActionController::Base
-  protect_from_forgery with: :exception
+  protect_from_forgery
 
   if ENV['AUTH_USERNAME'] && ENV['AUTH_PASSWORD']
     http_basic_authenticate_with name: ENV['AUTH_USERNAME'], password: ENV['AUTH_PASSWORD']


### PR DESCRIPTION
In production we have seen a few CORS requests using the HTTP `OPTIONS` verb. These are generating a 500 error because a `ActionController::InvalidAuthenticityToken` was being throw when we try and gracefully render a 404 page.

This change provides an empty session if CSRF token is invalid for the request but doesn't reset it completely. Used as default if `:with` option is not specified.