### PR TITLE
Handle Postcodes::IO lookup timeouts

### DIFF
--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -14,6 +14,8 @@ class LocationsController < ApplicationController
       end
     rescue Geocoder::InvalidPostcode
       render :invalid_postcode
+    rescue Geocoder::FailedLookup
+      render :failed_lookup
     end
   end
 

--- a/app/views/locations/failed_lookup.html.erb
+++ b/app/views/locations/failed_lookup.html.erb
@@ -1,0 +1,15 @@
+<% content_for(:page_title, 'Find a face-to-face appointment location - Pension Wise') %>
+
+<h1>Something went wrong, please try again</h1>
+
+<form action="/locations" method="get">
+  <div class="form-group">
+    <label class="form-label-bold" for="location">Postcode
+      <span class="form-hint">
+        For example, 'SW1A 1AA'
+      </span>
+    </label>
+    <input type="text" class="form-control" name="postcode" id="location" value="<%= @postcode.squish %>">
+    <input type="submit" class="button" value="Search">
+  </div>
+</form>

--- a/lib/geocoder.rb
+++ b/lib/geocoder.rb
@@ -1,13 +1,20 @@
 class Geocoder
   InvalidPostcode = Class.new(StandardError)
+  FailedLookup = Class.new(StandardError)
 
   def self.lookup(postcode)
     ukp = UKPostcode.parse(postcode)
     fail InvalidPostcode unless ukp.full_valid?
 
-    lookup = Postcodes::IO.new.lookup(postcode)
+    lookup = perform_lookup(postcode)
     fail InvalidPostcode unless lookup
 
     [lookup.latitude, lookup.longitude]
+  end
+
+  def self.perform_lookup(postcode)
+    Postcodes::IO.new.lookup(postcode)
+  rescue
+    raise FailedLookup
   end
 end

--- a/spec/controllers/locations_controller_spec.rb
+++ b/spec/controllers/locations_controller_spec.rb
@@ -24,6 +24,14 @@ RSpec.describe LocationsController, type: :controller do
       expect(response).to render_template(:invalid_postcode)
     end
 
+    specify 'with a failed postcode lookup' do
+      allow(Locations).to receive(:nearest_to_postcode).and_raise(Geocoder::FailedLookup)
+
+      get :index, postcode: 'BT7 3AP'
+
+      expect(response).to render_template(:failed_lookup)
+    end
+
     specify 'with a postcode' do
       get :index, postcode: 'BT7 3AP'
 

--- a/spec/lib/geocoder_spec.rb
+++ b/spec/lib/geocoder_spec.rb
@@ -20,8 +20,16 @@ RSpec.describe Geocoder, '.lookup' do
       allow(postcodes_io).to receive(:lookup).with(postcode).and_return(lookup)
     end
 
-    context 'but the lookup fails' do
+    context 'but the lookup is invalid' do
       specify { expect { geocode }.to raise_error(Geocoder::InvalidPostcode) }
+    end
+
+    context 'but the lookup fails' do
+      before do
+        allow(postcodes_io).to receive(:lookup).with(postcode).and_raise('lookup timeout')
+      end
+
+      specify { expect { geocode }.to raise_error(Geocoder::FailedLookup) }
     end
 
     context 'and the lookup is successful' do


### PR DESCRIPTION
Addresses #322 

The specific exception we've seen raised in production is `Excon::Errors::Timeout` but this covers anything being raised.

Too crude @andrewgarner ? Are we ok with rendering the _xxx is not a valid postcode_ page when this occurs?