### PR TITLE
Disable `Switchboard` lookups after testing

### DIFF
--- a/spec/lib/switchboard_spec.rb
+++ b/spec/lib/switchboard_spec.rb
@@ -8,6 +8,10 @@ RSpec.describe Switchboard, '.lookup' do
     Registry[:switchboard_connection] = connection
   end
 
+  after(:all) do
+    Registry[:switchboard_connection] = nil
+  end
+
   subject(:lookup) { described_class.lookup(id) }
 
   context 'when the connection does not exist' do


### PR DESCRIPTION
The connection was lingering around and causing tests hitting `LocationsController#show` to fail whenever they were ran after.

Failure demonstrated with:
```
rspec ./spec/lib/switchboard_spec.rb ./spec/controllers/locations_journey_breadcrumbs_spec.rb:48 --seed 64399
```