### PR TITLE
Visually highlight numbers on change

### DIFF
--- a/app/helpers/calculators_helper.rb
+++ b/app/helpers/calculators_helper.rb
@@ -1,0 +1,10 @@
+module CalculatorsHelper
+  CONTRIBUTION_MULTIPLIER = 5
+  DEFAULT_CONTRIBUTION_UPPER_LIMIT = 500
+
+  def leave_pot_untouched_slider_max(contribution)
+    max = contribution * CONTRIBUTION_MULTIPLIER
+    max = DEFAULT_CONTRIBUTION_UPPER_LIMIT if max.zero?
+    max
+  end
+end

--- a/app/views/calculators/leave_pot_untouched/_estimate.html.erb
+++ b/app/views/calculators/leave_pot_untouched/_estimate.html.erb
@@ -30,7 +30,7 @@
       text_before: '£',
       initial_value: contribution.to_f.ceil,
       min: 0,
-      max: contribution.to_i * 5,
+      max: leave_pot_untouched_slider_max(contribution.to_i),
       step: 5
   } %>
 </p>

--- a/app/views/calculators/leave_pot_untouched/_estimate.html.erb
+++ b/app/views/calculators/leave_pot_untouched/_estimate.html.erb
@@ -14,7 +14,7 @@
     <% estimate.each_with_index do |value, year| %>
       <tr>
         <td><%= year + 1 %></td>
-        <td class="t-calculator-future-pot-size"><%= number_to_currency(value) %></td>
+        <td class="t-calculator-future-pot-size"><span class="calculator__highlight"><%= number_to_currency(value) %></span></td>
       </tr>
     <% end %>
     </tbody>

--- a/app/views/calculators/take_cash_in_chunks/_estimate.html.erb
+++ b/app/views/calculators/take_cash_in_chunks/_estimate.html.erb
@@ -1,6 +1,6 @@
 <div id="js-estimate">
   <p>
-    If you take <span class="t-calculator-chunk"><%= number_to_currency(estimate.chunk) %></span> from your
+    If you take <span class="t-calculator-chunk calculator__highlight"><%= number_to_currency(estimate.chunk) %></span> from your
     <span class="t-calculator-pot"><%= number_to_currency(estimate.pot) %></span> pot, you could get:
 
     <strong class="calculator__estimate__number t-calculator-chunk-remaining">


### PR DESCRIPTION
* Visually highlight numbers on the Take cash in chunks and Leave your pot untouched calculators
* Provide a fallback slider maximum when a zero monthly contribution is provided