### PR TITLE
Optionally enable garbage collection profiling

### DIFF
--- a/config/initializers/gc_profiling.rb
+++ b/config/initializers/gc_profiling.rb
@@ -1,0 +1,1 @@
+GC::Profiler.enable if ENV['ENABLE_GC_PROFILING']


### PR DESCRIPTION
Setting `ENABLE_GC_PROFILING` in the environment will enable garbage collection instrumentation. Hoping to get some insight into the occasional slowness, and occasional failure-to-exit errors. This will push GC timing to New Relic.

see: https://docs.newrelic.com/docs/agents/ruby-agent/features/garbage-collection#gc_setup