### PR TITLE
Tags in content frontmatter

### DIFF
--- a/app/decorators/guide_decorator.rb
+++ b/app/decorators/guide_decorator.rb
@@ -1,5 +1,6 @@
 class GuideDecorator < Draper::Decorator
-  delegate :id, :slug, :concise_label, :description
+  delegate :id, :slug, :concise_label, :description,
+           :option?, :related_to_appointments?, :related_to_booking?
 
   def url
     "/#{slug}"

--- a/app/models/guide.rb
+++ b/app/models/guide.rb
@@ -2,17 +2,18 @@ class Guide
   extend Forwardable
 
   Metadata = Class.new do
-    attr_accessor :label, :concise_label, :description
+    attr_accessor :label, :concise_label, :description, :tags
 
-    def initialize(label: nil, concise_label: nil, description: nil)
+    def initialize(label: nil, concise_label: nil, description: nil, tags: nil)
       self.label = label
       self.concise_label = concise_label
       self.description = description
+      self.tags = tags
     end
   end
 
   attr_reader :id, :content, :content_type
-  def_delegators :@metadata, :label, :concise_label, :description
+  def_delegators :@metadata, :label, :concise_label, :description, :tags
 
   def initialize(id, content: '', content_type: nil, metadata: nil)
     @id = id
@@ -27,5 +28,23 @@ class Guide
 
   def slug
     id.tr('_', '-')
+  end
+
+  def option?
+    tagged_with?('option')
+  end
+
+  def related_to_appointments?
+    tagged_with?('appointments')
+  end
+
+  def related_to_booking?
+    tagged_with?('booking')
+  end
+
+  private
+
+  def tagged_with?(tag)
+    Array(tags).include?(tag)
   end
 end

--- a/app/repositories/guide_repository.rb
+++ b/app/repositories/guide_repository.rb
@@ -36,7 +36,8 @@ class GuideRepository
     source = FrontMatterParser.new(File.read(path))
     metadata = Guide::Metadata.new(label: source.front_matter['label'],
                                    concise_label: source.front_matter['concise_label'],
-                                   description: source.front_matter['description'])
+                                   description: source.front_matter['description'],
+                                   tags: source.front_matter['tags'])
 
     Guide.new(id,
               content: source.content,

--- a/content/adjustable_income.md
+++ b/content/adjustable_income.md
@@ -1,6 +1,8 @@
 ---
 label: Adjustable income
 description: Your money is invested in a flexi-access drawdown fund to give you a regular income with the option to take cash when you need to.
+tags:
+  - option
 ---
 
 <div class="circle circle--m circle--adjustable-income"></div>

--- a/content/appointments.md
+++ b/content/appointments.md
@@ -1,5 +1,7 @@
 ---
 description: Book a phone or face-to-face appointment with Pension Wise for personal guidance on your pension pot options.
+tags:
+  - appointments
 ---
 
 # Book a free appointment

--- a/content/book.md
+++ b/content/book.md
@@ -1,5 +1,8 @@
 ---
 description: Call 0300 330 1001 between 8am to 10pm, every day.
+tags:
+  - appointments
+  - booking
 ---
 
 # How to book

--- a/content/guaranteed_income.md
+++ b/content/guaranteed_income.md
@@ -1,6 +1,8 @@
 ---
 label: Guaranteed income
 description: You can use your pension pot to buy an insurance policy that guarantees you an income for the rest of your life.
+tags:
+  - option
 ---
 
 <div class="circle circle--m circle--guaranteed-income"></div>
@@ -25,7 +27,7 @@ There are lots of different types of annuity and you can shop around – you don
 -|-
 Single life | Paid just to you, either for life or for a fixed number of years.
 Joint life | Payments continue to your spouse or partner after you die.
-Fixed term or Guaranteed period | Stops paying at the end of the set term, eg you get a guaranteed 10 year annuity and die after 7 years, your spouse or partner still gets payments for another 3 years. 
+Fixed term or Guaranteed period | Stops paying at the end of the set term, eg you get a guaranteed 10 year annuity and die after 7 years, your spouse or partner still gets payments for another 3 years.
 Enhanced or Impaired | May pay more than a standard annuity if you smoke or have a medical condition, eg diabetes or high blood pressure.
 Escalating | The amount increases each year to reduce the effect of inflation.
 Level | Pays a flat amount of income each year.

--- a/content/leave_pot_untouched.md
+++ b/content/leave_pot_untouched.md
@@ -1,6 +1,8 @@
 ---
 label: Leave pot untouched
 description: You can decide when you take money from your pension pot.
+tags:
+  - option
 ---
 <div class="circle circle--m circle--leave-pot-untouched"></div>
 

--- a/content/mix_options.md
+++ b/content/mix_options.md
@@ -1,6 +1,8 @@
 ---
 label: Mix your options
 description: You can mix your pension options to suit your circumstances at different times during retirement.
+tags:
+  - option
 ---
 
 <div class="circle circle--m circle--mix-options"></div>

--- a/content/take_cash_in_chunks.md
+++ b/content/take_cash_in_chunks.md
@@ -1,5 +1,7 @@
 ---
 description: You can take smaller chunks of cash from your pension pot until it runs out.
+tags:
+  - option
 ---
 
 <div class="circle circle--m circle--take-cash"></div>

--- a/content/take_whole_pot.md
+++ b/content/take_whole_pot.md
@@ -1,6 +1,8 @@
 ---
 label: Take your whole pot
 description: You can cash in your whole pension pot – 75% of that money is taxable.
+tags:
+  - option
 ---
 
 <div class="circle circle--m circle--whole-pot"></div>

--- a/spec/fixtures/the_test_govspeak_guide.md
+++ b/spec/fixtures/the_test_govspeak_guide.md
@@ -1,5 +1,9 @@
 ---
 label: Tested
 description: The guide used for testing
+tags:
+  - testing
+  - tags
+  - govspeak
 ---
 # This is the test guide

--- a/spec/fixtures/the_test_html_guide.html
+++ b/spec/fixtures/the_test_html_guide.html
@@ -1,5 +1,9 @@
 ---
 label: Tested
 description: The guide used for testing
+tags:
+  - testing
+  - tags
+  - html
 ---
 <h1>This is the test guide</h1>

--- a/spec/models/guide_spec.rb
+++ b/spec/models/guide_spec.rb
@@ -5,18 +5,20 @@ RSpec.describe Guide, type: :model do
   let(:label) { 'Tested' }
   let(:concise_label) { 'Test' }
   let(:description) { 'A test description' }
+  let(:tags) { [] }
 
   let(:metadata) do
     Guide::Metadata.new(label: label,
                         concise_label: concise_label,
-                        description: description)
+                        description: description,
+                        tags: tags)
   end
 
-  let(:guide) do
-    Guide.new(id, content: content, content_type: content_type, metadata: metadata)
+  subject(:guide) do
+    described_class.new(id, content: content, content_type: content_type, metadata: metadata)
   end
 
-  %i( id content content_type label concise_label description ).each do |attr|
+  %i( id content content_type label concise_label description tags ).each do |attr|
     describe "##{attr}" do
       it "returns the initialised #{attr}" do
         expect(guide.public_send(attr)).to eq(public_send(attr))
@@ -33,6 +35,30 @@ RSpec.describe Guide, type: :model do
   describe '#==' do
     it 'considers two guides with the same ID as equal' do
       expect(described_class.new('foo')).to eq(described_class.new('foo'))
+    end
+  end
+
+  describe '#related_to_appointments?' do
+    context 'when tagged with "appointments"' do
+      let(:tags) { %w(appointments) }
+
+      it { is_expected.to be_related_to_appointments }
+    end
+  end
+
+  describe '#related_to_booking?' do
+    context 'when tagged with "booking"' do
+      let(:tags) { %w(booking) }
+
+      it { is_expected.to be_related_to_booking }
+    end
+  end
+
+  describe '#option?' do
+    context 'when tagged with "option"' do
+      let(:tags) { %w(option) }
+
+      it { is_expected.to be_option }
     end
   end
 end


### PR DESCRIPTION
Avoids continually having to hardcode page id's to manipulate views

- [x] Add to guide model
- [x] Use in place of `PENSION_OPTION_IDS` in controller
- [x] Write more tests
- [x] Work out what to do about ordering (was previously specified by the [hardcoded array](https://github.com/guidance-guarantee-programme/pension_guidance/blob/master/app/controllers/guides_controller.rb#L6-L20))