### PR TITLE
`validateJSDoc` has been deprecated from JSCS, remove it

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -36,15 +36,6 @@
   "requireSpacesInNamedFunctionExpression": {
     "beforeOpeningCurlyBrace": true
   },
-  "validateJSDoc": {
-    "checkParamNames": true,
-    "checkRedundantParams": true,
-    "requireParamTypes": true,
-    "checkReturnTypes": true,
-    "checkRedundantReturns": true,
-    "requireReturnTypes": true,
-    "checkTypes": true
-  },
   "disallowSpacesInFunctionExpression": {
     "beforeOpeningRoundBrace": true
   },


### PR DESCRIPTION
https://github.com/jscs-dev/node-jscs/issues/993