### PR TITLE
Allow click events to only be sent only once

### DIFF
--- a/app/assets/javascripts/click-event-logger.js
+++ b/app/assets/javascripts/click-event-logger.js
@@ -1,8 +1,14 @@
 (function() {
   'use strict';
 
+  var clickEventCache = {};
+
   function categoryName() {
     return 'Clicks on ' + window.location.pathname;
+  }
+
+  function generateKeyForCache(actionLabel, url) {
+    return '' + actionLabel + url;
   }
 
   var clickEventLogger = {
@@ -13,6 +19,15 @@
         'eventAction': actionLabel,
         'eventLabel': url
       });
+    },
+
+    sendEventOnlyOnce: function(actionLabel, url) {
+      var keyForCache = generateKeyForCache(actionLabel, url);
+
+      if (!!!clickEventCache[keyForCache]) {
+        clickEventCache[keyForCache] = true;
+        return this.sendEvent(actionLabel, url);
+      }
     }
   };
 

--- a/spec/javascripts/click-event-loggerSpec.js
+++ b/spec/javascripts/click-event-loggerSpec.js
@@ -5,9 +5,11 @@ describe('click event logger', function() {
     expect(PWPG.clickEventLogger).toBeDefined();
   });
 
-  it ('sends data to Google Analytics via Google Tag Manager', function() {
+  beforeEach(function() {
     window.dataLayer = [];
+  });
 
+  it ('sends data to Google Analytics via Google Tag Manager', function() {
     PWPG.clickEventLogger.sendEvent('exampleActionLabel', 'exampleUrl');
 
     expect(window.dataLayer).toContain({
@@ -29,5 +31,12 @@ describe('click event logger', function() {
       'eventAction': jasmine.any(String),
       'eventLabel': jasmine.any(String)
     });
+  });
+
+  it ('sends only one event to Google Analytics when specified', function() {
+    PWPG.clickEventLogger.sendEventOnlyOnce('exampleActionLabel', 'exampleUrl');
+    PWPG.clickEventLogger.sendEventOnlyOnce('exampleActionLabel', 'exampleUrl');
+
+    expect(window.dataLayer.length).toBe(1);
   });
 });


### PR DESCRIPTION
Example: we want to track the number of times a user hovers
over the new navigation bar, but only need to know if they interact
with it once, rather than on every single hover.