### PR TITLE
Make `.ruby-version` the canonical Ruby version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '2.3.0'
+ruby IO.read('.ruby-version').strip
 
 gem 'bugsnag'
 gem 'canonical-rails'


### PR DESCRIPTION
Load the configured Ruby version via the `.ruby-version` file to ensure
that is the single source of truth.

See guidance-guarantee-programme/location-register#6 for precedent.