### PR TITLE
Don't depend on system for DNS resolution

### DIFF
--- a/config/initializers/resolv.rb
+++ b/config/initializers/resolv.rb
@@ -1,0 +1,2 @@
+# http://blog.gregburek.com/2015/02/22/dns-eglibc-and-resolv-replace-on-heroku/
+require 'resolv-replace'


### PR DESCRIPTION
We've had [a few failed DNS lookups](https://bugsnag.com/hm-treasury-1/pension-guidance/errors/56096ff402c5eb752121b3d6) as described [in this post](http://blog.gregburek.com/2015/02/22/dns-eglibc-and-resolv-replace-on-heroku/).

We can give this a spin for a while and see if the problem disappears.