### PR TITLE
Improve calculator error handling

### DIFF
--- a/app/forms/take_whole_pot_calculator_form.rb
+++ b/app/forms/take_whole_pot_calculator_form.rb
@@ -5,8 +5,8 @@ class TakeWholePotCalculatorForm
 
   attr_accessor :pot, :income
 
-  validates :pot, presence: true, numericality: { greater_than_or_equal_to: 0 }
-  validates :income, numericality: true
+  validates :pot, presence: true, numericality: { allow_blank: true, greater_than: 0 }
+  validates :income, presence: true, numericality: { allow_blank: true, greater_than_or_equal_to: 0 }
 
   def pot
     Float(@pot.gsub(/,/, '')) rescue @pot

--- a/app/views/calculators/_error_summary.html.erb
+++ b/app/views/calculators/_error_summary.html.erb
@@ -5,8 +5,10 @@
   </h1>
 
   <ul class="error-summary-list">
-    <% errors.try(:keys).try(:each) do |attribute| %>
-      <li><a href="#<%= attribute %>"><%= errors[attribute].first %></a></li>
+    <% messages.each do |attribute, attribute_messages| %>
+      <% attribute_messages.each do |attribute_message| %>
+        <li><a href="#<%= attribute %>"><%= attribute_message %></a></li>
+      <% end %>
     <% end %>
   </ul>
 

--- a/app/views/calculators/_form_input_currency.html.erb
+++ b/app/views/calculators/_form_input_currency.html.erb
@@ -1,15 +1,15 @@
 <%
-  error_message = local_assigns[:error_message]
+  error_messages = local_assigns[:error_messages] || []
   hint = local_assigns[:hint]
   labelled_by = "#{field}-a"
 %>
 
-<div class="form-group <%= 'error' unless error_message.blank? %>">
+<div class="form-group <%= 'error' unless error_messages.empty? %>">
   <label class="form-label" for="<%= field %>">
     <%= label %>
     <%= content_tag :span, hint, class: 'form-hint' unless hint.blank? %>
   </label>
-  <%= content_tag :span, error_message, class: 'error-message' unless error_message.blank? %>
+  <%= simple_format error_messages.join("\n"), { class: 'error-message' }, wrapper_tag: 'span' %>
   <%= content_tag :span, '£', id: labelled_by %>
   <%= text_field_tag field, value, 'aria-labelledby' => labelled_by, class: %w(form-control calculator__field) %>
 </div>

--- a/app/views/calculators/take_whole_pot/_form.html.erb
+++ b/app/views/calculators/take_whole_pot/_form.html.erb
@@ -12,14 +12,14 @@
              field: :pot,
              value: local_assigns[:pot],
              label: 'Total pension pot value',
-             error_message: errors.try(:get, :pot).try(:first) %>
+             error_messages: errors.try(:get, :pot) %>
 
   <%= render 'calculators/form_input_currency',
              field: :income,
              value: local_assigns[:income],
              label: 'Income for the year',
              hint: 'Includes your salary, savings, benefits and State Pension payments',
-             error_message: errors.try(:get, :income).try(:first) %>
+             error_messages: errors.try(:get, :income) %>
 
   <%= render 'calculators/form_input_submit' %>
 </form>

--- a/app/views/calculators/take_whole_pot/_form.html.erb
+++ b/app/views/calculators/take_whole_pot/_form.html.erb
@@ -11,7 +11,7 @@
   <%= render 'calculators/form_input_currency',
              field: :pot,
              value: local_assigns[:pot],
-             label: 'Total pension pot value',
+             label: 'Pension pot value',
              error_messages: errors.try(:get, :pot) %>
 
   <%= render 'calculators/form_input_currency',

--- a/app/views/calculators/take_whole_pot/_form.html.erb
+++ b/app/views/calculators/take_whole_pot/_form.html.erb
@@ -5,7 +5,7 @@
 
 <h2 id="calculator">Find out what you’d get after tax</h2>
 
-<%= render 'calculators/error_summary', errors: errors if calculator && calculator.invalid? %>
+<%= render 'calculators/error_summary', messages: errors.try(:messages) if calculator && calculator.invalid? %>
 
 <form action="/take-whole-pot/results#calculator" method="get">
   <%= render 'calculators/form_input_currency',

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -17,6 +17,12 @@ en:
     errors:
       models:
         take_whole_pot_calculator_form:
-          blank: 'Using numbers, please enter the value of your %{attribute}'
-          not_a_number: 'Using numbers, please enter the value of your %{attribute}'
-          greater_than_or_equal_to: 'Using numbers, please enter the value of your %{attribute}'
+          attributes:
+            pot:
+              blank: Please enter your pension pot value
+              not_a_number: Using numbers, please enter your pension pot value
+              greater_than: Your pension pot value must be at least £1
+            income:
+              blank: Please enter your income for the year
+              not_a_number: Using numbers, please enter your income for the year
+              greater_than_or_equal_to: Your income for the year must be £0 or more

--- a/spec/forms/take_whole_pot_calculator_form_spec.rb
+++ b/spec/forms/take_whole_pot_calculator_form_spec.rb
@@ -1,7 +1,8 @@
 RSpec.describe TakeWholePotCalculatorForm do
   it { is_expected.to validate_presence_of(:pot) }
-  it { should validate_numericality_of(:pot).is_greater_than_or_equal_to(0) }
-  it { should validate_numericality_of(:income) }
+  it { is_expected.to validate_presence_of(:income) }
+  it { is_expected.to validate_numericality_of(:pot).is_greater_than(0) }
+  it { is_expected.to validate_numericality_of(:income).is_greater_than_or_equal_to(0) }
 
   describe 'type coercion' do
     subject(:calculator) do


### PR DESCRIPTION
If there are multiple errors for an attribute we should show them, however, we can display error messages that give more context about the specific error instead of just using the same error messages for all validation errors.