### PR TITLE
Add UserZoom JavaScript tracking codes

### DIFF
--- a/app/views/layouts/_base.html.erb
+++ b/app/views/layouts/_base.html.erb
@@ -45,6 +45,7 @@
 
 <% content_for :body_end do %>
   <%= javascript_include_tag 'application' %>
+  <%= javascript_include_tag 'https://cdn3.userzoom.com/uz.js?cuid=C85E515772DAE311BEDA0022196C4538' %>
   <%= yield :after_script %>
 <% end %>
 


### PR DESCRIPTION
Do we want to include logic to exclude by environment? We don't for Google Tag Manager.