### PR TITLE
Don't redirect when no postcode supplied

### DIFF
--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -2,7 +2,7 @@ class LocationsController < ApplicationController
   layout 'full_width'
 
   def index
-    return redirect_to(appointments_path) unless params[:postcode].present?
+    return render :invalid_postcode unless params[:postcode].present?
 
     @locations = locations.map do |location|
       SearchResultDecorator.new(location)

--- a/spec/controllers/locations_controller_spec.rb
+++ b/spec/controllers/locations_controller_spec.rb
@@ -7,19 +7,19 @@ RSpec.describe LocationsController, type: :controller do
     specify 'without a postcode param' do
       get :index
 
-      expect(response).to redirect_to(appointments_path)
+      expect(response).to render_template(:invalid_postcode)
     end
 
     specify 'with an empty postcode' do
       get :index, postcode: ' '
 
-      expect(response).to redirect_to(appointments_path)
+      expect(response).to render_template(:invalid_postcode)
     end
 
     specify 'with a postcode' do
       get :index, postcode: 'BT7 3AP'
 
-      expect(response).to be_ok
+      expect(response).to render_template(:index)
     end
   end
 


### PR DESCRIPTION
This view will need the search form added to it but will mean people can browse to `/locations`:

![image](https://cloud.githubusercontent.com/assets/45121/8409348/30526594-1e6f-11e5-85f4-f9c3a637daf2.png)
