### PR TITLE
Handle postcodes having the correct form but not actually existing

### DIFF
--- a/lib/geocoder.rb
+++ b/lib/geocoder.rb
@@ -1,13 +1,12 @@
 class Geocoder
   InvalidPostcode = Class.new(StandardError)
-  InvalidLookup = Class.new(StandardError)
 
   def self.lookup(postcode)
     ukp = UKPostcode.parse(postcode)
     fail InvalidPostcode unless ukp.full_valid?
 
     lookup = Postcodes::IO.new.lookup(postcode)
-    fail InvalidLookup unless lookup
+    fail InvalidPostcode unless lookup
 
     [lookup.latitude, lookup.longitude]
   end

--- a/spec/lib/geocoder_spec.rb
+++ b/spec/lib/geocoder_spec.rb
@@ -3,11 +3,11 @@ RSpec.describe Geocoder, '.lookup' do
 
   subject(:geocode) { described_class.lookup(postcode) }
 
-  context 'with an invalid postode' do
+  context 'with an invalid syntax postcode' do
     specify { expect { geocode }.to raise_error(Geocoder::InvalidPostcode) }
   end
 
-  context 'with a valid postcode' do
+  context 'with a valid syntax postcode' do
     let(:postcode) { 'BT7 3AP' }
     let(:postcodes_io) { double }
     let(:lat) { 1 }
@@ -21,7 +21,7 @@ RSpec.describe Geocoder, '.lookup' do
     end
 
     context 'but the lookup fails' do
-      specify { expect { geocode }.to raise_error(Geocoder::InvalidLookup) }
+      specify { expect { geocode }.to raise_error(Geocoder::InvalidPostcode) }
     end
 
     context 'and the lookup is successful' do


### PR DESCRIPTION
`UKPostcode` will let through `SW18 0QE` which doesn't exist so we can't give it sole responsibility for catching invalid postcodes and it no longer makes sense to have two possible exceptions raised.

#269