### PR TITLE
Cache govspeak

### DIFF
--- a/app/controllers/guides_controller.rb
+++ b/app/controllers/guides_controller.rb
@@ -41,9 +41,9 @@ class GuidesController < ApplicationController
 
   def decorate(guide_or_collection)
     if guide_or_collection.is_a?(Enumerable)
-      guide_or_collection.map { |guide| GuideDecorator.for(guide) }
+      guide_or_collection.map { |guide| GuideDecorator.cached_for(guide) }
     else
-      GuideDecorator.for(guide_or_collection)
+      GuideDecorator.cached_for(guide_or_collection)
     end
   end
 

--- a/app/decorators/cached_guide_decorator.rb
+++ b/app/decorators/cached_guide_decorator.rb
@@ -1,0 +1,15 @@
+class CachedGuideDecorator < SimpleDelegator
+  attr_accessor :cache
+
+  def initialize(decorator, cache)
+    __setobj__(decorator)
+    self.cache = cache
+  end
+
+  %i(title content).each do |method|
+    define_method(method) do
+      cache_key = "#{__getobj__.id}-#{method}"
+      cache.fetch(cache_key) { super() }
+    end
+  end
+end

--- a/app/decorators/guide_decorator.rb
+++ b/app/decorators/guide_decorator.rb
@@ -23,4 +23,8 @@ class GuideDecorator < Draper::Decorator
     when :html then HTMLGuideDecorator.new(guide)
     end
   end
+
+  def self.cached_for(guide)
+    CachedGuideDecorator.new(self.for(guide), Rails.cache)
+  end
 end

--- a/spec/decorators/cached_guide_decorator_spec.rb
+++ b/spec/decorators/cached_guide_decorator_spec.rb
@@ -1,0 +1,103 @@
+RSpec.describe CachedGuideDecorator do
+  let(:id) { 'id' }
+  let(:title) { 'title' }
+  let(:content) { 'content' }
+  let(:cache) { double }
+  let(:decorator) { double(id: id, title: title, content: content, slug: '', description: '', label: '', url: '') }
+
+  subject(:cached_decorator) { described_class.new(decorator, cache) }
+
+  describe '#title' do
+    it 'uses the correct cache key' do
+      expect(cache).to receive(:fetch).with("#{id}-#{title}")
+      cached_decorator.title
+    end
+
+    context 'when the cache key does not exist' do
+      before do
+        allow(decorator).to receive(:title).and_return(title)
+        allow(cache).to receive(:fetch) do |_key, &block|
+          block.call
+        end
+      end
+
+      it 'calls the decorator' do
+        expect(decorator).to receive(:title)
+        cached_decorator.title
+      end
+
+      it 'returns the value' do
+        expect(cached_decorator.title).to eq(title)
+      end
+    end
+
+    context 'when the cache key exists' do
+      before do
+        allow(cache).to receive(:fetch).and_return(title)
+      end
+
+      it 'does not call the decorator' do
+        expect(decorator).to_not receive(:title)
+        cached_decorator.title
+      end
+
+      it 'returns the cached value' do
+        expect(cached_decorator.title).to eq(title)
+      end
+    end
+  end
+
+  describe '#content' do
+    it 'uses the correct cache key' do
+      expect(cache).to receive(:fetch).with("#{id}-#{content}")
+      cached_decorator.content
+    end
+
+    context 'when the cache key does not exist' do
+      before do
+        allow(decorator).to receive(:content).and_return(content)
+        allow(cache).to receive(:fetch) do |_key, &block|
+          block.call
+        end
+      end
+
+      it 'calls the decorator' do
+        expect(decorator).to receive(:content)
+        cached_decorator.content
+      end
+
+      it 'returns the value' do
+        expect(cached_decorator.content).to eq(content)
+      end
+    end
+
+    context 'when the cache key exists' do
+      before do
+        allow(cache).to receive(:fetch).and_return(content)
+      end
+
+      it 'does not call the decorator' do
+        expect(decorator).to_not receive(:content)
+        cached_decorator.content
+      end
+
+      it 'returns the cached value' do
+        expect(cached_decorator.content).to eq(content)
+      end
+    end
+  end
+
+  %i(id slug description label url).each do |attribute|
+    describe "##{attribute}" do
+      it 'does not call the cache' do
+        expect(cache).to_not receive(:fetch)
+        cached_decorator.public_send(attribute)
+      end
+
+      it 'calls the decorator' do
+        expect(decorator).to receive(attribute)
+        cached_decorator.public_send(attribute)
+      end
+    end
+  end
+end

--- a/spec/decorators/guide_decorator_spec.rb
+++ b/spec/decorators/guide_decorator_spec.rb
@@ -33,6 +33,18 @@ RSpec.describe GuideDecorator, type: :decorator do
     end
   end
 
+  describe '.cached_for' do
+    let(:guide) { double }
+
+    subject(:cached_decorator) { described_class.cached_for(guide) }
+
+    before do
+      expect(described_class).to receive(:for).with(guide)
+    end
+
+    it { is_expected.to be_a(CachedGuideDecorator) }
+  end
+
   describe '#label' do
     let(:guide) { Guide.new('test-guide', label: label) }
 


### PR DESCRIPTION
This caches the `title` and `content` attributes of instances of `GovspeakGuideDecorator`