### PR TITLE
Landing page links

### DIFF
--- a/app/assets/stylesheets/components/_journey-overview.scss
+++ b/app/assets/stylesheets/components/_journey-overview.scss
@@ -1,15 +1,5 @@
 .journey-overview {
   margin-top: 60px;
-
-  a,
-  a:visited {
-    color: $color-black;
-    text-decoration: none;
-  }
-
-  a:hover {
-    text-decoration: underline;
-  }
 }
 
 .journey-overview__item {

--- a/app/assets/stylesheets/components/_options-overview.scss
+++ b/app/assets/stylesheets/components/_options-overview.scss
@@ -9,16 +9,6 @@
     }
   }
 
-  a,
-  a:visited {
-    color: $color-black;
-    text-decoration: none;
-  }
-
-  a:hover {
-    text-decoration: underline;
-  }
-
   .circle {
     position: absolute;
     top: 7px;

--- a/content/6_steps_you_need_to_take.html
+++ b/content/6_steps_you_need_to_take.html
@@ -15,75 +15,75 @@ description: Understand the options for your pension pot by following these step
   <!-- 1 -->
   <section class="journey-overview__item">
     <h2 class="journey-overview__heading" id="step1">
-      <a href="/pension-pot-value">
-        <span class="journey-overview__number journey-overview__number--1">1.</span>
-        Check how much is in your pension pot
-      </a>
+      <span class="journey-overview__number journey-overview__number--1">1.</span>
+      Check how much is in your pension pot
     </h2>
 
     <p>You can ask your pension provider to tell you how much is in your pot. You can also look
       at information your provider has sent to you already, eg a pension statement.</p>
+
+    <p><a href="/pension-pot-value">More on pension pot value</a></p>
   </section>
 
   <!-- 2 -->
   <section class="journey-overview__item">
     <h2 class="journey-overview__heading" id="step2">
-      <a href="/pension-pot-options">
-        <span class="journey-overview__number journey-overview__number--2">2.</span>
-        What you can do with your pension pot
-      </a>
+      <span class="journey-overview__number journey-overview__number--2">2.</span>
+      What you can do with your pension pot
     </h2>
 
     <p>There are different ways you can take money from your pension pot. You can get an income, take cash, or mix your options. You decide when you start taking money from your pot.</p>
+
+    <p><a href="/pension-pot-options">More on your options</a></p>
   </section>
 
   <!-- 3 -->
   <section class="journey-overview__item">
     <h2 class="journey-overview__heading" id="step3">
-      <a href="/making-money-last">
-        <span class="journey-overview__number journey-overview__number--3">3.</span>
-        Plan how long your money needs to last
-      </a>
+      <span class="journey-overview__number journey-overview__number--3">3.</span>
+      Plan how long your money needs to last
     </h2>
 
     <p>Your costs and financial needs are likely to change during retirement. You need to think about when you’ll start taking money from your pension pot and how much you’ll need at different times.</p>
+
+    <p><a href="/making-money-last">More on making your money last</a></p>
   </section>
 
   <!-- 4 -->
   <section class="journey-overview__item">
     <h2 class="journey-overview__heading" id="step4">
-      <a href="/work-out-income">
-        <span class="journey-overview__number journey-overview__number--4">4.</span>
-        Work out how much you’ll have in retirement
-      </a>
+      <span class="journey-overview__number journey-overview__number--4">4.</span>
+      Work out how much you’ll have in retirement
     </h2>
 
     <p>How much income you have is likely to change as you get older. Work out how much money
       you’ll get from your pension and from other income you have and how it’ll cover your costs.</p>
+
+    <p><a href="/work-out-income">More on working out your income</a></p>
   </section>
 
   <!-- 5 -->
   <section class="journey-overview__item">
     <h2 class="journey-overview__heading" id="step5">
-      <a href="/tax">
-        <span class="journey-overview__number journey-overview__number--5">5.</span>
-        Watch out for tax
-      </a>
+      <span class="journey-overview__number journey-overview__number--5">5.</span>
+      Watch out for tax
     </h2>
 
     <p>Your income in retirement is taxed, just like it is when you’re in work.</p>
+
+    <p><a href="/tax">More on tax</a></p>
   </section>
 
   <!-- 6 -->
   <section class="journey-overview__item last-child">
     <h2 class="journey-overview__heading" id="step6">
-      <a href="/shop-around">
-        <span class="journey-overview__number journey-overview__number--6">6.</span>
-        Shop around for the best deal
-      </a>
+      <span class="journey-overview__number journey-overview__number--6">6.</span>
+      Shop around for the best deal
     </h2>
 
     <p>Remember that you don’t have to stay with your current pension provider. People usually benefit from taking time to shop around and compare products. The pack your provider sends you when you reach retirement age is likely to only include information about their own products.</p>
+
+    <p><a href="/shop-around">More on shopping around</a></p>
   </section>
 </div>
 

--- a/content/pension_pot_options.md
+++ b/content/pension_pot_options.md
@@ -11,33 +11,39 @@ You have 6 options:
 <div class="options-overview">
   <div class="options-overview__item">
     <div class="circle circle--s circle--leave-pot-untouched"></div>
-    <h2><a href="/leave-pot-untouched">Leave your whole pot untouched</a></h2>
+    <h2>Leave your whole pot untouched</h2>
     <p>You don’t have to start taking money from your pension pot when you reach your ‘selected retirement age’. You can leave your money invested in your pot until you need it.</p>
+    <p><a href="/leave-pot-untouched">More on leaving your whole pot untouched</a></p>
   </div>
   <div class="options-overview__item">
     <div class="circle circle--s circle--guaranteed-income"></div>
-    <h2><a href="/guaranteed-income">Guaranteed income (annuity)</a></h2>
+    <h2>Guaranteed income (annuity)</h2>
     <p>You use your pot to buy an insurance policy that guarantees you an income for the rest of your life - no matter how long you live.</p>
+    <p><a href="/guaranteed-income">More on getting a guaranteed income (annuity)</a></p>
   </div>
   <div class="options-overview__item">
     <div class="circle circle--s circle--adjustable-income"></div>
-    <h2><a href="/adjustable-income">Adjustable income</a></h2>
+    <h2>Adjustable income</h2>
     <p>Your pot is invested to give you a regular income. You decide how much to take out and when, and how long you want it to last.</p>
+    <p><a href="/adjustable-income">More on adjustable income</a></p>
   </div>
   <div class="options-overview__item">
     <div class="circle circle--s circle--take-cash"></div>
-    <h2><a href="/take-cash-in-chunks">Take cash in chunks</a></h2>
+    <h2>Take cash in chunks</h2>
     <p>You can take smaller sums of money from your pot until you run out.</p>
+    <p><a href="/take-cash-in-chunks">More on taking cash in chunks</a></p>
   </div>
   <div class="options-overview__item">
     <div class="circle circle--s circle--take-cash"></div>
-    <h2><a href="/take-whole-pot">Take your whole pot in one go</a></h2>
+    <h2>Take your whole pot in one go</h2>
     <p>You can cash in your entire pot. One quarter is tax free, the rest is taxable.</p>
+    <p><a href="/take-whole-pot">More on taking your whole pot in one go</a></p>
   </div>
   <div class="options-overview__item">
     <div class="circle circle--s circle--mix-options"></div>
-    <h2><a href="/mix-options">Mix your options</a></h2>
+    <h2>Mix your options</h2>
     <p>You can mix different options. Usually, you would need a bigger pot to do this.</p>
+    <p><a href="/mix-options">More on mixing your options</a></p>
   </div>
 </div>
 


### PR DESCRIPTION
Switching from subtle heading links to more obvious 'More on ...' links on the '6 steps' and 'Options' index page