### PR TITLE
[WIP] Use the GeoJSON Feature ID to identify locations

### DIFF
--- a/lib/locations/location.rb
+++ b/lib/locations/location.rb
@@ -1,7 +1,3 @@
 module Locations
-  Location = Struct.new(:name, :address, :phone, :hours, :lat_lng) do
-    def id
-      name.downcase.gsub(/\W/, '-').gsub(/-{2,}/, '-')
-    end
-  end
+  Location = Struct.new(:id, :name, :address, :phone, :hours, :lat_lng)
 end

--- a/lib/locations/repository.rb
+++ b/lib/locations/repository.rb
@@ -22,6 +22,7 @@ module Locations
     def map_features(features)
       features.map do |feature|
         Location.new(
+          feature.feature_id,
           feature.properties['title'],
           feature.properties['address'],
           feature.properties['phone'],

--- a/spec/fixtures/locations.json
+++ b/spec/fixtures/locations.json
@@ -3,6 +3,7 @@
   "features": [
     {
       "type": "Feature",
+      "id": "704cb1cf-82ad-4051-9a93-abe01a851584",
       "geometry": {
         "type": "Point",
         "coordinates": [

--- a/spec/lib/locations/location_spec.rb
+++ b/spec/lib/locations/location_spec.rb
@@ -1,7 +1,0 @@
-RSpec.describe Locations::Location do
-  let(:name) { 'Local & Beyond - CAB' }
-
-  subject(:location) { described_class.new(name, 'address', 'phone', 'hours', [1, 0]) }
-
-  specify { expect(location.id).to eq('local-beyond-cab') }
-end

--- a/spec/lib/locations/repository_spec.rb
+++ b/spec/lib/locations/repository_spec.rb
@@ -25,10 +25,10 @@ RSpec.describe Locations::Repository do
     end
 
     context 'with an valid id' do
-      let(:id) { 'belfast-citizens-advice-bureau' }
+      let(:id) { '704cb1cf-82ad-4051-9a93-abe01a851584' }
 
       specify { expect(result).to be_a(Locations::Location) }
-      specify { expect(result.name).to eq(name) }
+      specify { expect(result.id).to eq(id) }
     end
   end
 end

--- a/spec/lib/locations/search_result_spec.rb
+++ b/spec/lib/locations/search_result_spec.rb
@@ -1,16 +1,18 @@
 RSpec.describe Locations::SearchResult do
+  let(:id) { 'location-id' }
   let(:name) { 'location name' }
   let(:address) { 'location address' }
   let(:phone) { 'phone number' }
   let(:hours) { 'opening hours' }
   let(:lat_lng) { [1, 0] }
   let(:distance) { 150 }
-  let(:location) { Locations::Location.new(name, address, phone, hours, lat_lng) }
+  let(:location) { Locations::Location.new(id, name, address, phone, hours, lat_lng) }
 
   subject(:search_result) { described_class.new(location, distance) }
 
   it { is_expected.to eq(location) }
 
+  specify { expect(search_result.id).to eq(id) }
   specify { expect(search_result.name).to eq(name) }
   specify { expect(search_result.address).to eq(address) }
   specify { expect(search_result.phone).to eq(phone) }

--- a/spec/lib/locations/search_spec.rb
+++ b/spec/lib/locations/search_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Locations::Search, '.nearest_to' do
-  let(:london) { Locations::Location.new('London', '', '', '', [51.500152, -0.126236]) }
-  let(:paris) { Locations::Location.new('Paris', '', '', '', [48.85666, 2.350987]) }
-  let(:new_york) { Locations::Location.new('New York', '', '', '', [40.714269, 74.005973]) }
+  let(:london) { Locations::Location.new('london', 'London', '', '', '', [51.500152, -0.126236]) }
+  let(:paris) { Locations::Location.new('paris', 'Paris', '', '', '', [48.85666, 2.350987]) }
+  let(:new_york) { Locations::Location.new('new-york', 'New York', '', '', '', [40.714269, 74.005973]) }
   let(:belfast) { [54.597269, -5.930109] }
   let(:locations) { [new_york, paris, london] }
   let(:limit) { 5 }


### PR DESCRIPTION
Generating a slug for each location based on its title is too brittle. We know location titles will change. If that happens previously addressable locations will no longer be addressable.

The GeoJSON specification supports an ID attribute for each location. By using that we can be continue to address a location if its title changes.

***These needs updated cassettes before merging.***