### PR TITLE
Add asset from `govuk_elements` to precompile list

### DIFF
--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -4,6 +4,9 @@ Rails.application.config.assets.paths << Rails.root.join('vendor', 'assets', 'bo
                                                          'govuk_elements', 'public', 'sass')
 
 Rails.application.config.assets.paths << Rails.root.join('vendor', 'assets', 'bower_components',
+                                                         'govuk_elements', 'public', 'images')
+
+Rails.application.config.assets.paths << Rails.root.join('vendor', 'assets', 'bower_components',
                                                          'govuk_elements', 'govuk', 'public',
                                                          'javascripts', 'vendor')
 
@@ -17,6 +20,7 @@ Rails.application.config.assets.precompile += %w( apple-touch-icon-120x120.png
                                                   experiments/*.js
                                                   favicon.ico
                                                   gov.uk_logotype_crown.png
+                                                  icon-arrow-left.png
                                                   icons/icon-pointer-2x.png
                                                   icons/icon-pointer.png
                                                   opengraph-image.png


### PR DESCRIPTION
We've had a small trickle of 404s for one of the `govuk_elements` assets:

![image](https://cloud.githubusercontent.com/assets/45121/10605319/54fcce28-7722-11e5-9ba5-d7d0d4f2f34b.png)

__elements/_elements-typography.scss__ pulls in [icon-arrow-left.png](https://github.com/alphagov/govuk_elements/blob/32009ec34756d0acc95350b12a276cbe726f3de6/public/sass/elements/_elements-typography.scss#L235) from [public/images](https://github.com/alphagov/govuk_elements/tree/master/public/images) which wasn't being picked up by Sprockets.