### PR TITLE
Hyphen errors on options pages

### DIFF
--- a/content/adjustable_income.md
+++ b/content/adjustable_income.md
@@ -36,12 +36,12 @@ The income you get from the fund is taxable. Your provider will pay you the inco
 {: .info-notice--adjustable-income}
 $E
 **Example**
-You have a pot of £80,000 and take a tax-free lump sum of £20,000. This leaves you with £60,000 to invest into flexi-access. You get an income of £3,000 a year from your fund. If you pay 20% tax on this your provider pays you £2,400.
+You have a pot of £80,000 and take a tax-free lump sum of £20,000. This leaves you with £60,000 to invest into flexi-access drawdown. You get an income of £3,000 a year from your fund. If you pay 20% tax on this your provider pays you £2,400.
 $E
 
 If you take the 25% tax-free lump sum, under current pension rules you must buy your flexi-access product within 6 months or use one of the [other options](/pension-pot-options).
 
-Alternatively, you can move your pot gradually into flexi-access - you don’t have to move it all at once. Each time you move an amount you can take 25% tax free.
+Alternatively, you can move your pot gradually into flexi-access drawdown – you don’t have to move it all at once. Each time you move an amount you can take 25% tax free.
 
 If the pension provider your fund is with goes bust you’ll be covered by the [Financial Services Compensation Scheme](http://www.fscs.org.uk/what-we-cover).
 
@@ -65,6 +65,6 @@ If you’re interested in getting an adjustable income you can:
 - check with your current provider if they offer this option and what they charge in fees
 - check if your pot has any special features that could mean you get a better deal, eg a guaranteed annuity rate
 - [get financial advice](/shop-around) if you’re interested in getting an adjustable income
-- [shop around](/shop-around) - check with providers what products they offer to suit your circumstances
-- get some estimates from other providers on how much your pot could grow and what the charges are - usually you just have to fill in a short form on their website.
+- [shop around](/shop-around) – check with providers what products they offer to suit your circumstances
+- get some estimates from other providers on how much your pot could grow and what the charges are – usually you just have to fill in a short form on their website.
 - make sure you know [how much tax](/tax) you’ll pay on any money you’re planning to take out

--- a/content/guaranteed_income.md
+++ b/content/guaranteed_income.md
@@ -13,19 +13,24 @@ You might want to use your pension pot to buy an insurance policy that gives you
 
 Once you’ve bought your annuity you only have a short period when you can still change your mind (in most cases 30 days). After that you can’t change the decision and your rate will be fixed.
 
-## Types of annuities
+## Types of annuity
 
-Types of annuities you can buy:
+Types of annuity you can buy include:
 
-- single - only you get paid an income either for life or for a fixed number of years
-- joint - payments continue to your spouse/partner after you die
-- guaranteed period - you fix the number of years where payments to your spouse/partner continue after you die (sometimes this can be a lump sum), the guaranteed period starts the day you take money from your pot, eg you take a guaranteed 10 year annuity and die after 8 years, your spouse/partner gets payments for another 2 years
-- escalating - increases every year to reduce the effect of inflation
-- enhanced - if your health is bad you may get more money from your annuity
+- ‘single life’ – paid just to you, either for life or for a fixed number of years
+- ‘joint life’ – payments continue to your spouse or partner after you die
+- ‘fixed term’ or ‘guaranteed period’ – stops paying at the end of the set term, eg you get a guaranteed 10 year annuity and die after 7 years, your spouse or partner still gets payments for another 3 years
+- ‘enhanced’ or ‘impaired’ – may pay more than a standard annuity if you smoke or have a medical condition, eg diabetes or high blood pressure
+- ‘escalating’ – the amount increases each year to reduce the effect of inflation
+- ‘level’ – pays a flat amount of income each year
+- ‘investment-linked’ – tied to the stock market, the amount it pays can vary and depends on the success of the investments
+- ‘capital protected’ – your pot is paid to whoever you leave it to (your ‘beneficiary’) if you die within a set period, subject to tax
 
-## Tax-free lump sum with annuities
+## Tax-free lump sums
 
-If you decide to buy an annuity you can still take up to 25% of your pension pot tax free as cash. You could then, for example, buy the annuity with the remaining 75%. Under current pension rules you have to buy the annuity within 6 months or alternatively use one of the [other options](/pension-pot-options).
+If you decide to buy an annuity you can still take up to 25% of your pension pot tax free as cash. You could then, for example, buy the annuity with the remaining 75%. 
+
+Under current pension rules you have to buy the annuity within 6 months or use one of the other pension options.
 
 ## How an annuity is calculated
 
@@ -46,7 +51,7 @@ If the insurer you bought your annuity with goes bust the [Financial Services Co
 If you’re interested in buying an annuity you can:
 
 - [compare annuities](https://www.moneyadviceservice.org.uk/en/tools/annuities) to check how much you might get
-- [shop around](/shop-around) for the best deal - you don’t have to stay with your current provider
+- [shop around](/shop-around) for the best deal – you don’t have to stay with your current provider
 - make sure you know [how much tax you’ll pay](/tax) on your annuity income
 - check with your provider if the annuity they offer is right for you, eg if you’re in poor health you could get a better rate
 - ask your provider if your pension pot has any special features that could mean you get a better deal, eg a guaranteed annuity rate

--- a/content/mix_options.md
+++ b/content/mix_options.md
@@ -34,5 +34,5 @@ $E
 If you’re interested in mixing your options:
 
 - look at all options to see which ones are right for you
-- shop around - you don’t have to buy a product from your current provider
+- shop around – you don’t have to buy a product from your current provider
 - [get financial advice](/shop-around#getting-financial-advice) before making a decision

--- a/content/take_cash_in_chunks.md
+++ b/content/take_cash_in_chunks.md
@@ -52,6 +52,6 @@ Your provider may also let you continue to pay into the pot you take cash from.
 
 Here are some next steps if you’re interested in taking cash in chunks:
 
-- ask your current provider if they offer the option and what they charge - if they don’t offer it, you can transfer your pot but you might be charged
+- ask your current provider if they offer the option and what they charge – if they don’t offer it, you can transfer your pot but you might be charged
 - check if your pot has any special features that could mean you get a better deal, eg a guaranteed annuity rate
 - make sure you know [how much tax](/tax) you’ll pay on any money you’re planning to take out

--- a/content/take_whole_pot.md
+++ b/content/take_whole_pot.md
@@ -1,13 +1,13 @@
 ---
 label: Take your whole pot
-description: You can cash in your whole pension pot - 75% of that money is taxable.
+description: You can cash in your whole pension pot – 75% of that money is taxable.
 ---
 
 <div class="circle circle--m circle--take-cash"></div>
 
 # Taking your whole pot in one go
 
-You can take your whole pot as cash in one go - 25% is tax-free, the other 75% is taxable.
+You can take your whole pot as cash in one go – 25% is tax-free, the other 75% is taxable.
 
 You pay tax when you take money from your pot. This is because when you’re paying into your pension you get [tax relief](https://www.gov.uk/tax-on-your-private-pension/pension-tax-relief) on your contributions.
 


### PR DESCRIPTION
Some of the options pages had hyphens where there should have been dashes. These have been fixed. I've also tidied some copy, eg the annuity page has had some headers updated and the list of annuity types.