### PR TITLE
Tell IE11+ there is no "browserconfig.xml"

### DIFF
--- a/app/views/layouts/_base.html.erb
+++ b/app/views/layouts/_base.html.erb
@@ -9,6 +9,9 @@
   <% if content_for?(:meta_description) %>
     <meta name="description" content="<%= content_for(:meta_description) %>">
   <% end %>
+  
+  <%# Tell IE11+ there is no "browserconfig.xml" %>
+  <meta name="msapplication-config" content="none">
 <% end %>
 
 <% content_for :body_start do %>


### PR DESCRIPTION
If a webpage does not specify a browser configuration file, IE11+ automatically looks for "browserconfig.xml" in the root directory of the server. To prevent this, use an "msapplication-config" header with the content attribute to "none". See https://msdn.microsoft.com/en-us/library/dn320426(v=vs.85).aspx