### PR TITLE
Adds `next-steps` component and applies to content pages

### DIFF
--- a/app/assets/stylesheets/components/_next-steps.scss
+++ b/app/assets/stylesheets/components/_next-steps.scss
@@ -1,0 +1,109 @@
+.next-steps {
+  display: inline-block;
+  position: relative;
+  padding: 0 1.5em .5em;
+  margin-bottom: 1.3em;
+
+  @include media(desktop) {
+    margin-left: -2em;
+    padding-left: 2em;
+    padding-right: 2em;
+    padding-bottom: .833em;
+  }
+
+  ul li {
+    list-style: none;
+    position: relative;
+    padding-bottom: .5em;
+    border-bottom: 1px solid $border-colour;
+    margin-bottom: .8em;
+
+    &:last-child {
+      border-bottom: 0;
+    }
+
+    &:before {
+      content: "";
+      display: block;
+      position: absolute;
+      width: 10px;
+      height: 10px;
+      border-radius: 10px;
+      left: -1em;
+      top: 7px;
+      background-color: $border-colour;
+    }
+  }
+}
+
+.next-steps--leave-pot-untouched {
+  background: transparentize($color-option-leave-pot-untouched, .9);
+
+  ul li {
+    border-bottom-color: transparentize($color-option-leave-pot-untouched, .4);
+
+    &:before {
+      background: $color-option-leave-pot-untouched;
+    }
+  }
+}
+
+.next-steps--guaranteed-income {
+  background: transparentize($color-option-guaranteed-income, .9);
+
+  ul li {
+    border-bottom-color: transparentize($color-option-guaranteed-income, .4);
+
+    &:before {
+      background: $color-option-guaranteed-income;
+    }
+  }
+}
+
+.next-steps--adjustable-income {
+  background: transparentize($color-option-adjustable-income, .8);
+
+  ul li {
+    border-bottom-color: transparentize($color-option-adjustable-income, .4);
+
+    &:before {
+      background: $color-option-adjustable-income;
+    }
+  }
+}
+
+.next-steps--take-cash-in-chunks {
+  background: transparentize($color-option-take-cash, .9);
+
+  ul li {
+    border-bottom-color: transparentize($color-option-take-cash, .4);
+
+    &:before {
+      background: $color-option-take-cash;
+    }
+  }
+}
+
+.next-steps--whole-pot {
+  background: transparentize($color-option-whole-pot, .9);
+
+  ul li {
+    border-bottom-color: transparentize($color-option-whole-pot, .4);
+
+    &:before {
+      background: $color-option-whole-pot;
+    }
+  }
+}
+
+.next-steps--mix-options {
+  background: transparentize($color-option-mix-options, .9);
+
+  ul li {
+    border-bottom-color: transparentize($color-option-mix-options, .4);
+
+    &:before {
+      background: $color-option-mix-options;
+    }
+  }
+}

--- a/content/adjustable_income.md
+++ b/content/adjustable_income.md
@@ -58,6 +58,8 @@ If you’re interested in this option you might want to [get financial advice](/
 
 You can [leave your pot to someone](/when-you-die) when you die but they may have to pay tax on it.
 
+{::options parse_block_html="true" /}
+<div class="next-steps next-steps--adjustable-income">
 ## Your next steps
 
 If you’re interested in getting an adjustable income you can:
@@ -68,3 +70,4 @@ If you’re interested in getting an adjustable income you can:
 - [shop around](/shop-around) – check with providers what products they offer to suit your circumstances
 - get some estimates from other providers on how much your pot could grow and what the charges are – usually you just have to fill in a short form on their website.
 - make sure you know [how much tax](/tax) you’ll pay on any money you’re planning to take out
+</div>

--- a/content/guaranteed_income.md
+++ b/content/guaranteed_income.md
@@ -28,7 +28,7 @@ Types of annuity you can buy include:
 
 ## Tax-free lump sums
 
-If you decide to buy an annuity you can still take up to 25% of your pension pot tax free as cash. You could then, for example, buy the annuity with the remaining 75%. 
+If you decide to buy an annuity you can still take up to 25% of your pension pot tax free as cash. You could then, for example, buy the annuity with the remaining 75%.
 
 Under current pension rules you have to buy the annuity within 6 months or use one of the other pension options.
 
@@ -46,6 +46,8 @@ You [pay tax on income from an annuity](/tax), just like you do on your salary. 
 
 If the insurer you bought your annuity with goes bust the [Financial Services Compensation Scheme](http://www.fscs.org.uk/what-we-cover/) will cover you in full.
 
+{::options parse_block_html="true" /}
+<div class="next-steps next-steps--guaranteed-income">
 ## Your next steps
 
 If you’re interested in buying an annuity you can:
@@ -55,3 +57,4 @@ If you’re interested in buying an annuity you can:
 - make sure you know [how much tax you’ll pay](/tax) on your annuity income
 - check with your provider if the annuity they offer is right for you, eg if you’re in poor health you could get a better rate
 - ask your provider if your pension pot has any special features that could mean you get a better deal, eg a guaranteed annuity rate
+</div>

--- a/content/leave_pot_untouched.md
+++ b/content/leave_pot_untouched.md
@@ -22,6 +22,8 @@ Your provider may charge you administration fees for managing the fund after you
 
 As with every investment the value of your pot could go up or down.
 
+{::options parse_block_html="true" /}
+<div class="next-steps next-steps--leave-pot-untouched">
 ## Your next steps
 
 If you want to leave your pot untouched for a while, ask your pension provider the following questions:
@@ -33,3 +35,4 @@ If you want to leave your pot untouched for a while, ask your pension provider t
 - How much can I still pay in?
 - Does my pot have any special features that could mean I get a better deal, eg a guaranteed annuity rate?
 - Do you have up-to-date details of the person I want to leave my pot to (my ‘beneficiary’)?
+</div>

--- a/content/mix_options.md
+++ b/content/mix_options.md
@@ -29,6 +29,8 @@ You use £20,000 to buy an annuity. This gives you a taxable income for the rest
 You also put £25,000 into a drawdown fund to get an adjustable income and take out about £5,000 a year for about 5 years.
 $E
 
+{::options parse_block_html="true" /}
+<div class="next-steps next-steps--mix-options">
 ## Your next steps
 
 If you’re interested in mixing your options:
@@ -36,3 +38,4 @@ If you’re interested in mixing your options:
 - look at all options to see which ones are right for you
 - shop around – you don’t have to buy a product from your current provider
 - [get financial advice](/shop-around#getting-financial-advice) before making a decision
+</div>

--- a/content/take_cash_in_chunks.md
+++ b/content/take_cash_in_chunks.md
@@ -48,6 +48,8 @@ If you have multiple pension pots, you can take chunks of cash from one and cont
 
 Your provider may also let you continue to pay into the pot you take cash from.
 
+{::options parse_block_html="true" /}
+<div class="next-steps next-steps--take-cash-in-chunks">
 ## Your next steps
 
 Here are some next steps if you’re interested in taking cash in chunks:
@@ -55,3 +57,4 @@ Here are some next steps if you’re interested in taking cash in chunks:
 - ask your current provider if they offer the option and what they charge – if they don’t offer it, you can transfer your pot but you might be charged
 - check if your pot has any special features that could mean you get a better deal, eg a guaranteed annuity rate
 - make sure you know [how much tax](/tax) you’ll pay on any money you’re planning to take out
+</div>

--- a/content/take_whole_pot.md
+++ b/content/take_whole_pot.md
@@ -54,6 +54,8 @@ At the end of the tax year HM Revenue and Customs will calculate how much tax yo
 
 Beware of [pension scams](/scams) contacting you unexpectedly about an investment or business opportunity that you’ve not spoken to them about before. You could lose all your money and face tax of up to 55% and extra fees.
 
+{::options parse_block_html="true" /}
+<div class="next-steps next-steps--whole-pot">
 ## Your next steps
 
 Here are some next steps if you’re interested in taking your whole pot in one go:
@@ -61,3 +63,4 @@ Here are some next steps if you’re interested in taking your whole pot in one 
 - check with your provider if they offer this option – they may charge you a fee if you move your pension to a provider that does
 - you can take 25% tax free
 - if you want to reinvest the money, talk to a [registered financial adviser](http://www.fca.org.uk/register) first
+</div>


### PR DESCRIPTION
This follows the current colour scheme, so does not include the new option colours. They will come as part of #391 

This can therefore be merged independently.

<img width="623" alt="screen shot 2015-12-29 at 17 28 30" src="https://cloud.githubusercontent.com/assets/295469/12038623/9c4561f8-ae51-11e5-91ef-db849fc97c4a.png">
