### PR TITLE
Update _estimate.html.erb

### DIFF
--- a/app/views/calculators/leave_pot_untouched/_estimate.html.erb
+++ b/app/views/calculators/leave_pot_untouched/_estimate.html.erb
@@ -29,7 +29,6 @@
     The amount in your pot will be affected by inflation and any fees your provider charges.
   </li>
   <li>
-    You must leave your whole pot — if you take a 25% tax-free lump sum, you must take the rest of your
-    money within 6 months, using one of the <a href="/pension-pot-options">other pension options</a>.
+    You must leave your whole pot — you can't take just the 25% tax-free lump sum.
   </li>
 </ul>


### PR DESCRIPTION
Changed text around taking one of the options within 6 months. ABI said it was wrong. Though a user technically has 6 months to decide what to do with their pot, the provider won't release the tax-free lump sum until they know what the user is doing with their pot.