### PR TITLE
Search results error page

### DIFF
--- a/app/controllers/search_results_controller.rb
+++ b/app/controllers/search_results_controller.rb
@@ -6,10 +6,6 @@ class SearchResultsController < ApplicationController
 
     @search_results = Search::PerformSearch.new(params[:query], page: params[:page]).call
 
-    if @search_results.any?
-      render :index_with_results
-    else
-      render :index_no_results
-    end
+    render @search_results.any? ? :index_with_results : :index_no_results
   end
 end

--- a/app/controllers/search_results_controller.rb
+++ b/app/controllers/search_results_controller.rb
@@ -4,7 +4,11 @@ class SearchResultsController < ApplicationController
   def index
     return if params[:query].blank?
 
-    @search_results = Search::PerformSearch.new(params[:query], page: params[:page]).call
+    begin
+      @search_results = Search::PerformSearch.new(params[:query], page: params[:page]).call
+    rescue
+      return render :index_error
+    end
 
     render @search_results.any? ? :index_with_results : :index_no_results
   end

--- a/app/views/search_results/index_error.html.erb
+++ b/app/views/search_results/index_error.html.erb
@@ -1,0 +1,10 @@
+<% content_for(:page_title, t('service.title', page_title: t('.document_title', query: params[:query]))) %>
+<% content_for(:search_global, true) %>
+
+<h1 class="heading-search-results">
+  <%= t('.page_title_html', query: params[:query]) %>
+</h1>
+
+<%= render 'form' %>
+
+<p><%= t '.body' %></p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,6 +24,10 @@ en:
       document_title: "%{query} - Search"
       page_title_html: Search results<span class="visually-hidden"> for “%{query}”</span>
       body: No results were found. Please try a different search.
+    index_error:
+      document_title: "%{query} - Search"
+      page_title_html: Search results<span class="visually-hidden"> for “%{query}”</span>
+      body: Something went wrong, please try again.
     index_with_results:
       document_title: "%{query} - Search"
       page_title_html: Search results<span class="visually-hidden"> for “%{query}”</span>

--- a/spec/controllers/search_results_controller_spec.rb
+++ b/spec/controllers/search_results_controller_spec.rb
@@ -39,6 +39,18 @@ RSpec.describe SearchResultsController, type: :controller do
           expect(response).to render_template 'search_results/index_no_results'
         end
       end
+
+      context 'but the lookup fails' do
+        before do
+          allow(searcher).to receive(:call) { fail 'failed lookup' }
+        end
+
+        it 'renders the error page' do
+          get :index, query: query
+
+          expect(response).to render_template 'search_results/index_error'
+        end
+      end
     end
 
     context 'without a search term' do


### PR DESCRIPTION
Google Custom Search Engine has been giving us [a few 5xx errors this last while](https://bugsnag.com/hm-treasury-1/pension-guidance/errors/55e6f68688f8ad5351666b96).

Rendering the search form again on the error page would allow the user to manually retry the search if desired:
![image](https://cloud.githubusercontent.com/assets/45121/10141954/61a3f880-6607-11e5-932c-1815c1afd08a.png)