### PR TITLE
Cap income lasting to 120 on adjustable income calculator

### DIFF
--- a/lib/adjustable_income_calculator.rb
+++ b/lib/adjustable_income_calculator.rb
@@ -3,6 +3,7 @@ class AdjustableIncomeCalculator
   TAX_FREE_POT_PORTION = 0.25
   GROWTH_INTEREST_RATE = 0.03
   AMOUNT_TO_REDUCE_LIFETIME_PAYMENT_BY = 100
+  INCOME_LASTS_UNTIL_AGE_CAP = 120
 
   def initialize(pot:, age:, desired_income:)
     self.pot = pot
@@ -52,7 +53,7 @@ class AdjustableIncomeCalculator
 
       years_lasted += 1 if pot_remaining.positive?
 
-      break if years_lasted > 100
+      break if age + years_lasted >= INCOME_LASTS_UNTIL_AGE_CAP
     end
 
     age + years_lasted


### PR DESCRIPTION
The reality is drawdown can last for many years, or even
infinitely. But as this calculator is to illustrate how this
option works, we limit this number to an age of 120. Previously,
we showed (for example) "your income could last until you're 161"
– which can seem confusing.