### PR TITLE
CAB locator features

### DIFF
--- a/config/cucumber.yml
+++ b/config/cucumber.yml
@@ -1,7 +1,7 @@
 <%
 rerun = File.file?('rerun.txt') ? IO.read('rerun.txt') : ""
 rerun_opts = rerun.to_s.strip.empty? ? "--format #{ENV['CUCUMBER_FORMAT'] || 'progress'} features" : "--format #{ENV['CUCUMBER_FORMAT'] || 'pretty'} #{rerun}"
-std_opts = "--format #{ENV['CUCUMBER_FORMAT'] || 'pretty'} --strict --tags ~@wip"
+std_opts = "--format #{ENV['CUCUMBER_FORMAT'] || 'pretty'} --strict --tags ~@wip --tags ~@todo"
 %>
 default: <%= std_opts %> features
 wip: --tags @wip:3 --wip features

--- a/features/find_nearest_face-to-face_appointment_locations.feature
+++ b/features/find_nearest_face-to-face_appointment_locations.feature
@@ -1,0 +1,19 @@
+@todo
+Feature: Find nearest face-to-face appointment locations
+  As a customer who'd prefer a face-to-face appointment
+  I want the details of nearest appointment locations
+  So that I can book a convenient face-to-face appointment
+
+Scenario: Search using a valid postcode
+  When I search for appointment locations near to a valid postcode
+  Then I should see the 5 appointment locations nearest to that postcode
+
+Scenario: Search using an invalid postcode (i.e. one that we can't find)
+  When I search for appointment locations near to an invalid postcode
+  Then I should be informed that Pension Wise cannot find that postcode
+
+Scenario: Bookmark search results
+  Given I have searched for appointment locations near to a valid postcode
+  And I have bookmarked the page
+  When I visit the bookmarked page
+  Then I should see the 5 appointment locations nearest to that postcode

--- a/features/view_face-to-face_appointment_location_details.feature
+++ b/features/view_face-to-face_appointment_location_details.feature
@@ -1,0 +1,35 @@
+@todo
+Feature: View face-to-face appointment location details
+  As a customer who'd prefer a face-to-face appointment
+  I want full details of a specific appointment location
+  So that I can book a face-to-face appointment at that location
+
+Scenario: From search results
+  Given I have searched for appointment locations near to a valid postcode
+  When I drill down into a specific search result
+  Then I should see the details of that appointment location
+
+Scenario: Bookmark a appointment location
+  Given I have searched for appointment locations near to a valid postcode
+  And I have drilled down into a specific search result
+  And I have bookmarked the page
+  When I visit the bookmarked page
+  Then I should see the details of that appointment location
+
+Scenario: Appointment location that handles its own booking
+  When I view the details of an appointment location that handles its own booking
+  Then I should see the following appointment location details:
+    | its name                              |
+    | its address                           |
+    | its opening hours                     |
+    | its Pension Wise booking phone number |
+
+Scenario: Appointment location that doesn't handle its own booking
+  When I view the details of an appointment location that doesn't handle its own booking
+  Then I should see the following appointment location details:
+    | its name                                           |
+    | its address                                        |
+    | its opening hours                                  |
+    | booking location name                              |
+    | booking location opening hours                     |
+    | booking location Pension Wise booking phone number |


### PR DESCRIPTION
Add features for locating face-to-face appointment locations, which won't be run currently as they are tagged with `@todo`.