### PR TITLE
Cache journey nav partial for each guide

### DIFF
--- a/app/views/guides/show.html.erb
+++ b/app/views/guides/show.html.erb
@@ -12,7 +12,9 @@
 
       <hr class="hr-thin">
 
-      <%= render 'components/journey_nav', journey: @journey, current_step: @guide %>
+      <% cache(@guide.slug) do %>
+        <%= render 'components/journey_nav', journey: @journey, current_step: @guide %>
+      <% end %>
     </div>
   <% end %>
 


### PR DESCRIPTION
Rendering a guide page is the slowest part of the app:

![image](https://cloud.githubusercontent.com/assets/45121/7751462/04cef970-ffd2-11e4-9278-d16450123f00.png)

Turns out half the time taken to display a guide page is spent rendering the journey navigation partial:

![image](https://cloud.githubusercontent.com/assets/45121/7751473/1e12d082-ffd2-11e4-84af-59d55de6acd1.png)

Caching this single partial dramatically speeds up rendering time.

Something to consider before this goes in is that the default Rails cache [uses the filesystem](http://guides.rubyonrails.org/caching_with_rails.html#activesupport-cache-filestore) and never expires(!)