### PR TITLE
Refresh calculator results when slider text input is changed

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,7 @@ gem 'utf8-cleaner'
 group :development, :test do
   gem 'jasmine-jquery-rails'
   gem 'jasmine-rails'
+  gem 'phantomjs', '1.9.8.0'
   gem 'pry-rails'
   gem 'rspec-rails', '~> 3.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -325,6 +325,7 @@ DEPENDENCIES
   nokogiri
   output-templates (~> 4.1.0)!
   pdf-inspector
+  phantomjs (= 1.9.8.0)
   phoner
   poltergeist
   postcodes_io
@@ -357,4 +358,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.12.3
+   1.12.4

--- a/app/assets/javascripts/calculators.js
+++ b/app/assets/javascripts/calculators.js
@@ -107,7 +107,7 @@
         var $target = $($('#slider').attr('data-target'));
         var buffer;
 
-        slider.$textInput.on('change', $.proxy(function() {
+        slider.$textInput.on('change keyup', $.proxy(function() {
           clearTimeout(buffer);
 
           buffer = setTimeout($.proxy(function() {

--- a/spec/javascripts/calculatorSpec.js
+++ b/spec/javascripts/calculatorSpec.js
@@ -30,9 +30,9 @@ describe('calculators', function() {
       var $worker = $('<div/>');
       $worker.append(html)
              .find('.js-calculator-estimate')
-             .append('<div id="slider" data-slider>\
-                        <input data-slider-text-input />\
-                      </div>');
+             .append('<div id="slider" data-slider>' +
+                        '<input data-slider-text-input class="t-slider-input" />' +
+                      '</div>');
 
       return $worker.html();
     }
@@ -193,6 +193,22 @@ describe('calculators', function() {
       PWPG.calculators.updateEstimate(estimateWithSliderHTML);
 
       expect(spy).toHaveBeenCalled();
+    });
+
+    it('submits the form when the slider is changed', function(done) {
+      var estimateWithSliderHTML = addSlider(this.$calculator.html());
+      var $slider;
+
+      spyOn(PWPG.calculators, 'submitForm').and.returnValue($.Deferred());
+      PWPG.calculators.updateEstimate(estimateWithSliderHTML);
+
+      $slider = this.$calculator.find('.t-slider-input');
+      $slider.keyup();
+
+      setTimeout(function() {
+        expect(PWPG.calculators.submitForm).toHaveBeenCalled();
+        done();
+      }, 200);
     });
   });
 });

--- a/spec/javascripts/calculatorSpec.js
+++ b/spec/javascripts/calculatorSpec.js
@@ -26,6 +26,17 @@ describe('calculators', function() {
       return promise;
     }
 
+    function addSlider(html) {
+      var $worker = $('<div/>');
+      $worker.append(html)
+             .find('.js-calculator-estimate')
+             .append('<div id="slider" data-slider>\
+                        <input data-slider-text-input />\
+                      </div>');
+
+      return $worker.html();
+    }
+
     it('creates a `loading-status` on load', function() {
       expect(this.$calculator.find('.calculator__loading-status').length).toBe(1);
     });
@@ -173,6 +184,15 @@ describe('calculators', function() {
 
       $actualScrollToTarget = $(PWPG.calculators._scrollTo.calls.mostRecent().args[0]);
       expect($actualScrollToTarget.attr('class')).toEqual($defaultScrollTarget.attr('class'));
+    });
+
+    it('initalises a slider when slider is present in estimate response', function() {
+      var estimateWithSliderHTML = addSlider(this.$calculator.html());
+      var spy = spyOn(PWPG.Slider.prototype, 'init').and.callThrough();
+
+      PWPG.calculators.updateEstimate(estimateWithSliderHTML);
+
+      expect(spy).toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
Previously users had to hit enter or click outside the text field after changing the value of the slider. This PR adds test coverage and ensures that the form is updated on key change.