### PR TITLE
Tax page changes

### DIFF
--- a/app/domain/taxonomy.rb
+++ b/app/domain/taxonomy.rb
@@ -9,6 +9,7 @@ class Taxonomy
       node << guide_node('divorce')
       node << guide_node('protection')
       node << guide_node('already-bought-annuity')
+      node << guide_node('pension-recycling')
       node << guide_node('pension_complaints')
     end
   end

--- a/content/pension_pot_options.md
+++ b/content/pension_pot_options.md
@@ -4,9 +4,9 @@ description: You can usually take 25% of your pension pot tax free and then choo
 ---
 # What you can do with your pension pot
 
-You can usually take 25% of your defined contribution pension pot tax free and then choose from a range of options. If you take 25% tax free, you must make a decision on the remaining 75% within 6 months – you can’t then leave it untouched.
+You can usually take 25% of your defined contribution pension pot tax free.
 
-You have 6 options:
+There are 6 ways you can take your pension pot.
 
 <div class="options-overview">
   <div class="options-overview__item">
@@ -45,96 +45,4 @@ You have 6 options:
     <p>You can mix different options. Usually, you would need a bigger pot to do this.</p>
     <p><a class="t-option" href="/mix-options">More on mixing your options</a></p>
   </div>
-</div>
-
-{: .hr-thin}
-* * *
-
-{: .options-overview__compare-title}
-## Tax and your pension pot
-
-It’s important to know how much tax you might pay on the money you take from your pension pot. This table gives a quick overview. You can read [more information on tax](/tax) and how it’s calculated.
-
-<div class="ga-options-table">
-  <table class="options-table">
-    <thead>
-      <tr>
-        <td></td>
-        <th scope="col">
-          What’s tax free
-        </th>
-        <th scope="col">
-          What’s taxable
-        </th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <th scope="row">
-          <a href="/leave-pot-untouched">Leave your pot untouched</a>
-        </th>
-        <td>
-          You can still pay into your pot. Tax relief on payments up to £40,000 per year or 100% of your earnings – whichever is lower.
-        </td>
-        <td>
-          Payments over £40,000 or 100% of your earnings – whichever is lower.
-        </td>
-      </tr>
-      <tr>
-        <th scope="row">
-          <a href="/guaranteed-income">Guaranteed income (annuity)</a>
-        </th>
-        <td>
-          25% of your whole pot
-        </td>
-        <td>
-          Income you get from the annuity
-        </td>
-      </tr>
-      <tr>
-        <th scope="row">
-          <a href="/adjustable-income">Adjustable income</a>
-        </th>
-        <td>
-          25% of your whole pot
-        </td>
-        <td>
-          Income you get from the fund your money is invested in
-        </td>
-      </tr>
-      <tr>
-        <th scope="row">
-          <a href="/take-cash-in-chunks">Take cash in chunks</a>
-        </th>
-        <td>
-          25% of each amount you take out
-        </td>
-        <td>
-          75% of each amount you take out
-        </td>
-      </tr>
-      <tr>
-        <th scope="row">
-          <a href="/take-whole-pot">Take your whole pot in one go</a>
-        </th>
-        <td>
-          25% of your whole pot
-        </td>
-        <td>
-          75% of your whole pot
-        </td>
-      </tr>
-      <tr>
-        <th scope="row">
-          <a href="/mix-options">Mix your options</a>
-        </th>
-        <td>
-          Depends on the options you mix
-        </td>
-        <td>
-          Depends on the options you mix
-        </td>
-      </tr>
-    </tbody>
-  </table>
 </div>

--- a/content/pension_recycling.md
+++ b/content/pension_recycling.md
@@ -1,0 +1,13 @@
+---
+description: Be aware of pension recycling laws if you take your tax-fee lump sum and then pay into a pension.
+---
+
+# Pension recycling
+
+If you’re planning to take your tax-free lump sum and pay into the same pension pot or another one, you need to be aware of ‘pension recycling’ laws. 
+
+It could be pension recycling if you intend to use the tax-free lump sum to pay into a pension to get [tax relief](https://www.gov.uk/tax-on-your-private-pension/pension-tax-relief).
+
+If HM Revenue and Customs decide you have broken pension recycling laws, you may have to pay tax on the whole of the original tax-free lump sum – even if you only recycle some of the money.
+
+Get [financial advice](/financial-advice) if you want to reinvest your tax-free money into a pension.

--- a/content/tax.md
+++ b/content/tax.md
@@ -4,124 +4,166 @@ description: You pay tax on any income, including pension, that’s above your t
 
 # Tax you pay on your pension
 
-When you take money from your pension pot, you pay tax on any income above your tax-free [Personal Allowance](https://www.gov.uk/income-tax-rates).
+When you take money from your pension pot, 25% is tax free. This doesn’t use up any of your tax-free Personal Allowance. The standard allowance is £10,600.
 
-The amount of tax you pay depends on your total income and your [tax rate](https://www.gov.uk/income-tax-rates).
+You pay Income Tax on the other 75%. The amount you pay depends on your total income for the year and your tax rate.
 
-^25% of what you take is tax free – this money doesn't use up any of your Personal Allowance.^
+## How each pension option is taxed
 
-##What is taxed
+This table gives an overview of how much tax you may pay on the money you take from your pension pot.
 
-You could be taxed on:
+<div class="ga-options-table">
+  <table class="options-table">
+    <thead>
+      <tr>
+        <th scope="col" style="width:auto;"></th>
+        <th scope="col">
+        The pension options
+        </th>
+        <th scope="col">
+          What’s tax free
+        </th>
+        <th scope="col">
+          What’s taxable
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td style="width:auto;">
+          <span class="circle circle--s circle--leave-pot-untouched"></span>
+        </td>
+        <th scope="row">
+          <a href="/leave-pot-untouched">Leave your pot untouched</a>
+        </th>
+        <td>
+          Your whole pot while it stays untouched
+        </td>
+        <td>
+          Nothing while your pot stays untouched
+        </td>
+      </tr>
+      <tr>
+        <td style="width:auto;">
+          <span class="circle circle--s circle--guaranteed-income"></span>
+        </td>
+        <th scope="row">
+          <a href="/guaranteed-income">Guaranteed income (annuity)</a>
+        </th>
+        <td>
+          25% of your pot before you buy an annuity
+        </td>
+        <td>
+          Income from the annuity
+        </td>
+      </tr>
+      <tr>
+        <td style="width:auto;">
+          <span class="circle circle--s circle--adjustable-income"></span>
+        </td>
+        <th scope="row">
+          <a href="/adjustable-income">Adjustable income</a>
+        </th>
+        <td>
+          25% of your pot before you invest in an adjustable income
+        </td>
+        <td>
+          Income you get from your investment
+        </td>
+      </tr>
+      <tr>
+        <td style="width:auto;">
+          <span class="circle circle--s circle--take-cash-in-chunks"></span>
+        </td>
+        <th scope="row">
+          <a href="/take-cash-in-chunks">Take cash in chunks</a>
+        </th>
+        <td>
+          25% of each amount you take out
+        </td>
+        <td>
+          75% of each amount you take out
+        </td>
+      </tr>
+      <tr>
+        <td style="width:auto;">
+          <span class="circle circle--s circle--take-whole-pot"></span>
+        </td>
+        <th scope="row">
+          <a href="/take-whole-pot">Take your whole pot in one go</a>
+        </th>
+        <td>
+          25% of your whole pot
+        </td>
+        <td>
+          75% of your whole pot
+        </td>
+      </tr>
+      <tr>
+        <td style="width:auto;">
+          <span class="circle circle--s circle--mix-options"></span>
+        </td>
+        <th scope="row">
+          <a href="/mix-options">Mix your options</a>
+        </th>
+        <td>
+          Depends on the options you mix
+        </td>
+        <td>
+          Depends on the options you mix
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
 
-- any money you get from your pension pot, eg as an [annuity](/guaranteed-income), [cash in chunks](/take-cash-in-chunks) or the [whole pot in one go](/take-whole-pot)
+## Other tax you could pay
+
+You could also pay Income Tax on:
+
 - your State Pension
 - earnings from employment or self employment
 - any other income, eg money from rental income, savings, investments
 - any taxable benefits you might get, eg Carer’s Allowance
 
-If you [leave your pot untouched](/leave-pot-untouched), you don’t pay Income Tax on it.
+## The 25% tax-free amount
+There are 2 ways you can take your tax-free amount.
 
-##What’s tax free
-You can usually take 25% of your pot tax free. There are 2 ways you can do this.
-
-###Take it all in one go
-You can take 25% of your whole pension pot tax free.
-
-If you do this, you can’t leave the remaining 75% untouched. You must either take the [whole pot in one go](/take-whole-pot), buy an [annuity](/guaranteed-income) or [get an adjustable income](/adjustable-income).
-
-Money you take from the other 75% is taxable.
+### Take it all in one go
+You can take 25% as a lump sum without paying tax. If you do this, you can’t leave the remaining 75% untouched. You must either:
+- buy a guaranteed income (annuity) 
+- get an adjustable income (flexi-access drawdown)
+- take the whole pot as cash
 
 $E
 **Example**
-Your pot is £60,000 and you take £15,000 tax-free in one go.
+Your pot is £60,000 and you take £15,000 – this is your tax-free lump sum.
 You buy an annuity with the remaining £45,000 which pays you £2,000 a year.
 This money is taxable.
 $E
 
-###Take it in chunks
-You can take smaller cash sums from your pension pot – 25% of each chunk is tax free.
+### Take it in chunks
+You can take smaller cash sums from your pension pot without paying tax. 25% of each chunk is tax free.
 
 $E
 **Example**
-Your pot is £60,000 and you take £1,000 every month. £250 of this amount is tax free every time. The remaining £750 is taxable.
+Your pot is £60,000 and you take £1,000 every month – £250 of this is tax free. The remaining £750 is taxable.
 $E
 
-##Work out your Income Tax
-
-To calculate how much tax you could pay, do the following:
-
-s1. Take the 25% you get tax free away from your pension pot.
-s2. Add the remaining 75% to any other income you have. The remaining 75% can be a cash sum or income from an annuity or adjustable income.
-s3. Take your tax-free Personal Allowance away from this total.
-s4. Check your tax rate to calculate how much tax you’ll pay for the year.
-
-$E
-**Example:**
-You’ve decided to take your whole pot of £60,000 in one go.
-You also work part-time and make £7,000 a year.
-
-###1. Take 25% away from your pension pot.
-25% of £60,000 is £15,000.
-This leaves £45,000.
-
-###2. Add your other taxable income.
-£45,000 plus £7,000 = £52,000
-
-###3. Take away your tax-free allowance.
-You were born after 5 April 1948. Your Personal Allowance is £10,600.
-
-£52,000 minus £10,600 = £41,400
-
-This is your total taxable income for the year.
-
-###4. Check your tax rate
-You pay 20% on your income up to £31,785 (the limit for the basic rate of tax) = £6,357
-
-You pay 40% on the remaining £9,615 of your income = £3,846
-
-Total tax you pay for the year: £10,203
-$E
-
-^Other tax rules apply if [someone inherits your pension pot](/when-you-die).^
-
-##How your tax is paid
+## How your tax is paid
 
 Money you take from your pot comes from your provider with the tax already taken off.
 
 Your provider will also take off any tax due on your State Pension.
 
-###When you stop working
+You may pay emergency tax when you take money from your pot. You can [claim this back](https://www.gov.uk/claim-tax-refund/you-get-a-pension) from HM Revenue and Customs.
 
-HM Revenue and Customs (HMRC) adjust how much tax you pay once you stop working. This could mean that you pay emergency tax until HMRC recalculate how much tax you should be paying and send you a new tax code. 
-
-HMRC use your P45 to recalculate your tax code - this shows how much tax you paid in the present or previous tax year. 
-
-This is what you have to do and what happens next: 
-
-s1. You send parts 2 and 3 of your P45 to your pension provider or tell them you don’t have a P45.
-s2. Your provider tells HMRC that you've started to receive pension payments or have taken out all your money.
-s3. Your provider takes tax from your pension money. They’ll base the tax on your first payment on your tax rate from the P45. If you don’t have a P45 you’ll be given a temporary [emergency tax code](https://www.gov.uk/emergency-tax-code). This means you’ll pay Income Tax on everything above £883.33 a month (monthly portion of your £10,600 tax-free Personal Allowance) until HMRC sends a new tax code to your provider.
-s4. At the end of the tax year HMRC will check you've paid the right amount of tax. If you owe tax or have overpaid, they’ll send you a tax calculation and a new tax code to your provider. They’ll use this to work out how much tax to take from your pension payments for that tax year.
-s5. HMRC will send you a ‘PAYE coding notice’ which explains the changes.
-s6. You can [claim back any tax you’ve overpaid](https://www.gov.uk/claim-tax-refund/you-get-a-pension).
-
-
-###If you continue to work
+### If you continue to work
 Your employer will take any tax you owe off your earnings and your State Pension. This is called Pay As You Earn (PAYE). 
 
-If your total (including money from pensions and PAYE) is £100,000 or more for the tax year, or if you're self-employed, you'll have to fill in a [Self-Assessment tax return](https://www.gov.uk/self-assessment-tax-returns).
+If your total income (including money from pensions and PAYE) is £100,000 or more for the tax year, or if you're self-employed, you'll have to fill in a Self-Assessment tax return.
 
-###If you have other income
+### If you have other income
 You’re responsible for paying tax on other income you have, eg from property or investments, and you might have to fill in a Self-Assessment tax return.
 
-###Lifetime allowance
-You’ll have to pay tax on any amount in your pension pot above your [lifetime allowance of £1.25 million](https://www.gov.uk/tax-on-your-private-pension).
-
-##Pension recycling
-
-If you take a tax-free lump sum from your pot and you pay into the same or another pot, it’s known as ‘pension recycling’.
- 
-You may have to pay 55% tax on the whole tax-free lump sum, even if you only recycle some of the money.
-
-Get [financial advice](/financial-advice) if you’re thinking of increasing your pension contributions at the same time as taking a lump sum.
+^You usually pay tax if your pension pots are worth more than the [lifetime allowance.](https://www.gov.uk/tax-on-your-private-pension) This is currently £1.25 million (£1 million from 6 April 2016).^

--- a/features/guides.feature
+++ b/features/guides.feature
@@ -30,6 +30,7 @@ Feature: Guides
       | pension-pot-options    |
       | pension-pot-value      |
       | pension-statements     |
+      | pension-recycling      |
       | pension-types          |
       | scams                  |
       | shop-around            |


### PR DESCRIPTION
Changes to the 'Tax you pay on your pension' and 'What you can do with your pension pot' pages.

New page 'Pension recycling'.

'Pension recycling page needs to sit under the 'More' tab on the navigation.
There might be a couple of pension recycling page files. The first file I created, I didn't put the .md on the end. So I redid it.