### PR TITLE
Revert "Remove rake task fix for jasmine"

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -17,4 +17,18 @@ begin
 rescue LoadError
 end
 
+Rake::Task['spec:javascript'].clear
+
+namespace :spec do
+  desc 'Run the code examples in spec/javascripts with PhantomJS'
+  task javascript: [:environment] do
+    unless Rails.env.test?
+      system('RAILS_ENV=test bundle exec rake spec:javascript')
+      next
+    end
+    require 'jasmine_rails/runner'
+    JasmineRails::Runner.run ENV['SPEC'], ENV.fetch('REPORTERS', 'console')
+  end
+end
+
 task default: %i(analyse_javascript spec:javascript)


### PR DESCRIPTION
The fix introduced in 0372f76226c1171b88b93e36f372b5764c901993 was reverted in c9bcc895407e7c8180094af410e5b9a23378250e, however running `rake spec:javascript` locally now breaks. Revert it.

Any opinions @andrewgarner ?