### PR TITLE
Use correct asset paths for media player

### DIFF
--- a/app/assets/stylesheets/components/_player-container.scss
+++ b/app/assets/stylesheets/components/_player-container.scss
@@ -1,3 +1,6 @@
+// see _govuk-elements.scss for explanation
+$path: false;
+
 .player-container {
   @include media-player;
   margin: 0;
@@ -28,22 +31,6 @@
 
   .control-bar {
     .player-controls {
-      .play {
-        background-image: image-url("player-icon-play.png");
-      }
-
-      .pause {
-        background-image: image-url("player-icon-pause.png");
-      }
-
-      .rewind {
-        background-image: image-url("player-icon-rewind.png");
-      }
-
-      .forward {
-        background-image: image-url("player-icon-forward.png");
-      }
-
       .captions {
         display: none;
 


### PR DESCRIPTION
Varible scoping within the `media-player` mixin caused a similar problem to what was solved with https://github.com/guidance-guarantee-programme/pension_guidance/commit/dea46e6195ddfd8e2fb637c4044af536426690cd.

This change solves the 404 on the volume icon and removes the need to redefine the images for the other controls:

![image](https://cloud.githubusercontent.com/assets/45121/10369720/9d2a86b6-6dd3-11e5-8a69-711e276b5828.png)

