### PR TITLE
Replace Draper decorators with POROs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,6 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}.git" }
 gem 'autoprefixer-rails'
 gem 'bugsnag'
 gem 'canonical-rails'
-gem 'draper'
 gem 'faraday'
 gem 'faraday-conductivity'
 gem 'faraday_middleware'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,11 +84,6 @@ GEM
       nokogiri (~> 1.5)
       rails (>= 3, < 5)
     diff-lcs (1.2.5)
-    draper (1.4.0)
-      actionpack (>= 3.0)
-      activemodel (>= 3.0)
-      activesupport (>= 3.0)
-      request_store (~> 1.0)
     erubis (2.7.0)
     excon (0.45.3)
     execjs (2.5.2)
@@ -215,7 +210,6 @@ GEM
     rainbow (2.1.0)
     rake (11.1.2)
     redis (3.2.1)
-    request_store (1.1.0)
     rgeo (0.3.20)
     rgeo-geojson (0.3.1)
       rgeo (~> 0.3)
@@ -314,7 +308,6 @@ DEPENDENCIES
   bugsnag
   canonical-rails
   cucumber-rails
-  draper
   fakeredis
   faraday
   faraday-conductivity
@@ -360,5 +353,8 @@ DEPENDENCIES
   vcr
   webmock
 
+RUBY VERSION
+   ruby 2.3.1p112
+
 BUNDLED WITH
-   1.11.2
+   1.12.3

--- a/app/decorators/category_decorator.rb
+++ b/app/decorators/category_decorator.rb
@@ -1,11 +1,19 @@
-class CategoryDecorator < Draper::Decorator
-  delegate :id, :title, :description, :label
+class CategoryDecorator
+  delegate :id, :title, :description, :label, :slug, to: :category
+
+  def initialize(category)
+    @category = category
+  end
 
   def label
     title
   end
 
   def url
-    "/browse/#{object.slug}"
+    "/browse/#{slug}"
   end
+
+  private
+
+  attr_reader :category
 end

--- a/app/decorators/govspeak_guide_decorator.rb
+++ b/app/decorators/govspeak_guide_decorator.rb
@@ -1,5 +1,5 @@
 class GovspeakGuideDecorator < GuideDecorator
   def content
-    @content ||= Govspeak::Document.new(object.content).to_html.html_safe
+    @content ||= Govspeak::Document.new(guide.content).to_html.html_safe
   end
 end

--- a/app/decorators/guide_decorator.rb
+++ b/app/decorators/guide_decorator.rb
@@ -1,6 +1,19 @@
-class GuideDecorator < Draper::Decorator
-  delegate :id, :slug, :concise_label, :description,
-           :option?, :related_to_appointments?, :related_to_booking?
+class GuideDecorator
+  delegate(
+    :id,
+    :slug,
+    :concise_label,
+    :description,
+    :option?,
+    :related_to_appointments?,
+    :related_to_booking?,
+    :==,
+    to: :guide
+  )
+
+  def initialize(guide)
+    @guide = guide
+  end
 
   def url
     "/#{slug}"
@@ -11,7 +24,7 @@ class GuideDecorator < Draper::Decorator
   end
 
   def label
-    object.label.blank? ? title : object.label
+    guide.label.presence || title
   end
 
   def content
@@ -36,6 +49,8 @@ class GuideDecorator < Draper::Decorator
   end
 
   private
+
+  attr_reader :guide
 
   def content_document
     @content_document ||= Nokogiri::HTML(content)

--- a/app/decorators/html_guide_decorator.rb
+++ b/app/decorators/html_guide_decorator.rb
@@ -1,5 +1,5 @@
 class HTMLGuideDecorator < GuideDecorator
   def content
-    @content ||= Kramdown::Document.new(object.content, input: 'html').to_html.html_safe
+    @content ||= Kramdown::Document.new(guide.content, input: 'html').to_html.html_safe
   end
 end

--- a/app/view_models/navigation.rb
+++ b/app/view_models/navigation.rb
@@ -18,7 +18,7 @@ class Navigation
   private
 
   def find_topic(node)
-    category = CategoryDecorator.decorate(node.content)
+    category = CategoryDecorator.new(node.content)
     guides = find_guides(node.children).reject(&:empty?)
 
     Topic.new(category.id, category.label, category.url, guides)
@@ -55,7 +55,7 @@ class Navigation
   end
 
   def more_category
-    @more_category ||= CategoryDecorator.decorate(CategoryRepository.new.find('more'))
+    @more_category ||= CategoryDecorator.new(CategoryRepository.new.find('more'))
   end
 
   def more_topic


### PR DESCRIPTION
Drops the Draper dependency in favour of PORO decorators. Draper seems pretty
dormant and likely won't be supporting the imminent Rails 5 release any time
soon.

It seems most of our decorators favour `SimpleDelegator` over Draper too, so
this also brings some consistencies.