### PR TITLE
Changes to Leave_pot_untouched.md

### DIFF
--- a/content/leave_pot_untouched.md
+++ b/content/leave_pot_untouched.md
@@ -6,33 +6,41 @@ description: You can decide when you take money from your pension pot.
 
 # Leaving your whole pension pot untouched
 
-You don’t have to start taking money from your pension pot when you reach your ‘selected retirement age’ (the age you agreed with your provider to retire).
+You don’t have to start taking money from your pension pot when you reach your ‘selected retirement age’ (the age you agreed with your provider to retire). You could leave the money invested, eg while you’re working.
 
-You can leave the money invested, eg while you’re working. Your pension pot could grow further and give you a larger amount of money to last for a shorter amount of time.
+- The money in your pot could grow.
+- You have more money to last a shorter length of time.
+- You (and your employer) can also still pay into your pot but there may be restrictions.
 
-## Tax when you leave your whole pot untouched
+%If someone contacts you unexpectedly about getting money out of your pot before you’re 55, it’s nearly always a pension scam.%
 
-As long as your money stays in your pension pot you don’t pay tax on it. You can still pay into it up to your [annual allowance](https://www.gov.uk/tax-on-your-private-pension/annual-allowance).
+## Tax
 
-Whatever money you leave in your pension pot you can [pass on](/when-you-die) tax free if you die before the age of 75.
+You don’t pay tax while the money stays in your pot. You can still pay into it up to your [annual allowance](https://www.gov.uk/tax-on-your-private-pension/annual-allowance).
 
-## Charges and investment risk
+Money you leave in your pot can be passed on [passed on](/when-you-die) tax free if you die before the age of 75.
 
-Your provider may charge you administration fees for managing the fund after your selected retirement age.
+## Fees and investment risk
+
+Your provider may charge you administration fees for managing your pot.
 
 As with every investment the value of your pot could go up or down.
 
+Your provider may charge you a penalty fee if you don’t start taking your pension when you reach your selected retirement age.
+
 {::options parse_block_html="true" /}
 <div class="next-steps next-steps--leave-pot-untouched">
-## Your next steps
+## Next steps
 
-If you want to leave your pot untouched for a while, ask your pension provider the following questions:
+Ask your pension provider the following questions:
 
-- What are your charges for leaving my money in longer?
-- Do I have to take the money by a certain date and are there penalty charges if I don’t?
+- What are your fees for leaving my money in longer?
+- Do I have to take the money by a certain date and are there penalty fees if I don’t?
 - How much is the pot likely to grow each year?
 - How is the money invested and can I change this if I want?
 - How much can I still pay in?
 - Does my pot have any special features that could mean I get a better deal, eg a guaranteed annuity rate?
 - Do you have up-to-date details of the person I want to leave my pot to (my ‘beneficiary’)?
 </div>
+
+Book a [free Pension Wise appointment](/appointments) to find out more about what you can do with your pot.


### PR DESCRIPTION
Moved 2nd paragraph up to be part of 1st para. Changed 'can' to 'could' in 2nd sentence.
Deleted 3rd sentence 'Your pension pot could grow further and give you a larger amount of money to last for a shorter amount of time.'
Added 3 bullet points under 2nd sentence.
Added %scams warning below new bullet points.
Changed '## Tax when you leave your whole pot untouched' to '##Tax'
Changed 'As long as your money stays in your pension pot you don’t pay tax on it.' to 'You don’t pay tax while the money stays in your pot.'
Changed 'Whatever money you leave in your pension pot you can [pass on]' to 'Money you leave in your pot can be [passed on]'
Heading '## Charges and investment risk' changed to 'Fees and investment risk'
Split 'Your provider may charge you administration fees for managing the fund after your selected retirement age.' into 2 new sentences.
Deleted 'Your' from '## Your next steps' and capitalised the N of Next.
Deleted 'If you want to leave your pot untouched for a while,' 
In bullets: 1st and 2nd bullet changed 'charges' to 'fees'
Added new sentence after bullets: 'Book a [free Pension Wise appointment](/appointments) to find out more about what you can do with your pot.'