### PR TITLE
Visually separate ‘Compare your options’ heading

### DIFF
--- a/app/assets/stylesheets/components/_options-overview.scss
+++ b/app/assets/stylesheets/components/_options-overview.scss
@@ -42,3 +42,8 @@
     padding-top: 0;
   }
 }
+
+.options-overview__compare-title {
+  color: $color-options-overview-compare;
+  font-weight: normal;
+}

--- a/app/assets/stylesheets/lib/_variables.scss
+++ b/app/assets/stylesheets/lib/_variables.scss
@@ -38,6 +38,8 @@ $color-option-adjustable-income: $color-blue-picton;
 $color-option-take-cash: $color-green-atlantis;
 $color-option-mix-options: $color-blue-biscay;
 
+$color-options-overview-compare: $color-grey-rolling-stone;
+
 $color-options-table-bg: $color-grey-black-haze;
 $color-options-table-text: $color-grey-rolling-stone;
 

--- a/content/pension_pot_options.md
+++ b/content/pension_pot_options.md
@@ -39,6 +39,7 @@ You have 5 options:
 {: .hr-thin}
 * * *
 
+{: .options-overview__compare-title}
 ## Compare your options
 
 Compare the 3 options that give you an income or let you take cash:


### PR DESCRIPTION
We believe that users are currently confusing this section with the list of options.

Before:

![screenshot 2015-06-23 11 14 37](https://cloud.githubusercontent.com/assets/2715/8303880/1e6092be-1999-11e5-88b1-b425bbe3af56.png)

After:

![screenshot 2015-06-23 11 14 24](https://cloud.githubusercontent.com/assets/2715/8303882/26c5da4a-1999-11e5-8a5b-50dec0618bb3.png)
