### PR TITLE
Adds `book a free appointment` link

### DIFF
--- a/app/assets/stylesheets/components/_book-appointment.scss
+++ b/app/assets/stylesheets/components/_book-appointment.scss
@@ -1,0 +1,11 @@
+.book-appointment {
+  @include bold-19;
+  display: inline-block;
+  margin-bottom: 19px;
+
+  @include media(desktop) {
+    position: relative;
+    top: -75px;
+    margin-bottom: 0;
+  }
+}

--- a/app/controllers/guides_controller.rb
+++ b/app/controllers/guides_controller.rb
@@ -5,7 +5,6 @@ class GuidesController < ApplicationController
   before_action :set_breadcrumbs
 
   NON_JOURNEY_RELATED_GUIDE_IDS = %w(
-    appointments
     pension-pot-options
     6-steps-you-need-to-take
     pension-types
@@ -13,7 +12,6 @@ class GuidesController < ApplicationController
   )
 
   JOURNEY_RELATED_GUIDE_IDS = %w(
-    appointments
     when-you-die
     benefits
     care-costs

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,4 +2,8 @@ module ApplicationHelper
   def format_currency(amount)
     number_to_currency(amount).sub(/\.00$/, '')
   end
+
+  def book_an_appointment_link?
+    true
+  end
 end

--- a/app/helpers/guides_helper.rb
+++ b/app/helpers/guides_helper.rb
@@ -1,0 +1,5 @@
+module GuidesHelper
+  def book_an_appointment_link?
+    !@guide.related_to_appointments?
+  end
+end

--- a/app/helpers/locations_helper.rb
+++ b/app/helpers/locations_helper.rb
@@ -1,0 +1,5 @@
+module LocationsHelper
+  def book_an_appointment_link?
+    false
+  end
+end

--- a/app/views/layouts/_two_column.erb
+++ b/app/views/layouts/_two_column.erb
@@ -16,6 +16,10 @@
         </main>
       </div>
       <div class="l-column-third l-column-third--sidebar">
+        <% if book_an_appointment_link? %>
+          <a href="/appointments" class="book-appointment">Book a free appointment</a>
+        <% end %>
+
         <% if content_for?(:sidebar) %>
           <div class="sidebar-hr"></div>
           <%= yield :sidebar %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,6 +8,7 @@ Bundler.require(*Rails.groups)
 
 module PensionGuidance
   class Application < Rails::Application
+    config.action_controller.include_all_helpers = false
     config.action_dispatch.rescue_responses.merge! 'GuideRepository::GuideNotFound' => :not_found
 
     config.autoload_paths << Rails.root.join('lib')

--- a/features/step_definitions/guide_steps.rb
+++ b/features/step_definitions/guide_steps.rb
@@ -53,8 +53,7 @@ end
 
 Then(/^I can navigate to content related to the journey$/) do
   expect(@guide.link_promo_items.map(&:text))
-    .to eq(['Book a free appointment',
-            'Your pension when you die',
+    .to eq(['Your pension when you die',
             'Benefits entitlement',
             'Care costs',
             'How to avoid a pension scam'])
@@ -62,8 +61,7 @@ end
 
 Then(/^I can navigate to related content$/) do
   expect(@guide.link_promo_items.map(&:text))
-    .to eq(['Book a free appointment',
-            'What you can do with your pension pot',
+    .to eq(['What you can do with your pension pot',
             '6 steps you need to take',
             'Know your pension type',
             'Tax you pay on your pension'])


### PR DESCRIPTION
Appears on `two-column` template and is compatible with both the current and new (dropdown nav) headers.

- [x] Create link
- [x] Use tags to determine whether to show link on relevant pages (https://github.com/guidance-guarantee-programme/pension_guidance/pull/406)

<img width="979" alt="screen shot 2015-12-30 at 10 44 23" src="https://cloud.githubusercontent.com/assets/295469/12049689/52161438-aee2-11e5-818a-d9a8e0dbdf25.png">
