### PR TITLE
Render take whole pot calculator form from content

### DIFF
--- a/app/views/calculators/_error_summary.html.erb
+++ b/app/views/calculators/_error_summary.html.erb
@@ -5,7 +5,7 @@
   </h1>
 
   <ul class="error-summary-list">
-    <% errors.keys.each do |attribute| %>
+    <% errors.try(:keys).try(:each) do |attribute| %>
       <li><a href="#<%= attribute %>"><%= errors[attribute].first %></a></li>
     <% end %>
   </ul>

--- a/app/views/calculators/take_whole_pot/_form.html.erb
+++ b/app/views/calculators/take_whole_pot/_form.html.erb
@@ -1,20 +1,25 @@
+<%
+  calculator = local_assigns[:calculator]
+  errors = calculator.try(:errors)
+%>
+
 <h2 id="calculator">Find out what you’d get after tax</h2>
 
-<%= render 'calculators/error_summary', errors: calculator.errors unless calculator.valid? %>
+<%= render 'calculators/error_summary', errors: errors if calculator && calculator.invalid? %>
 
 <form action="/take-whole-pot/results#calculator" method="get">
   <%= render 'calculators/form_input_currency',
              field: :pot,
-             value: pot,
+             value: local_assigns[:pot],
              label: 'Total pension pot value',
-             error_message: calculator.errors[:pot].try(:first) %>
+             error_message: errors.try(:fetch, :pot).try(:first) %>
 
   <%= render 'calculators/form_input_currency',
              field: :income,
-             value: income,
+             value: local_assigns[:income],
              label: 'Income for the year',
              hint: 'Includes your salary, savings, benefits and State Pension payments',
-             error_message: calculator.errors[:income].try(:first) %>
+             error_message: errors.try(:fetch, :income).try(:first) %>
 
   <%= render 'calculators/form_input_submit' %>
 </form>

--- a/config/initializers/govspeak.rb
+++ b/config/initializers/govspeak.rb
@@ -1,0 +1,10 @@
+require 'govspeak'
+
+Govspeak::Document.extension('calculator', %r(^{::calculator\sid="(?<id>.*?)"\s/})) do |id|
+  classes = "t-calculator calculator calculator--in-article calculator--#{id} js-calculator--#{id}"
+  partial = "calculators/#{id.tr('-', '_')}/form"
+
+  calculator = ApplicationController.new.render_to_string(partial: partial)
+
+  %(\n\n<div class="#{classes}">#{calculator}</div>\n)
+end

--- a/content/take_whole_pot.md
+++ b/content/take_whole_pot.md
@@ -18,32 +18,7 @@ You pay tax when you take money from your pot. This is because when you’re pay
 
 %Taking a large sum of cash from your pot can mean you pay a higher amount of tax.%
 
-{::options parse_block_html="false" /}
-<div class="calculator calculator--in-article calculator--take-whole-pot js-calculator--take-whole-pot">
-  <h2 id="calculator">Find out what you’d get after tax</h2>
-
-  <form action="/take-whole-pot/results#calculator" method="get">
-    <div class="form-group">
-      <label class="form-label" for="pot">
-        Total amount in your pension pot(s)
-      </label>
-      <span id="pot-a">£</span> <input aria-labelledby="pot-a" class="form-control calculator__field" type="text" id="pot" name="pot">
-    </div>
-
-    <div class="form-group">
-      <label class="form-label" for="income">
-        Your income for the year
-        <span class="form-hint">Includes your salary, savings, benefits and State Pension payments</span>
-      </label>
-      <span id="income-a">£</span> <input aria-labelledby="income-a" class="form-control calculator__field" type="text" id="income" name="income">
-    </div>
-
-    <div class="form-group">
-      <input type="submit" class="button" value="Calculate" id="js-calculate">
-    </div>
-  </form>
-</div>
-{::options parse_block_html="true" /}
+{::calculator id="take-whole-pot" /}
 
 ## Paying tax
 


### PR DESCRIPTION
This removes duplication and makes the markdown content easier to understand.

:fireworks: 