### PR TITLE
Link to relevant appointment content from location profile

### DIFF
--- a/app/views/locations/show.html.erb
+++ b/app/views/locations/show.html.erb
@@ -20,4 +20,5 @@
   <p>We can’t answer specific questions about your pension on this number.</p>
 </div>
 
-<p><a href="/appointments">What you need to know</a> for your face-to-face appointment.</p>
+<p><a href="/appointments#what-youll-get-from-the-appointment">What you need to know</a> for your face-to-face
+    appointment.</p>


### PR DESCRIPTION
Linking to the “What you’ll get from the appointment” heading is more useful to the user since all content before that on the page is about phone booking and who can book.

cc/ @alexkouz @aduggin 