### PR TITLE
[DO NOT MERGE] Take whole pot calculator - server-side validation

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -3,4 +3,3 @@
 //= require take-whole-pot-calculator
 
 PWPG.clickTracker.init();
-PWPG.takeWholePotCalculator.init();

--- a/app/controllers/take_whole_pot_calculator_controller.rb
+++ b/app/controllers/take_whole_pot_calculator_controller.rb
@@ -1,32 +1,17 @@
 class TakeWholePotCalculatorController < ApplicationController
   layout 'guides'
 
-  before_action :set_params
-
   def show
-    result = TakeWholePotCalculator.new(@pot, total_income)
-    @pot_received = result.pot_received
-    @pot_tax = result.pot_tax
+    @pot = params[:pot]
+    @income = params[:income]
+    @pension = params[:pension]
+    @pension_frequency = params[:pension_frequency]
+
+    @calculator = TakeWholePotCalculatorForm.new(
+      pot: @pot, income: @income, pension: @pension,
+      pension_frequency: @pension_frequency)
+    @result = @calculator.result
 
     return render partial: 'results' if request.xhr?
-  end
-
-  private
-
-  def set_params
-    @pot = params[:pot].to_i
-    @income = params[:income].to_i
-    @pension = params[:pension].to_i
-    @pension_frequency = params[:pension_frequency]
-  end
-
-  def total_income
-    annual_pension = case @pension_frequency
-                     when 'weekly'
-                       @pension * 52
-                     when 'annually'
-                       @pension
-                     end
-    @income + annual_pension
   end
 end

--- a/app/forms/take_whole_pot_calculator_form.rb
+++ b/app/forms/take_whole_pot_calculator_form.rb
@@ -3,6 +3,8 @@ require 'active_model'
 class TakeWholePotCalculatorForm
   include ActiveModel::Model
 
+  WEEKS_PER_YEAR = 52
+
   attr_accessor :pot, :income, :pension, :pension_frequency
 
   validates :pot, presence: true, numericality: { greater_than_or_equal_to: 0 }
@@ -20,5 +22,21 @@ class TakeWholePotCalculatorForm
 
   def pension
     Float(@pension.gsub(/,/, '')) rescue @pension
+  end
+
+  def result
+    TakeWholePotCalculator.new(pot, total_income) if valid?
+  end
+
+  private
+
+  def total_income
+    annual_pension = case pension_frequency
+                     when 'weekly'
+                       pension * WEEKS_PER_YEAR
+                     when 'annually'
+                       pension
+                     end
+    income + annual_pension
   end
 end

--- a/app/forms/take_whole_pot_calculator_form.rb
+++ b/app/forms/take_whole_pot_calculator_form.rb
@@ -3,6 +3,7 @@ require 'active_model'
 class TakeWholePotCalculatorForm
   include ActiveModel::Model
 
+  MAXIMUM_STATE_PENSION = 10_400
   WEEKS_PER_YEAR = 52
 
   attr_accessor :pot, :income, :pension, :pension_frequency
@@ -11,6 +12,7 @@ class TakeWholePotCalculatorForm
   validates :income, numericality: true
   validates :pension, numericality: true
   validates :pension_frequency, inclusion: { in: %w(weekly annually) }
+  validate :within_state_pension_limit
 
   def pot
     Float(@pot.gsub(/,/, '')) rescue @pot
@@ -30,13 +32,22 @@ class TakeWholePotCalculatorForm
 
   private
 
+  def within_state_pension_limit
+    errors.add(:pension, :above_limit) if annual_pension > MAXIMUM_STATE_PENSION
+  end
+
+  def annual_pension
+    return 0 unless pension_frequency && pension
+
+    case pension_frequency
+    when 'weekly'
+      pension * WEEKS_PER_YEAR
+    when 'annually'
+      pension
+    end
+  end
+
   def total_income
-    annual_pension = case pension_frequency
-                     when 'weekly'
-                       pension * WEEKS_PER_YEAR
-                     when 'annually'
-                       pension
-                     end
     income + annual_pension
   end
 end

--- a/app/forms/take_whole_pot_calculator_form.rb
+++ b/app/forms/take_whole_pot_calculator_form.rb
@@ -1,0 +1,24 @@
+require 'active_model'
+
+class TakeWholePotCalculatorForm
+  include ActiveModel::Model
+
+  attr_accessor :pot, :income, :pension, :pension_frequency
+
+  validates :pot, presence: true, numericality: { greater_than_or_equal_to: 0 }
+  validates :income, numericality: true
+  validates :pension, numericality: true
+  validates :pension_frequency, inclusion: { in: %w(weekly annually) }
+
+  def pot
+    Float(@pot.gsub(/,/, '')) rescue @pot
+  end
+
+  def income
+    Float(@income.gsub(/,/, '')) rescue @income
+  end
+
+  def pension
+    Float(@pension.gsub(/,/, '')) rescue @pension
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,5 @@
 module ApplicationHelper
+  def format_currency(amount)
+    number_to_currency(amount).sub(/\.00$/, '')
+  end
 end

--- a/app/views/take_whole_pot_calculator/_results.html.erb
+++ b/app/views/take_whole_pot_calculator/_results.html.erb
@@ -1,12 +1,14 @@
+<% return unless @result %>
+
 <p>
-  Based on what you've told us, if you take your whole <%= number_to_currency(@pot) %>
+  Based on what you've told us, if you take your whole <%= number_to_currency(@calculator.pot) %>
   pension pot in one go, you could receive:
 
-  <strong class="calculator__result__number t-pot-received"><%= number_to_currency(@pot_received) %></strong>
+  <strong class="calculator__result__number t-pot-received"><%= number_to_currency(@result.pot_received) %></strong>
 
   after paying:
 
-  <strong class="calculator__result__number t-pot-tax"><%= number_to_currency(@pot_tax) %> in tax</strong>
+  <strong class="calculator__result__number t-pot-tax"><%= number_to_currency(@result.pot_tax) %> in tax</strong>
 </p>
 
 <h2>Things to note</h2>

--- a/app/views/take_whole_pot_calculator/_results.html.erb
+++ b/app/views/take_whole_pot_calculator/_results.html.erb
@@ -1,14 +1,14 @@
 <% return unless @result %>
 
 <p>
-  Based on what you've told us, if you take your whole <%= number_to_currency(@calculator.pot) %>
+  Based on what you've told us, if you take your whole <%= format_currency(@calculator.pot) %>
   pension pot in one go, you could receive:
 
-  <strong class="calculator__result__number t-pot-received"><%= number_to_currency(@result.pot_received) %></strong>
+  <strong class="calculator__result__number t-pot-received"><%= format_currency(@result.pot_received) %></strong>
 
   after paying:
 
-  <strong class="calculator__result__number t-pot-tax"><%= number_to_currency(@result.pot_tax) %> in tax</strong>
+  <strong class="calculator__result__number t-pot-tax"><%= format_currency(@result.pot_tax) %> in tax</strong>
 </p>
 
 <h2>Things to note</h2>

--- a/app/views/take_whole_pot_calculator/show.html.erb
+++ b/app/views/take_whole_pot_calculator/show.html.erb
@@ -1,3 +1,14 @@
+<% content_for(:data_layer) do %>
+  <script>
+    dataLayer = [{
+      'pot': '<%= @pot %>',
+      'income': '<%= @income %>',
+      'pension': '<%= @pension %>',
+      'pension_frequency': '<%= @pension_frequency %>'
+    }];
+  </script>
+<% end %>
+
 <a class="link-back" href="/take-whole-pot">Back to description</a>
 
 <h1>Taking your whole pot in one go</h1>

--- a/app/views/take_whole_pot_calculator/show.html.erb
+++ b/app/views/take_whole_pot_calculator/show.html.erb
@@ -5,26 +5,51 @@
 <div class="calculator">
   <h2 id="estimate-how-much">Estimate how much you would get</h2>
 
+  <% unless @calculator.valid? %>
+    <div class="error-summary" role="group" aria-labelledby="error-summary-heading" tabindex="-1">
+
+      <h1 class="heading-medium error-summary-heading" id="error-summary-heading">
+        There was a problem with your details
+      </h1>
+
+      <ul class="error-summary-list">
+        <% @calculator.errors.keys.each do |attribute| %>
+          <li><a href="#<%= attribute %>"><%= @calculator.errors.full_messages_for(attribute).first %></a></li>
+        <% end %>
+      </ul>
+
+    </div>
+  <% end %>
+
   <form action="/take-whole-pot/results#estimate-how-much" method="get">
-    <div class="form-group">
+    <div class="form-group <%= 'error' if @calculator.errors.has_key?(:pot) %>">
       <label class="form-label" for="pot">
         Total value of your pension pot(s)
       </label>
+      <% if @calculator.errors.has_key?(:pot) %>
+        <span class="error-message"><%= @calculator.errors.full_messages_for(:pot).first %></span>
+      <% end %>
       <span id="pot-a">£</span> <input aria-labelledby="pot-a" class="form-control calculator__field" type="text" id="pot" name="pot" value="<%= @pot %>">
     </div>
 
-    <div class="form-group">
+    <div class="form-group <%= 'error' if @calculator.errors.has_key?(:income) %>">
       <label class="form-label" for="income">
         Your total other income for the year (before tax)
         <span class="form-hint">Earnings and income from any savings or benefits.</span>
       </label>
+      <% if @calculator.errors.has_key?(:income) %>
+        <span class="error-message"><%= @calculator.errors.full_messages_for(:income).first %></span>
+      <% end %>
       <span id="income-a">£</span> <input aria-labelledby="income-a" class="form-control calculator__field" type="text" id="income" name="income" value="<%= @income %>">
     </div>
 
-    <div class="form-group">
+    <div class="form-group <%= 'error' if @calculator.errors.has_key?(:pension) %>">
       <label class="form-label" for="pension">
         State pension
       </label>
+      <% if @calculator.errors.has_key?(:pension) %>
+        <span class="error-message"><%= @calculator.errors.full_messages_for(:pension).first %></span>
+      <% end %>
       <span id="pension-a">£</span> <input aria-labelledby="pension-a" class="form-control calculator__field--small" type="text" id="pension" name="pension" value="<%= @pension %>">
       <select class="form-control calculator__field--frequency-select" name="pension_frequency">
         <option value="weekly" <%= 'selected' if @pension_frequency == 'weekly' %>>Weekly</option>

--- a/app/views/take_whole_pot_calculator/show.html.erb
+++ b/app/views/take_whole_pot_calculator/show.html.erb
@@ -14,7 +14,7 @@
 
       <ul class="error-summary-list">
         <% @calculator.errors.keys.each do |attribute| %>
-          <li><a href="#<%= attribute %>"><%= @calculator.errors.full_messages_for(attribute).first %></a></li>
+          <li><a href="#<%= attribute %>"><%= @calculator.errors[attribute].first %></a></li>
         <% end %>
       </ul>
 
@@ -27,7 +27,7 @@
         Total value of your pension pot(s)
       </label>
       <% if @calculator.errors.has_key?(:pot) %>
-        <span class="error-message"><%= @calculator.errors.full_messages_for(:pot).first %></span>
+        <span class="error-message"><%= @calculator.errors[:pot].first %></span>
       <% end %>
       <span id="pot-a">£</span> <input aria-labelledby="pot-a" class="form-control calculator__field" type="text" id="pot" name="pot" value="<%= @pot %>">
     </div>
@@ -38,7 +38,7 @@
         <span class="form-hint">Earnings and income from any savings or benefits.</span>
       </label>
       <% if @calculator.errors.has_key?(:income) %>
-        <span class="error-message"><%= @calculator.errors.full_messages_for(:income).first %></span>
+        <span class="error-message"><%= @calculator.errors[:income].first %></span>
       <% end %>
       <span id="income-a">£</span> <input aria-labelledby="income-a" class="form-control calculator__field" type="text" id="income" name="income" value="<%= @income %>">
     </div>
@@ -48,7 +48,7 @@
         State pension
       </label>
       <% if @calculator.errors.has_key?(:pension) %>
-        <span class="error-message"><%= @calculator.errors.full_messages_for(:pension).first %></span>
+        <span class="error-message"><%= @calculator.errors[:pension].first %></span>
       <% end %>
       <span id="pension-a">£</span> <input aria-labelledby="pension-a" class="form-control calculator__field--small" type="text" id="pension" name="pension" value="<%= @pension %>">
       <select class="form-control calculator__field--frequency-select" name="pension_frequency">

--- a/app/views/take_whole_pot_calculator/show.html.erb
+++ b/app/views/take_whole_pot_calculator/show.html.erb
@@ -1,10 +1,15 @@
 <% content_for(:data_layer) do %>
   <script>
     dataLayer = [{
+      'valid': <%= !@result.nil? %>,
       'pot': '<%= @pot %>',
       'income': '<%= @income %>',
       'pension': '<%= @pension %>',
       'pension_frequency': '<%= @pension_frequency %>'
+      <% if @result %> ,
+        'pot_tax': '<%= @result.pot_tax %>',
+        'pot_received': '<%= @result.pot_received %>'
+      <% end %>
     }];
   </script>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -43,3 +43,6 @@ en:
         take_whole_pot_calculator_form:
           blank: 'Using numbers, please enter the value of your %{attribute}'
           not_a_number: 'Using numbers, please enter the value of your %{attribute}'
+          attributes:
+            pension:
+              above_limit: "You’ve entered more than the maximum allowable state pension"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,3 +36,10 @@ en:
     currency:
       format:
         unit: £
+
+  activemodel:
+    errors:
+      models:
+        take_whole_pot_calculator_form:
+          blank: 'Using numbers, please enter the value of your %{attribute}'
+          not_a_number: 'Using numbers, please enter the value of your %{attribute}'

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -5,3 +5,4 @@ Disallow: /book$
 Disallow: /book.html$
 Disallow: /email/
 Disallow: /signposting/
+Disallow: /take-whole-pot/results

--- a/spec/controllers/take_whole_pot_calculator_controller_spec.rb
+++ b/spec/controllers/take_whole_pot_calculator_controller_spec.rb
@@ -2,12 +2,12 @@ RSpec.describe TakeWholePotCalculatorController, type: :controller do
   describe 'POST show' do
     let(:pot) { 100_000 }
     let(:income) { 10_000 }
-    let(:pension) { 1_000 }
+    let(:pension) { 200 }
     let(:result) { double(pot_received: 0, pot_tax: 0) }
 
     context 'when the pension is paid weekly' do
       let(:pension_frequency) { 'weekly' }
-      let(:total_income) { 62_000 }
+      let(:total_income) { 20_400 }
 
       it 'calculates the total income' do
         expect(TakeWholePotCalculator).to receive(:new).with(
@@ -23,7 +23,7 @@ RSpec.describe TakeWholePotCalculatorController, type: :controller do
 
     context 'when the pension is paid annually' do
       let(:pension_frequency) { 'annually' }
-      let(:total_income) { 11_000 }
+      let(:total_income) { 10_200 }
 
       it 'calculates the total income' do
         expect(TakeWholePotCalculator).to receive(:new).with(

--- a/spec/features/take_whole_pot_calculator_analytics_spec.rb
+++ b/spec/features/take_whole_pot_calculator_analytics_spec.rb
@@ -1,0 +1,28 @@
+RSpec.feature 'Take whole pot calculator analytics', type: :feature, js: true do
+  let(:pot) { '100000' }
+  let(:income) { '7000' }
+  let(:pension) { '5000' }
+  let(:pension_frequency) { 'annually' }
+  let(:pension_frequency_label) { 'Annual' }
+
+  def data_layer
+    Array(page.evaluate_script('window.dataLayer')).reduce({}, :merge)
+  end
+
+  scenario 'Calculator inputs available to the Google Tag Manage dataLayer' do
+    visit '/take-whole-pot'
+
+    fill_in 'pot', with: pot
+    fill_in 'income', with: income
+    fill_in 'pension', with: pension
+    select pension_frequency_label, from: 'pension_frequency'
+    click_on 'Calculate'
+
+    expect(data_layer).to include(
+      'pot' => pot,
+      'income' => income,
+      'pension' => pension,
+      'pension_frequency' => pension_frequency
+    )
+  end
+end

--- a/spec/features/take_whole_pot_calculator_analytics_spec.rb
+++ b/spec/features/take_whole_pot_calculator_analytics_spec.rb
@@ -2,27 +2,59 @@ RSpec.feature 'Take whole pot calculator analytics', type: :feature, js: true do
   let(:pot) { '100000' }
   let(:income) { '7000' }
   let(:pension) { '5000' }
+  let(:pension_invalid) { '5000000' }
   let(:pension_frequency) { 'annually' }
   let(:pension_frequency_label) { 'Annual' }
+
+  scenario 'with invalid input' do
+    enter_invalid_data
+    perform_calculation
+
+    expect(data_layer).to include(
+      'pot' => pot,
+      'income' => income,
+      'pension' => pension_invalid,
+      'pension_frequency' => pension_frequency,
+      'valid' => false
+    )
+  end
+
+  scenario 'with valid input' do
+    enter_valid_data
+    perform_calculation
+
+    expect(data_layer).to include(
+      'pot' => pot,
+      'income' => income,
+      'pension' => pension,
+      'pension_frequency' => pension_frequency,
+      'valid' => true,
+      'pot_tax' => '23923.0',
+      'pot_received' => '76077.0'
+    )
+  end
+
+  private
 
   def data_layer
     Array(page.evaluate_script('window.dataLayer')).reduce({}, :merge)
   end
 
-  scenario 'Calculator inputs available to the Google Tag Manage dataLayer' do
+  def enter_valid_data
     visit '/take-whole-pot'
 
     fill_in 'pot', with: pot
     fill_in 'income', with: income
     fill_in 'pension', with: pension
     select pension_frequency_label, from: 'pension_frequency'
-    click_on 'Calculate'
+  end
 
-    expect(data_layer).to include(
-      'pot' => pot,
-      'income' => income,
-      'pension' => pension,
-      'pension_frequency' => pension_frequency
-    )
+  def enter_invalid_data
+    enter_valid_data
+    fill_in 'pension', with: pension_invalid
+  end
+
+  def perform_calculation
+    click_on 'Calculate'
   end
 end

--- a/spec/features/take_whole_pot_calculator_spec.rb
+++ b/spec/features/take_whole_pot_calculator_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe 'Take whole pot calculator', type: :feature do
       select 'Annual', from: 'pension_frequency'
       click_on 'Calculate'
 
-      expect(page.find('.t-pot-tax')).to have_content('£23,923.00')
+      expect(page.find('.t-pot-received')).to have_content('£76,077')
+      expect(page.find('.t-pot-tax')).to have_content('£23,923')
     end
   end
 end

--- a/spec/forms/take_whole_pot_calculator_form_spec.rb
+++ b/spec/forms/take_whole_pot_calculator_form_spec.rb
@@ -1,0 +1,21 @@
+RSpec.describe TakeWholePotCalculatorForm do
+  it { is_expected.to validate_presence_of(:pot) }
+  it { should validate_numericality_of(:pot).is_greater_than_or_equal_to(0) }
+  it { should validate_numericality_of(:income) }
+  it { should validate_numericality_of(:pension) }
+  it { should validate_inclusion_of(:pension_frequency).in_array(%w(weekly annually)) }
+
+  describe 'type coercion' do
+    subject(:calculator) do
+      described_class.new(
+        pot: '100,000',
+        income: '10,000',
+        pension: '1,000'
+      )
+    end
+
+    specify { expect(calculator.pot).to eq(100_000.00) }
+    specify { expect(calculator.income).to eq(10_000.00) }
+    specify { expect(calculator.pension).to eq(1_000.00) }
+  end
+end

--- a/spec/forms/take_whole_pot_calculator_form_spec.rb
+++ b/spec/forms/take_whole_pot_calculator_form_spec.rb
@@ -5,6 +5,35 @@ RSpec.describe TakeWholePotCalculatorForm do
   it { should validate_numericality_of(:pension) }
   it { should validate_inclusion_of(:pension_frequency).in_array(%w(weekly annually)) }
 
+  describe 'maximum state pension' do
+    let(:pension) { 115 }
+    let(:pension_frequency) { 'weekly' }
+
+    subject(:form) do
+      described_class.new(pension: pension, pension_frequency: pension_frequency)
+    end
+
+    before { form.validate }
+
+    context 'below the limit' do
+      specify { expect(form.errors).to_not have_key(:pension) }
+    end
+
+    context 'at the limit' do
+      let(:pension) { 10_400 }
+      let(:pension_frequency) { 'annually' }
+
+      specify { expect(form.errors).to_not have_key(:pension) }
+    end
+
+    context 'above the limit' do
+      let(:pension) { 201 }
+      let(:pension_frequency) { 'weekly' }
+
+      specify { expect(form.errors).to have_key(:pension) }
+    end
+  end
+
   describe 'type coercion' do
     subject(:calculator) do
       described_class.new(
@@ -22,7 +51,7 @@ RSpec.describe TakeWholePotCalculatorForm do
   describe '#result' do
     let(:pot) { 100_000 }
     let(:income) { 10_000 }
-    let(:pension) { 1_000 }
+    let(:pension) { 100 }
     let(:pension_frequency) { 'weekly' }
     let(:params) do
       {
@@ -48,7 +77,7 @@ RSpec.describe TakeWholePotCalculatorForm do
     end
 
     context 'when the pension is paid weekly' do
-      let(:total_income) { 62_000 }
+      let(:total_income) { 15_200 }
 
       it 'calculates the total income' do
         expect(TakeWholePotCalculator).to receive(:new).with(pot, total_income)
@@ -58,7 +87,7 @@ RSpec.describe TakeWholePotCalculatorForm do
 
     context 'when the pension is paid annually' do
       let(:pension_frequency) { 'annually' }
-      let(:total_income) { 11_000 }
+      let(:total_income) { 10_100 }
 
       it 'calculates the total income' do
         expect(TakeWholePotCalculator).to receive(:new).with(pot, total_income)

--- a/spec/forms/take_whole_pot_calculator_form_spec.rb
+++ b/spec/forms/take_whole_pot_calculator_form_spec.rb
@@ -18,4 +18,52 @@ RSpec.describe TakeWholePotCalculatorForm do
     specify { expect(calculator.income).to eq(10_000.00) }
     specify { expect(calculator.pension).to eq(1_000.00) }
   end
+
+  describe '#result' do
+    let(:pot) { 100_000 }
+    let(:income) { 10_000 }
+    let(:pension) { 1_000 }
+    let(:pension_frequency) { 'weekly' }
+    let(:params) do
+      {
+        pot: pot,
+        income: income,
+        pension: pension,
+        pension_frequency: pension_frequency
+      }
+    end
+
+    def calculate_result
+      described_class.new(params).result
+    end
+
+    subject(:result) { calculate_result }
+
+    it { is_expected.to be_a(TakeWholePotCalculator) }
+
+    context 'with invalid input' do
+      let(:pot) { 'invalid' }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'when the pension is paid weekly' do
+      let(:total_income) { 62_000 }
+
+      it 'calculates the total income' do
+        expect(TakeWholePotCalculator).to receive(:new).with(pot, total_income)
+        calculate_result
+      end
+    end
+
+    context 'when the pension is paid annually' do
+      let(:pension_frequency) { 'annually' }
+      let(:total_income) { 11_000 }
+
+      it 'calculates the total income' do
+        expect(TakeWholePotCalculator).to receive(:new).with(pot, total_income)
+        calculate_result
+      end
+    end
+  end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,6 @@
+RSpec.describe ApplicationHelper, type: :helper do
+  describe '#format_currency' do
+    specify { expect(helper.format_currency(1_000_000)).to eq('£1,000,000') }
+    specify { expect(helper.format_currency(1_000.50)).to eq('£1,000.50') }
+  end
+end


### PR DESCRIPTION
A clunky first pass at performing side-side validation of calculator input and displaying validation errs per the [GOV.UK guidlines](http://govuk-elements.herokuapp.com/errors):

![image](https://cloud.githubusercontent.com/assets/45121/11037581/57e34f70-86f6-11e5-8723-4c0892a1a732.png)

At this stage this doesn't deal with commas in the supplied values and we still need to render values with the correct decimalisation. More helpful validation messages would also be an idea.