### PR TITLE
[DO NOT MERGE] Take whole pot calculator

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,4 +1,6 @@
 //= require jquery/dist/jquery.min.js
 //= require click-tracker.js
+//= require take-whole-pot-calculator
 
 PWPG.clickTracker.init();
+PWPG.takeWholePotCalculator.init();

--- a/app/assets/javascripts/take-whole-pot-calculator.js
+++ b/app/assets/javascripts/take-whole-pot-calculator.js
@@ -5,13 +5,32 @@
     init: function() {
       var $calculator = $('.js-take-whole-pot-calculator form');
       var $result = $('<div class="calculator__result" aria-live="polite"></div>').appendTo($calculator);
+      var $loadingStatus = $('<span class="calculator__loading-status">Please wait...</span>').
+                            insertAfter($calculator.find('#js-calculate'));
 
-      $calculator.on('submit', function(event) {
+      $calculator.on('submit', $.proxy(function(event) {
         event.preventDefault();
-        $.get($calculator.attr('action'), $calculator.serialize()).then(function(data) {
+
+        this.toggleLoading($loadingStatus, true);
+
+        $.get($calculator.attr('action'), $calculator.serialize()).then($.proxy(function(data) {
           $result.html(data).removeAttr('aria-live').attr('aria-live', 'polite');
-        });
-      });
+
+          this.scrollTo($result).then($.proxy(function() {
+            this.toggleLoading($loadingStatus, false);
+          }, this));
+        }, this));
+      }, this));
+    },
+
+    toggleLoading: function($el, to) {
+      $el[to ? 'show' : 'hide']();
+    },
+
+    scrollTo: function($el) {
+      return $('html, body').animate({
+        scrollTop: $el.offset().top
+      }, 500).promise();
     }
   };
 

--- a/app/assets/javascripts/take-whole-pot-calculator.js
+++ b/app/assets/javascripts/take-whole-pot-calculator.js
@@ -4,8 +4,7 @@
   var takeWholePotCalculator = {
     init: function() {
       var $calculator = $('.js-take-whole-pot-calculator form');
-
-      $calculator.append('<div class="calculator__result" aria-live="polite"></div>');
+      var $result = $('<div class="calculator__result" aria-live="polite"></div>').appendTo($calculator);
 
       $calculator.on('submit', function(event) {
         event.preventDefault();

--- a/app/assets/javascripts/take-whole-pot-calculator.js
+++ b/app/assets/javascripts/take-whole-pot-calculator.js
@@ -1,0 +1,21 @@
+(function($) {
+  'use strict';
+
+  var takeWholePotCalculator = {
+    init: function() {
+      var $calculator = $('.js-take-whole-pot-calculator form');
+
+      $calculator.append('<div class="calculator__result" aria-live="polite"></div>');
+
+      $calculator.on('submit', function(event) {
+        event.preventDefault();
+        $.get($calculator.attr('action'), $calculator.serialize()).then(function(data) {
+          $result.html(data).removeAttr('aria-live').attr('aria-live', 'polite');
+        });
+      });
+    }
+  };
+
+  window.PWPG = window.PWPG || {};
+  window.PWPG.takeWholePotCalculator = takeWholePotCalculator;
+})(jQuery);

--- a/app/assets/stylesheets/components/_calculator.scss
+++ b/app/assets/stylesheets/components/_calculator.scss
@@ -7,6 +7,11 @@
   border-bottom: 1px solid $color-grey-silver-sand;
 }
 
+.calculator__loading-status {
+  display: none;
+  line-height: 2.15;
+}
+
 .calculator__field {
   width: auto;
 }

--- a/app/assets/stylesheets/components/_calculator.scss
+++ b/app/assets/stylesheets/components/_calculator.scss
@@ -7,11 +7,15 @@
   border-bottom: 1px solid $color-grey-silver-sand;
 }
 
-.calculator--take-whole-pot__pension {
+.calculator__field {
+  width: auto;
+}
+
+.calculator__field--small {
   width: 25%;
 }
 
-.calculator--take-whole-pot__pension-frequency {
+.calculator__field--frequency-select {
   width: 25%;
   -webkit-appearance: menulist;
 }

--- a/app/assets/stylesheets/components/_calculator.scss
+++ b/app/assets/stylesheets/components/_calculator.scss
@@ -1,0 +1,23 @@
+.calculator {
+  overflow: hidden;
+}
+
+.calculator--in-article {
+  border-top: 1px solid $color-grey-silver-sand;
+  border-bottom: 1px solid $color-grey-silver-sand;
+}
+
+.calculator--take-whole-pot__pension {
+  width: 25%;
+}
+
+.calculator--take-whole-pot__pension-frequency {
+  width: 25%;
+  -webkit-appearance: menulist;
+}
+
+.calculator__result__number {
+  @include bold-24;
+  display: block;
+  margin: .4em .5em .4em 0;
+}

--- a/app/controllers/take_whole_pot_calculator_controller.rb
+++ b/app/controllers/take_whole_pot_calculator_controller.rb
@@ -1,0 +1,30 @@
+class TakeWholePotCalculatorController < ApplicationController
+  layout 'guides'
+
+  before_action :set_params
+
+  def show
+    result = TakeWholePotCalculator.new(@pot, total_income)
+    @pot_received = result.pot_received
+    @pot_tax = result.pot_tax
+  end
+
+  private
+
+  def set_params
+    @pot = params[:pot].to_i
+    @income = params[:income].to_i
+    @pension = params[:pension].to_i
+    @pension_frequency = params[:pension_frequency]
+  end
+
+  def total_income
+    annual_pension = case @pension_frequency
+                     when 'weekly'
+                       @pension * 52
+                     when 'annually'
+                       @pension
+                     end
+    @income + annual_pension
+  end
+end

--- a/app/controllers/take_whole_pot_calculator_controller.rb
+++ b/app/controllers/take_whole_pot_calculator_controller.rb
@@ -7,6 +7,8 @@ class TakeWholePotCalculatorController < ApplicationController
     result = TakeWholePotCalculator.new(@pot, total_income)
     @pot_received = result.pot_received
     @pot_tax = result.pot_tax
+
+    return render partial: 'results' if request.xhr?
   end
 
   private

--- a/app/views/take_whole_pot_calculator/_results.html.erb
+++ b/app/views/take_whole_pot_calculator/_results.html.erb
@@ -2,11 +2,11 @@
   Based on what you've told us, if you take your whole <%= number_to_currency(@pot) %>
   pension pot in one go, you could receive:
 
-  <strong class="calculator__result__number"><%= number_to_currency(@pot_received) %></strong>
+  <strong class="calculator__result__number t-pot-received"><%= number_to_currency(@pot_received) %></strong>
 
   after paying:
 
-  <strong class="calculator__result__number"><%= number_to_currency(@pot_tax) %> in tax</strong>
+  <strong class="calculator__result__number t-pot-tax"><%= number_to_currency(@pot_tax) %> in tax</strong>
 </p>
 
 <h2>Things to note</h2>

--- a/app/views/take_whole_pot_calculator/_results.html.erb
+++ b/app/views/take_whole_pot_calculator/_results.html.erb
@@ -1,0 +1,23 @@
+<p>
+  Based on what you've told us, if you take your whole <%= number_to_currency(@pot) %>
+  pension pot in one go, you could receive:
+
+  <strong class="calculator__result__number"><%= number_to_currency(@pot_received) %></strong>
+
+  after paying:
+
+  <strong class="calculator__result__number"><%= number_to_currency(@pot_tax) %> in tax</strong>
+</p>
+
+<h2>Things to note</h2>
+
+<ol>
+  <li>What you receive includes your 25% tax-free sum</li>
+  <li>To work out how much tax you have to pay, your pension monies are added to your other taxable income for the year</li>
+  <li>How much tax you pay will depend on your individual circumstances</li>
+</ol>
+
+<div class="application-notice help-notice">
+  <p>Pension payments are likely to attract emergency tax. Your provider may reimburse you
+  automatically, otherwise you can claim back the extra tax yourself.</p>
+</div>

--- a/app/views/take_whole_pot_calculator/show.html.erb
+++ b/app/views/take_whole_pot_calculator/show.html.erb
@@ -1,0 +1,43 @@
+<a class="link-back" href="/take-whole-pot">Back to description</a>
+
+<h1>Taking your whole pot in one go</h1>
+
+<div class="calculator">
+  <h2 id="estimate-how-much">Estimate how much you would get</h2>
+
+  <form action="/take-whole-pot/results#estimate-how-much" method="get">
+    <div class="form-group">
+      <label class="form-label" for="pot">
+        Total value of your pension pot(s)
+      </label>
+      £ <input class="form-control" type="text" id="pot" name="pot" value="<%= @pot %>">
+    </div>
+
+    <div class="form-group">
+      <label class="form-label" for="income">
+        Your total other income for the year (before tax)
+        <span class="form-hint">Earnings and income from any savings or benefits.</span>
+      </label>
+      £ <input class="form-control" type="text" id="income" name="income" value="<%= @income %>">
+    </div>
+
+    <div class="form-group">
+      <label class="form-label" for="pension">
+        State pension
+      </label>
+      £ <input class="form-control calculator--take-whole-pot__pension" type="text" id="pension" name="pension" value="<%= @pension %>">
+      <select class="form-control calculator--take-whole-pot__pension-frequency" name="pension_frequency">
+        <option value="weekly" <%= 'selected' if @pension_frequency == 'weekly' %>>Weekly</option>
+        <option value="annually" <%= 'selected' if @pension_frequency == 'annually' %>>Annually</option>
+      </select>
+    </div>
+
+    <div class="form-group">
+      <input type="submit" class="button" value="Calculate" id="js-calculate">
+    </div>
+  </form>
+
+  <%= render partial: 'results' %>
+</div>
+
+<a class="link-back" href="/take-whole-pot">Back to description</a>

--- a/app/views/take_whole_pot_calculator/show.html.erb
+++ b/app/views/take_whole_pot_calculator/show.html.erb
@@ -10,7 +10,7 @@
       <label class="form-label" for="pot">
         Total value of your pension pot(s)
       </label>
-      £ <input class="form-control" type="text" id="pot" name="pot" value="<%= @pot %>">
+      <span id="pot-a">£</span> <input aria-labelledby="pot-a" class="form-control calculator__field" type="text" id="pot" name="pot" value="<%= @pot %>">
     </div>
 
     <div class="form-group">
@@ -18,15 +18,15 @@
         Your total other income for the year (before tax)
         <span class="form-hint">Earnings and income from any savings or benefits.</span>
       </label>
-      £ <input class="form-control" type="text" id="income" name="income" value="<%= @income %>">
+      <span id="income-a">£</span> <input aria-labelledby="income-a" class="form-control calculator__field" type="text" id="income" name="income" value="<%= @income %>">
     </div>
 
     <div class="form-group">
       <label class="form-label" for="pension">
         State pension
       </label>
-      £ <input class="form-control calculator--take-whole-pot__pension" type="text" id="pension" name="pension" value="<%= @pension %>">
-      <select class="form-control calculator--take-whole-pot__pension-frequency" name="pension_frequency">
+      <span id="pension-a">£</span> <input aria-labelledby="pension-a" class="form-control calculator__field--small" type="text" id="pension" name="pension" value="<%= @pension %>">
+      <select class="form-control calculator__field--frequency-select" name="pension_frequency">
         <option value="weekly" <%= 'selected' if @pension_frequency == 'weekly' %>>Weekly</option>
         <option value="annually" <%= 'selected' if @pension_frequency == 'annually' %>>Annually</option>
       </select>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,3 +31,8 @@ en:
     index_with_results:
       document_title: "%{query} - Search"
       page_title_html: Search results<span class="visually-hidden"> for “%{query}”</span>
+
+  number:
+    currency:
+      format:
+        unit: £

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,6 +33,8 @@ Rails.application.routes.draw do
     end
   end
 
+  get 'take-whole-pot/results', controller: 'take_whole_pot_calculator', action: 'show'
+
   if Rails.application.config.mount_javascript_test_routes
     mount JasmineRails::Engine => '/specs'
     mount JasmineFixtures => '/spec/javascripts/fixtures'

--- a/content/take_whole_pot.md
+++ b/content/take_whole_pot.md
@@ -24,7 +24,7 @@ Adding a large cash sum to your income could mean that you get bumped into a hig
 Adding a large sum of cash to your income could also affect [your entitlement to any benefits](/benefits).
 
 {::options parse_block_html="false" /}
-<div class="calculator calculator--in-article">
+<div class="calculator calculator--in-article js-take-whole-pot-calculator">
   <h2>Estimate how much you would get</h2>
 
   <form action="/take-whole-pot/results#estimate-how-much" method="get">

--- a/content/take_whole_pot.md
+++ b/content/take_whole_pot.md
@@ -9,15 +9,6 @@ description: You can cash in your whole pension pot - 75% of that money is taxab
 
 You can take your whole pot as cash in one go - 25% is tax-free, the remaining 75% is taxable.
 
-{: .info-notice--take-cash}
-$E **Example**
-Your pot is £60,000.
-You can take £15,000 tax-free.
-The remaining £45,000 is taxable.
-You don’t have any other income.
-**You pay £7,400 in tax on your cash.**
-$E
-
 Any cash your provider pays you will have the [tax owed](/tax) already taken off.
 
 ## Watch out for higher tax
@@ -30,24 +21,49 @@ The cash you take will be added to any other income you have over the tax year. 
 
 Adding a large cash sum to your income could mean that you get bumped into a higher tax rate.
 
-{: .info-notice--take-cash}
-$E
-**Example**
-Your current income for the year is £20,000 and you pay tax at the basic rate of 20%.
-Your pension pot is £60,000.
-You get £15,000 tax free.
-The remaining £45,000 is added to your other income of £20,000.
-Your total income for the year is now £65,000.
-Everything over £31,785 will be taxed at the higher rate of 40%.
-**You’ll pay £15,400 in tax.**
-$E
-
 Adding a large sum of cash to your income could also affect [your entitlement to any benefits](/benefits).
+
+{::options parse_block_html="false" /}
+<div class="calculator calculator--in-article">
+  <h2>Estimate how much you would get</h2>
+
+  <form action="/take-whole-pot/results#estimate-how-much" method="get">
+    <div class="form-group">
+      <label class="form-label" for="pot">
+        Total value of your pension pot(s)
+      </label>
+      £ <input class="form-control" type="text" id="pot" name="pot">
+    </div>
+
+    <div class="form-group">
+      <label class="form-label" for="income">
+        Your total other income for the year (before tax)
+        <span class="form-hint">Earnings and income from any savings or benefits.</span>
+      </label>
+      £ <input class="form-control" type="text" id="income" name="income">
+    </div>
+
+    <div class="form-group">
+      <label class="form-label" for="pension">
+        State pension
+      </label>
+      £ <input class="form-control calculator--take-whole-pot__pension" type="text" id="pension" name="pension">
+      <select class="form-control calculator--take-whole-pot__pension-frequency" name="pension_frequency">
+        <option value="weekly">Weekly</option>
+        <option value="annually">Annually</option>
+      </select>
+    </div>
+
+    <div class="form-group">
+      <input type="submit" class="button" value="Calculate" id="js-calculate">
+    </div>
+  </form>
+</div>
+{::options parse_block_html="true" /}
 
 ## Your next steps
 
 Here are some next steps if you’re interested in taking cash:
 
 - check with your provider if you can take 25% tax free
-- make sure you know [how much tax you’ll pay](/tax) on the remaining 75%
 - if you want to reinvest the money, talk to a [registered financial adviser](http://www.fca.org.uk/register) first

--- a/content/take_whole_pot.md
+++ b/content/take_whole_pot.md
@@ -9,19 +9,19 @@ description: You can cash in your whole pension pot - 75% of that money is taxab
 
 You can take your whole pot as cash in one go - 25% is tax-free, the remaining 75% is taxable.
 
-Any cash your provider pays you will have the [tax owed](/tax) already taken off.
+You pay tax when you take money from your pot. This is because when you’re paying into your pension you get [tax relief](https://www.gov.uk/tax-on-your-private-pension/pension-tax-relief) on your contributions.
+
+Any money you receive from your pension provider will be paid to you with the tax already taken off.
 
 ## Watch out for higher tax
 
-It’s important to calculate how much tax you would pay on the amount if you take your whole pot in one go.
+It’s important to calculate how much tax you would pay if you take your whole pot in one go.
 
-%Taking a large sum of cash from your pension pot can mean you pay a higher amount of tax.%
+%Taking a large sum of cash from your pot can mean you pay a higher amount of tax.%
 
-The cash you take will be added to any other income you have over the tax year.  At the end of the tax year HM Revenue and Customs will calculate how much tax you owe.
+The cash you take will be added to any other income you have over the tax year, eg money from work, savings and benefits. At the end of the tax year HM Revenue and Customs will calculate how much tax you owe. 
 
-Adding a large cash sum to your income could mean that you get bumped into a higher tax rate.
-
-Adding a large sum of cash to your income could also affect [your entitlement to any benefits](/benefits).
+Adding a large cash sum to your income could mean that you get bumped into a higher tax rate. It could also affect your [entitlement to any benefits](/benefits).
 
 {::options parse_block_html="false" /}
 <div class="calculator calculator--in-article js-take-whole-pot-calculator">
@@ -63,7 +63,7 @@ Adding a large sum of cash to your income could also affect [your entitlement to
 
 ## Your next steps
 
-Here are some next steps if you’re interested in taking cash:
+Here are some next steps if you’re interested in taking your whole pot in one go:
 
 - check with your provider if you can take 25% tax free
 - if you want to reinvest the money, talk to a [registered financial adviser](http://www.fca.org.uk/register) first

--- a/content/take_whole_pot.md
+++ b/content/take_whole_pot.md
@@ -32,7 +32,7 @@ Adding a large sum of cash to your income could also affect [your entitlement to
       <label class="form-label" for="pot">
         Total value of your pension pot(s)
       </label>
-      £ <input class="form-control" type="text" id="pot" name="pot">
+      <span id="pot-a">£</span> <input aria-labelledby="pot-a" class="form-control calculator__field" type="text" id="pot" name="pot" value="0">
     </div>
 
     <div class="form-group">
@@ -40,17 +40,17 @@ Adding a large sum of cash to your income could also affect [your entitlement to
         Your total other income for the year (before tax)
         <span class="form-hint">Earnings and income from any savings or benefits.</span>
       </label>
-      £ <input class="form-control" type="text" id="income" name="income">
+      <span id="income-a">£</span> <input aria-labelledby="income-a" class="form-control calculator__field" type="text" id="income" name="income" value="0">
     </div>
 
     <div class="form-group">
       <label class="form-label" for="pension">
         State pension
       </label>
-      £ <input class="form-control calculator--take-whole-pot__pension" type="text" id="pension" name="pension">
-      <select class="form-control calculator--take-whole-pot__pension-frequency" name="pension_frequency">
-        <option value="weekly">Weekly</option>
-        <option value="annually">Annually</option>
+      <span id="pension-a">£</span> <input aria-labelledby="pension-a" class="form-control calculator__field--small" type="text" id="pension" name="pension" value="0">
+      <select class="form-control calculator__field--frequency-select" name="pension_frequency">
+        <option value="weekly" selected>Weekly</option>
+        <option value="annually" >Annually</option>
       </select>
     </div>
 

--- a/lib/take_whole_pot_calculator.rb
+++ b/lib/take_whole_pot_calculator.rb
@@ -3,6 +3,16 @@ class TakeWholePotCalculator
   PERSONAL_ALLOWANCE_REDUCTION_THRESHOLD = 100_000
   PERSONAL_ALLOWANCE_REDUCTION_RATIO = 2
 
+  BASIC_RATE_UPPER_LIMIT = 31_785
+  BASIC_RATE_TAX = 0.2
+
+  HIGHER_RATE_UPPER_LIMIT = 150_000
+  HIGHER_RATE_TAX = 0.4
+
+  ADDITIONAL_RATE_TAX = 0.45
+
+  TAXABLE_POT_PORTION = 0.75
+
   def self.personal_allowance_for(income)
     if income <= PERSONAL_ALLOWANCE_REDUCTION_THRESHOLD
       STANDARD_PERSONAL_ALLOWANCE
@@ -15,4 +25,44 @@ class TakeWholePotCalculator
       STANDARD_PERSONAL_ALLOWANCE - reduction
     end
   end
+
+  # rubocop:disable AbcSize, MethodLength
+  def self.marginal_tax_for_pot_with_income(pot, income)
+    potentially_taxable_pot = pot * TAXABLE_POT_PORTION
+    allowance = personal_allowance_for(potentially_taxable_pot + income)
+
+    # adjust bands according to income
+    income_above_allowance = [income - allowance, 0].max
+    effective_allowance = [allowance - income, 0].max
+    effective_basic_rate_upper_limit = [BASIC_RATE_UPPER_LIMIT - income_above_allowance, 0].max
+    effective_higher_rate_upper_limit = [HIGHER_RATE_UPPER_LIMIT - income_above_allowance, 0].max
+
+    # personal allowance
+    remaining_taxable_pot = if potentially_taxable_pot <= effective_allowance
+                              0
+                            else
+                              [potentially_taxable_pot - effective_allowance, 0].max
+                            end
+
+    # basic rate
+    subject_to_basic_rate = [remaining_taxable_pot, effective_basic_rate_upper_limit].min
+    remaining_taxable_pot -= subject_to_basic_rate
+
+    # higher rate
+    subject_to_higher_rate = [
+      remaining_taxable_pot,
+      (effective_higher_rate_upper_limit - effective_basic_rate_upper_limit)
+    ].min
+    remaining_taxable_pot -= subject_to_higher_rate
+
+    # additional rate
+    subject_to_additional_rate = remaining_taxable_pot
+
+    {
+      basic: subject_to_basic_rate * BASIC_RATE_TAX,
+      higher: subject_to_higher_rate * HIGHER_RATE_TAX,
+      additional: subject_to_additional_rate * ADDITIONAL_RATE_TAX
+    }
+  end
+  # rubocop:enable AbcSize, MethodLength
 end

--- a/lib/take_whole_pot_calculator.rb
+++ b/lib/take_whole_pot_calculator.rb
@@ -1,0 +1,18 @@
+class TakeWholePotCalculator
+  STANDARD_PERSONAL_ALLOWANCE = 10_600
+  PERSONAL_ALLOWANCE_REDUCTION_THRESHOLD = 100_000
+  PERSONAL_ALLOWANCE_REDUCTION_RATIO = 2
+
+  def self.personal_allowance_for(income)
+    if income <= PERSONAL_ALLOWANCE_REDUCTION_THRESHOLD
+      STANDARD_PERSONAL_ALLOWANCE
+    else
+      amount_over_threshold = income - PERSONAL_ALLOWANCE_REDUCTION_THRESHOLD
+      reduction = [
+        amount_over_threshold / PERSONAL_ALLOWANCE_REDUCTION_RATIO,
+        STANDARD_PERSONAL_ALLOWANCE
+      ].min
+      STANDARD_PERSONAL_ALLOWANCE - reduction
+    end
+  end
+end

--- a/lib/take_whole_pot_calculator.rb
+++ b/lib/take_whole_pot_calculator.rb
@@ -13,6 +13,8 @@ class TakeWholePotCalculator
 
   TAXABLE_POT_PORTION = 0.75
 
+  attr_accessor :pot_received, :pot_tax
+
   def self.personal_allowance_for(income)
     if income <= PERSONAL_ALLOWANCE_REDUCTION_THRESHOLD
       STANDARD_PERSONAL_ALLOWANCE
@@ -65,4 +67,10 @@ class TakeWholePotCalculator
     }
   end
   # rubocop:enable AbcSize, MethodLength
+
+  def initialize(pot, income)
+    tax = self.class.marginal_tax_for_pot_with_income(pot, income)
+    self.pot_tax = tax.values.reduce(:+)
+    self.pot_received = pot - pot_tax
+  end
 end

--- a/spec/controllers/take_whole_pot_calculator_controller_spec.rb
+++ b/spec/controllers/take_whole_pot_calculator_controller_spec.rb
@@ -1,0 +1,40 @@
+RSpec.describe TakeWholePotCalculatorController, type: :controller do
+  describe 'POST show' do
+    let(:pot) { 100_000 }
+    let(:income) { 10_000 }
+    let(:pension) { 1_000 }
+    let(:result) { double(pot_received: 0, pot_tax: 0) }
+
+    context 'when the pension is paid weekly' do
+      let(:pension_frequency) { 'weekly' }
+      let(:total_income) { 62_000 }
+
+      it 'calculates the total income' do
+        expect(TakeWholePotCalculator).to receive(:new).with(
+          pot, total_income
+        ).and_return(result)
+
+        get :show, pot: pot,
+                   income: income,
+                   pension: pension,
+                   pension_frequency: pension_frequency
+      end
+    end
+
+    context 'when the pension is paid annually' do
+      let(:pension_frequency) { 'annually' }
+      let(:total_income) { 11_000 }
+
+      it 'calculates the total income' do
+        expect(TakeWholePotCalculator).to receive(:new).with(
+          pot, total_income
+        ).and_return(result)
+
+        post :show, pot: pot,
+                    income: income,
+                    pension: pension,
+                    pension_frequency: pension_frequency
+      end
+    end
+  end
+end

--- a/spec/features/take_whole_pot_calculator_spec.rb
+++ b/spec/features/take_whole_pot_calculator_spec.rb
@@ -1,0 +1,15 @@
+RSpec.describe 'Take whole pot calculator', type: :feature do
+  with_and_without_javascript do
+    scenario 'Calculates tax payable and money receivable' do
+      visit '/take-whole-pot'
+
+      fill_in 'pot', with: 100_000
+      fill_in 'income', with: 7_000
+      fill_in 'pension', with: 5_000
+      select 'Annual', from: 'pension_frequency'
+      click_on 'Calculate'
+
+      expect(page.find('.t-pot-tax')).to have_content('£23,923.00')
+    end
+  end
+end

--- a/spec/lib/take_whole_pot_calculator_spec.rb
+++ b/spec/lib/take_whole_pot_calculator_spec.rb
@@ -161,4 +161,41 @@ RSpec.describe TakeWholePotCalculator do
       end
     end
   end
+
+  scenarios =
+    [{
+      income:       0,
+      pot:          10_000,
+      pot_tax:      0,
+      pot_received: 10_000
+    }, {
+      income:       10_000,
+      pot:          20_000,
+      pot_tax:      2_880,
+      pot_received: 17_120
+    }, {
+      income:       30_000,
+      pot:          50_000,
+      pot_tax:      12_523,
+      pot_received: 37_477
+    }, {
+      income:       0,
+      pot:          160_000,
+      pot_tax:      41_403,
+      pot_received: 118_597
+    }, {
+      income:       70_000,
+      pot:          250_000,
+      pot_tax:      80_375,
+      pot_received: 169_625
+    }]
+
+  scenarios.each do |scenario|
+    context "with a pot of £#{scenario[:pot]} and an income of £#{scenario[:income]}" do
+      subject(:calculator) { TakeWholePotCalculator.new(scenario[:pot], scenario[:income]) }
+
+      specify { expect(calculator.pot_received).to eq(scenario[:pot_received]) }
+      specify { expect(calculator.pot_tax).to eq(scenario[:pot_tax]) }
+    end
+  end
 end

--- a/spec/lib/take_whole_pot_calculator_spec.rb
+++ b/spec/lib/take_whole_pot_calculator_spec.rb
@@ -22,4 +22,143 @@ RSpec.describe TakeWholePotCalculator do
       it { is_expected.to eq(0) }
     end
   end
+
+  describe '.marginal_tax_for_pot_with_income' do
+    let(:pot) { 0 }
+    let(:income) { 0 }
+
+    subject(:tax) { described_class.marginal_tax_for_pot_with_income(pot, income) }
+
+    context 'when income is 0' do
+      describe 'and taxable portion of pot is within the personal allowance' do
+        let(:pot) { 10_000 }
+
+        it do
+          is_expected.to eq(
+            basic: 0,
+            higher: 0,
+            additional: 0
+          )
+        end
+      end
+
+      describe 'and taxable portion of pot is within the basic rate band' do
+        let(:pot) { 20_000 }
+
+        it do
+          is_expected.to eq(
+            basic: 880,
+            higher: 0,
+            additional: 0
+          )
+        end
+      end
+
+      describe 'and taxable portion of pot is within the higher rate band' do
+        let(:pot) { 60_000 }
+
+        it do
+          is_expected.to eq(
+            basic: 6357,
+            higher: 1046,
+            additional: 0
+          )
+        end
+      end
+
+      describe 'and taxable portion of pot is within the additional rate band' do
+        let(:pot) { 220_000 }
+
+        it do
+          is_expected.to eq(
+            basic: 6357,
+            higher: 47_286,
+            additional: 6750
+          )
+        end
+      end
+    end
+
+    context 'when income is within the basic rate band' do
+      let(:income) { 15_000 }
+
+      describe 'and taxable portion of pot is within the basic rate band' do
+        let(:pot) { 20_000 }
+
+        it do
+          is_expected.to eq(
+            basic: 3000,
+            higher: 0,
+            additional: 0
+          )
+        end
+      end
+
+      describe 'and taxable portion of pot is within the higher rate band' do
+        let(:pot) { 40_000 }
+
+        it do
+          is_expected.to eq(
+            basic: 5477,
+            higher: 1046,
+            additional: 0
+          )
+        end
+      end
+
+      describe 'and taxable portion of pot is within the additional rate band' do
+        let(:pot) { 200_000 }
+
+        it do
+          is_expected.to eq(
+            basic: 3357,
+            higher: 47_286,
+            additional: 6750
+          )
+        end
+      end
+    end
+
+    context 'when income is within the higher rate band' do
+      let(:income) { 45_000 }
+
+      describe 'and taxable portion of pot is within the higher rate band' do
+        let(:pot) { 20_000 }
+
+        it do
+          is_expected.to eq(
+            basic: 0,
+            higher: 6000,
+            additional: 0
+          )
+        end
+      end
+
+      describe 'and taxable portion of pot is within the additional rate band' do
+        let(:income) { 160_000 }
+        let(:pot) { 20_000 }
+
+        it do
+          is_expected.to eq(
+            basic: 0,
+            higher: 0,
+            additional: 6750
+          )
+        end
+      end
+    end
+
+    context 'when income is within the additional rate band' do
+      let(:pot) { 20_000 }
+      let(:income) { 150_000 }
+
+      it do
+        is_expected.to eq(
+          basic: 0,
+          higher: 0,
+          additional: 6750
+        )
+      end
+    end
+  end
 end

--- a/spec/lib/take_whole_pot_calculator_spec.rb
+++ b/spec/lib/take_whole_pot_calculator_spec.rb
@@ -1,0 +1,25 @@
+RSpec.describe TakeWholePotCalculator do
+  describe '.personal_allowance_for' do
+    let(:income) { 0 }
+
+    subject(:personal_allowance) { described_class.personal_allowance_for(income) }
+
+    context 'when £100,000 and below total income' do
+      let(:income) { 100_000 }
+
+      it { is_expected.to eq(10_600) }
+    end
+
+    context 'when between £100,000 and £121,200 total income' do
+      let(:income) { 110_000 }
+
+      it { is_expected.to eq(5_600) }
+    end
+
+    context 'when £121,200 and above total income' do
+      let(:income) { 122_000 }
+
+      it { is_expected.to eq(0) }
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,8 @@ Capybara.default_wait_time = 20
 Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 
 RSpec.configure do |config|
+  config.extend GroupHelpers
+
   config.default_formatter = 'doc' if config.files_to_run.one?
   config.order = :random
   config.profile_examples = 10

--- a/spec/support/helpers/with_and_without_javascript.rb
+++ b/spec/support/helpers/with_and_without_javascript.rb
@@ -1,0 +1,15 @@
+module GroupHelpers
+  def with_and_without_javascript(&block)
+    feature 'with javascript' do
+      metadata[:js] = true
+
+      class_exec(&block)
+    end
+
+    feature 'without javascript' do
+      metadata[:js] = false
+
+      class_exec(&block)
+    end
+  end
+end


### PR DESCRIPTION
This basically a reworking of [prototype-whole-pot-calculator](https://github.com/guidance-guarantee-programme/pension_guidance/compare/prototype-whole-pot-calculator) but with the logic implemented in Ruby and incorporating the feedback from lab testing.

It follows the style of progressive enhancement introduced with [leave-pot-untouched-calculator](https://github.com/guidance-guarantee-programme/pension_guidance/compare/leave-pot-untouched-calculator) and appears thus on `/take-whole-pot`:
![image](https://cloud.githubusercontent.com/assets/45121/10887101/39d15cc6-817d-11e5-9a25-a172a1df4443.png)

The computed result looks like:
![image](https://cloud.githubusercontent.com/assets/45121/10887151/7c168296-817d-11e5-8519-85793fe2f2c8.png)

The look and feel is my best effort at reproducing the user-researchers' design and no doubt fails to live up to @aduggin's legacy so will be good to get @benbarnett's opinion when he comes onboard.