### PR TITLE
Fix anchor links to options content

### DIFF
--- a/content/pension_pot_options.md
+++ b/content/pension_pot_options.md
@@ -17,7 +17,7 @@ The remaining 75% you can take as:
         <td class="col-1"></td>
         <th scope="col" class="col-2 options-table__annuity">
           <div class="options-table__hr"></div>
-          <a href="#get-a-guaranteed-income-annuity" id="th-link-annuity">Guaranteed income</a>
+          <a href="#annuity" id="th-link-annuity">Guaranteed income</a>
         </th>
         <th scope="col" class="col-3 options-table__flexible">
           <div class="options-table__hr"></div>

--- a/content/tax.md
+++ b/content/tax.md
@@ -13,7 +13,7 @@ How much tax you pay depends on your total income and the [tax rate](https://www
 
 Your taxable income may include:
 
-- any money you get from your pension pot, eg as an [annuity](/pension-pot-options#get-a-guaranteed-income-annuity) or [cash](/pension-pot-options#take-your-whole-pot-as-cash)
+- any money you get from your pension pot, eg as an [annuity](/pension-pot-options#annuity) or [cash](/pension-pot-options#cash)
 - the State Pension
 - earnings from employment or self employment
 - any other income, eg money from rental income, savings, investments
@@ -29,7 +29,7 @@ There are 2 ways you can take your tax-free lump sum.
 ###Take your lump sum in one go
 You can take 25% of your whole pension pot tax free.
 
-If you do this, you can’t leave the remaining 75% untouched. You must either take it as cash, or buy an [annuity](/pension-pot-options#get-a-guaranteed-income-annuity) with it, or put it into an [flexi-access drawdown](/pension-pot-options#option-1-flexi-access-drawdown) fund.
+If you do this, you can’t leave the remaining 75% untouched. You must either take it as cash, or buy an [annuity](/pension-pot-options#annuity) with it, or [get a flexible income](/pension-pot-options#option-2-get-a-flexible-income).
 
 Any payments you get from the remaining 75% are taxable.
 

--- a/content/when_you_die.md
+++ b/content/when_you_die.md
@@ -20,20 +20,20 @@ The same is true if you take all or part of your pot as cash and don’t use it 
 
 ##Leaving behind a pension
 
-When you die, if you have money still sitting in your pension pot, or if you’re taking your pension as an [annuity](/pension-pot-options#get-a-guaranteed-income-annuity) or as a flexible income ([flexi-access drawdown](/pension-pot-options#get-a-flexible-income)), the following tax rules apply:
+If you still have money in your pension pot, or if you’re taking your pension as an [annuity](/pension-pot-options#annuity) or as [a flexible income](/pension-pot-options#option-2-get-a-flexible-income), the rules are:
 
 
 - your beneficiary will inherit your pension tax free if you die before 75
 - your beneficiary will pay tax if you’re 75 or over when you die
 
 
-If you’re 75 or over when you die, how much tax they pay depends on whether they take it as a single lump sum or use it to get a retirement income (as an annuity or flexi-access drawdown).
+If you’re 75 or over when you die, how much tax they pay depends on whether they take it as a single lump sum or use it to get a retirement income (as an annuity or as a flexible income).
 
 From April 2016, new tax rules apply for inheriting a pension from someone who dies at 75 or later.
 
 ###Using an inheritance to buy a pension
 
-If you inherit a pension you can use the money to buy yourself an annuity or a flexi-access drawdown product. You still pay tax depending on the age of the person you inherited it from and on how you take the money.
+If you inherit a pension you can use the money to buy yourself an annuity or a flexible income. You still pay tax depending on the age of the person you inherited it from and on how you take the money.
 
 ##Money still in your pension pot
 


### PR DESCRIPTION
Changes introduced by #161 caused anchor links to stop working. These changes fix that and updates language to reflect new definitions.