### PR TITLE
Render option circles in view not content

### DIFF
--- a/app/views/guides/option.html.erb
+++ b/app/views/guides/option.html.erb
@@ -52,4 +52,5 @@
   </script>
 <% end %>
 
+<%= content_tag :span, nil, class: ['circle', 'circle--m', "circle--#{@guide.slug}"] %>
 <%= @guide.content %>

--- a/content/adjustable_income.md
+++ b/content/adjustable_income.md
@@ -5,8 +5,6 @@ tags:
   - option
 ---
 
-<div class="circle circle--m circle--adjustable-income"></div>
-
 # Get an adjustable income
 
 ## Overview

--- a/content/guaranteed_income.md
+++ b/content/guaranteed_income.md
@@ -5,8 +5,6 @@ tags:
   - option
 ---
 
-<div class="circle circle--m circle--guaranteed-income"></div>
-
 # Get a guaranteed income (annuity)
 
 ## Overview

--- a/content/leave_pot_untouched.md
+++ b/content/leave_pot_untouched.md
@@ -4,7 +4,6 @@ description: You can decide when you take money from your pension pot.
 tags:
   - option
 ---
-<div class="circle circle--m circle--leave-pot-untouched"></div>
 
 # Leave your whole pension pot untouched
 

--- a/content/mix_options.md
+++ b/content/mix_options.md
@@ -5,8 +5,6 @@ tags:
   - option
 ---
 
-<div class="circle circle--m circle--mix-options"></div>
-
 # Mix your pension options
 
 ## Overview

--- a/content/take_cash_in_chunks.md
+++ b/content/take_cash_in_chunks.md
@@ -4,8 +4,6 @@ tags:
   - option
 ---
 
-<div class="circle circle--m circle--take-cash-in-chunks"></div>
-
 # Take cash in chunks
 
 ## Overview

--- a/content/take_whole_pot.md
+++ b/content/take_whole_pot.md
@@ -5,8 +5,6 @@ tags:
   - option
 ---
 
-<div class="circle circle--m circle--take-whole-pot"></div>
-
 # Take your whole pension pot in one go
 
 ## Overview


### PR DESCRIPTION
Where possible we should avoid presentation markup in our content files.