### PR TITLE
Don't override `window.dataLayer` if it already exists

### DIFF
--- a/app/views/take_whole_pot_calculator/_results.html.erb
+++ b/app/views/take_whole_pot_calculator/_results.html.erb
@@ -1,5 +1,6 @@
 <script>
-  dataLayer = [{
+  window.dataLayer = window.dataLayer || [];
+  dataLayer.push({
     'valid': <%= @calculator.valid? %>,
     'pot': <%= @calculator.pot.to_i %>,
     'income': <%= @calculator.income.to_i %>,
@@ -8,7 +9,7 @@
       'pot_tax': <%= @result.pot_tax.to_i %>,
       'pot_received': <%= @result.pot_received.to_i %>
     <% end %>
-  }];
+  });
 </script>
 
 <% if @result %>


### PR DESCRIPTION
This is perhaps the cause of the problem Jim has reported. See:

http://www.simoahava.com/gtm-tips/datalayer-declaration-vs-push/