### PR TITLE
Put GOV.UK Elements assets at start of asset pipeline load path

### DIFF
--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -3,8 +3,8 @@ Rails.application.config.assets.version = '1.0'
 Rails.application.config.assets.paths << Rails.root.join('vendor', 'assets', 'bower_components',
                                                          'govuk_elements', 'public', 'sass')
 
-Rails.application.config.assets.paths << Rails.root.join('vendor', 'assets', 'bower_components',
-                                                         'govuk_elements', 'govuk', 'public', 'images')
+Rails.application.config.assets.paths.unshift Rails.root.join('vendor', 'assets', 'bower_components',
+                                                              'govuk_elements', 'govuk', 'public', 'images')
 
 Rails.application.config.assets.precompile += %w( icons/icon-pointer.png
                                                   icons/icon-pointer-2x.png


### PR DESCRIPTION
The SASS in the `govuk_elements` bower component refers to [/assets/icons/icon-pointer.png](https://github.com/alphagov/govuk_elements/blob/master/govuk/public/images/icons/icon-pointer.png) when compiled but the same file is also provided by the `govuk_frontend_toolkit` gem at [/assets/icon-pointer.png](https://github.com/alphagov/govuk_frontend_toolkit/blob/master/images/icon-pointer.png) which is what ends up in the compiled assets.

Put the bower component asset path before those of the gem so the correct url is used in the compiled stylesheet.