### PR TITLE
Simplify extraction of guide headers

### DIFF
--- a/app/decorators/govspeak_guide_decorator.rb
+++ b/app/decorators/govspeak_guide_decorator.rb
@@ -1,17 +1,5 @@
 class GovspeakGuideDecorator < GuideDecorator
   def content
-    @content ||= content_document.to_html.html_safe
-  end
-
-  def headers(level = 1)
-    content_document.headers.select { |header| header.level == level }.each_with_object({}) do |header, headers|
-      headers[header.id] = header.text
-    end
-  end
-
-  private
-
-  def content_document
-    @content_document ||= Govspeak::Document.new(object.content)
+    @content ||= Govspeak::Document.new(object.content).to_html.html_safe
   end
 end

--- a/app/decorators/guide_decorator.rb
+++ b/app/decorators/guide_decorator.rb
@@ -18,8 +18,10 @@ class GuideDecorator < Draper::Decorator
     fail 'GuideDecorator subclasses must implement content'
   end
 
-  def headers(_level = nil)
-    fail 'GuideDecorator subclasses must implement headers'
+  def headers(level = 1)
+    content_document.css("h#{level}").each_with_object({}) do |header, headers|
+      headers[header[:id]] = header.text
+    end
   end
 
   def self.for(guide)
@@ -31,5 +33,11 @@ class GuideDecorator < Draper::Decorator
 
   def self.cached_for(guide)
     CachedGuideDecorator.new(self.for(guide), Rails.cache)
+  end
+
+  private
+
+  def content_document
+    @content_document ||= Nokogiri::HTML(content)
   end
 end

--- a/app/decorators/html_guide_decorator.rb
+++ b/app/decorators/html_guide_decorator.rb
@@ -1,21 +1,5 @@
 class HTMLGuideDecorator < GuideDecorator
   def content
-    @content ||= guide_content.html_safe
-  end
-
-  def headers(level = 1)
-    content_document.css("h#{level}").each_with_object({}) do |header, headers|
-      headers[header[:id]] = header.text
-    end
-  end
-
-  private
-
-  def guide_content
-    Kramdown::Document.new(object.content, input: 'html').to_html
-  end
-
-  def content_document
-    @content_document ||= Nokogiri::HTML(guide_content)
+    @content ||= Kramdown::Document.new(object.content, input: 'html').to_html.html_safe
   end
 end

--- a/content/take_whole_pot.md
+++ b/content/take_whole_pot.md
@@ -22,9 +22,7 @@ You pay tax when you take money from your pot. This is because when you’re pay
 
 {::options parse_block_html="false" /}
 <div class="calculator calculator--in-article calculator--whole-pot js-take-whole-pot-calculator">
-  <div markdown="1">
-## Find out what you’d get after tax {#calculator}
-  </div>
+  <h2 id="calculator">Find out what you’d get after tax</h2>
 
   <form action="/take-whole-pot/results#calculator" method="get">
     <div class="form-group">

--- a/spec/decorators/guide_decorator_spec.rb
+++ b/spec/decorators/guide_decorator_spec.rb
@@ -12,11 +12,6 @@ RSpec.describe GuideDecorator, type: :decorator do
       expect { decorator.content }
         .to raise_error('GuideDecorator subclasses must implement content')
     end
-
-    specify 'must implement #headers' do
-      expect { decorator.headers(double) }
-        .to raise_error('GuideDecorator subclasses must implement headers')
-    end
   end
 
   describe '.for' do


### PR DESCRIPTION
Always extract headers from HTML content. This ensures we can also find headers in HTML derived from Govspeak, even if there is embedded HTML in the markdown content.