### PR TITLE
Remove the referral to TPAS and MAS for DB info

### DIFF
--- a/app/views/home/show.html.erb
+++ b/app/views/home/show.html.erb
@@ -194,21 +194,6 @@
       </a></p>
 
     </div>
-    <div class="l-column-half">
-      <p>If you have a defined benefit pension - one based on your salary and
-        length of time with your employer - you can still get information from
-        these organisations:</p>
-
-      <ul class="unstyled-list">
-        <li class="unstyled-list__item">
-          <a rel="external" href="http://www.pensionsadvisoryservice.org.uk/">The
-          Pensions Advisory Service</a>
-        </li>
-        <li class="unstyled-list__item">
-          <a rel="external" href="https://www.moneyadviceservice.org.uk/">
-          The Money Advice Service</a></li>
-      </ul>
-    </div>
   </div>
 </section>
 


### PR DESCRIPTION
We don't want to increase the volume of calls to these organisations during the mass media campaign.