### PR TITLE
Update _estimate.html.erb

### DIFF
--- a/app/views/calculators/leave_pot_untouched/_estimate.html.erb
+++ b/app/views/calculators/leave_pot_untouched/_estimate.html.erb
@@ -21,11 +21,15 @@
 
 <ul class="t-calculator-notes">
   <li>
-    This is an estimate based on your pot growing at a rate of about
+    This is an estimate based on your whole pot growing at a rate of about
     <%= number_to_percentage(LeavePotUntouchedCalculator::INTEREST_RATE * 100) %>
     per year — this may vary.
   </li>
   <li>
     The amount in your pot will be affected by inflation and any fees your provider charges.
+  </li>
+  <li>
+    You must leave your whole pot — if you take a 25% tax-free lump sum, you must take the rest of your
+    money within 6 months, using one of the [other pension options](/pension-pot-options).
   </li>
 </ul>

--- a/features/step_definitions/calculator_steps.rb
+++ b/features/step_definitions/calculator_steps.rb
@@ -53,7 +53,7 @@ And(/^I should see how the remaining value of my pot$/) do
 end
 
 Then(/^it explains the values are estimates based on growth at 3% per year$/) do
-  content = 'This is an estimate based on your pot growing at a rate of about 3% per year — this may vary.'
+  content = 'This is an estimate based on your whole pot growing at a rate of about 3% per year — this may vary.'
 
   expect(@page.calculator.notes).to have_content(content)
 end


### PR DESCRIPTION
Added in bullet point about must take your whole pot if you take your 25% tax-free lump sum because in lab testing users were getting very excited about being able to take their tax-free lump sum and leave the rest of their money to grow - which they can't do under the pension rules, they have to buy an annuity or invest in a drawdown or take the whole pot.