### PR TITLE
Check that each styleguide page gives a 200

### DIFF
--- a/spec/requests/styleguide_spec.rb
+++ b/spec/requests/styleguide_spec.rb
@@ -1,0 +1,30 @@
+RSpec.describe 'Styleguide', type: :request do
+  describe 'styleguide pages' do
+    routes = Rails.application.routes.routes.map do |route|
+      path = route.path.spec.to_s
+      path.sub(/\(.:format\)/, '') if path =~ /styleguide/ && path !~ /:action/
+    end.compact
+
+    routes.each do |route|
+      it "gives a 200 for each styleguide page #{route}" do
+        get route
+        expect(response.status).to eq(200)
+      end
+    end
+  end
+
+  describe 'styleguide component pages' do
+    components = Dir[Rails.root.join('app', 'views', 'styleguide', '*.html.erb')].map do |f|
+      File.basename(f, '.html.erb')
+    end
+
+    components.each do |component|
+      route = "/styleguide/#{component}"
+
+      it "gives a 200 for each styleguide component page #{route}" do
+        get route
+        expect(response.status).to eq(200)
+      end
+    end
+  end
+end


### PR DESCRIPTION
[`styleguide/components.html.erb`](https://github.com/guidance-guarantee-programme/pension_guidance/blob/8a640f1e1cfaf0d9c4e08ffe073d59305d498d66/app/views/styleguide/components.html.erb#L9) refers to `styleguide/components/_locator_promo.html.erb` which was deleted in 96939d8c1ad7c84675f3bc0a444d27628bd9a48e and is causing a 500 @aduggin 