### PR TITLE
Style phone number on iPhone.

### DIFF
--- a/app/assets/stylesheets/components/_highlighted-info.scss
+++ b/app/assets/stylesheets/components/_highlighted-info.scss
@@ -19,6 +19,10 @@
     padding-top: .5em;
   }
 
+  a {
+    color: $color-hightlight-info-link;
+  }
+
   em {
     font-size: 42px;
     font-weight: 700;

--- a/app/assets/stylesheets/lib/_variables.scss
+++ b/app/assets/stylesheets/lib/_variables.scss
@@ -39,6 +39,7 @@ $color-option-mix: $color-blue-biscay;
 
 $color-hightlight-info-bg: $color-green-jungle;
 $color-hightlight-info-text: $color-white;
+$color-hightlight-info-link: $color-white;
 
 $color-blockquote-bg: $color-grey-porcelain;
 $color-blockquote-border: $color-grey-rolling-stone;


### PR DESCRIPTION
Safari on iPhone adds an `<a href=tel:…>` to anything it recognises as a phone number.

cc: @aduggin