### PR TITLE
Next and previous buttons

### DIFF
--- a/app/controllers/guides_controller.rb
+++ b/app/controllers/guides_controller.rb
@@ -6,8 +6,6 @@ class GuidesController < ApplicationController
 
   def show
     expires_in Rails.application.config.cache_max_age, public: true
-
-    render :option if @guide.option?
   end
 
   private

--- a/app/decorators/guide_decorator.rb
+++ b/app/decorators/guide_decorator.rb
@@ -5,6 +5,7 @@ class GuideDecorator
     :concise_label,
     :description,
     :option?,
+    :related_to_journey?,
     :related_to_appointments?,
     :related_to_booking?,
     :==,

--- a/app/helpers/guides_helper.rb
+++ b/app/helpers/guides_helper.rb
@@ -2,4 +2,24 @@ module GuidesHelper
   def book_an_appointment_link?
     !@guide.related_to_appointments?
   end
+
+  def previous_guide
+    return @previous_guide if defined?(@previous_guide)
+
+    previous_sibling = current_node.previous_sibling
+    @previous_guide = previous_sibling && GuideDecorator.cached_for(GuideRepository.new.find(previous_sibling.name))
+  end
+
+  def next_guide
+    return @next_guide if defined?(@next_guide)
+
+    next_sibling = current_node.next_sibling
+    @next_guide = next_sibling && GuideDecorator.cached_for(GuideRepository.new.find(next_sibling.name))
+  end
+
+  private
+
+  def current_node
+    @current_node ||= Taxonomy.instance.tree.detect { |node| node.name == @guide.id }
+  end
 end

--- a/app/models/guide.rb
+++ b/app/models/guide.rb
@@ -34,6 +34,10 @@ class Guide
     tagged_with?('option')
   end
 
+  def related_to_journey?
+    tagged_with?('option')
+  end
+
   def related_to_appointments?
     tagged_with?('appointments')
   end

--- a/app/views/guides/_journey_links.html.erb
+++ b/app/views/guides/_journey_links.html.erb
@@ -1,0 +1,22 @@
+<ul class="pager">
+  <%- if previous_guide %>
+    <li class="pager__item pager__item--previous">
+      <a href="<%= previous_guide.url %>" rel="prev" class="t-previous-page">
+        <span class="pager__label">Previous</span>
+        <span class="pager__title">
+          <%= previous_guide.label %>
+        </span>
+      </a>
+    </li>
+  <% end %>
+  <%- if next_guide %>
+    <li class="pager__item pager__item--next">
+      <a href="<%= next_guide.url %>" rel="next" class="t-next-page">
+        <span class="pager__label">Next</span>
+        <span class="pager__title">
+          <%= next_guide.label %>
+        </span>
+      </a>
+    </li>
+  <% end %>
+</ul>

--- a/app/views/guides/_option.html.erb
+++ b/app/views/guides/_option.html.erb
@@ -1,6 +1,3 @@
-<% content_for(:page_title, t('service.title', page_title: @guide.title)) %>
-<% content_for(:meta_description, @guide.description) %>
-
 <% content_for :sticky_sidebar do %>
   <div class="l-sticky-sidebar">
     <div class="sticky-sidebar js-sticky-sidebar sticky-sidebar--<%= @guide.slug %>">
@@ -53,4 +50,3 @@
 <% end %>
 
 <%= content_tag :span, nil, class: ['circle', 'circle--m', "circle--#{@guide.slug}"] %>
-<%= @guide.content %>

--- a/app/views/guides/show.html.erb
+++ b/app/views/guides/show.html.erb
@@ -1,4 +1,6 @@
 <% content_for(:page_title, t('service.title', page_title: @guide.title)) %>
 <% content_for(:meta_description, @guide.description) %>
 
+<%= render 'option' if @guide.option? %>
+
 <%= @guide.content %>

--- a/app/views/guides/show.html.erb
+++ b/app/views/guides/show.html.erb
@@ -4,3 +4,5 @@
 <%= render 'option' if @guide.option? %>
 
 <%= @guide.content %>
+
+<%= render 'journey_links' if @guide.related_to_journey? %>

--- a/features/journey_navigation.feature
+++ b/features/journey_navigation.feature
@@ -1,0 +1,18 @@
+Feature: Journey navigation
+  As a visitor to the website considering the 6 options
+  I want to be able to easily move between pages
+  So that I can find the best option for me
+
+  Scenario Outline: Guide navigation
+    When I visit the <Slug> guide
+    Then next button navigates to <Next path>
+    Then previous button navigates to <Previous path>
+
+    Examples:
+      | Slug                | Previous path        | Next path            |
+      | leave-pot-untouched |                      | /guaranteed-income   |
+      | guaranteed-income   | /leave-pot-untouched | /adjustable-income   |
+      | adjustable-income   | /guaranteed-income   | /take-cash-in-chunks |
+      | take-cash-in-chunks | /adjustable-income   | /take-whole-pot      |
+      | take-whole-pot      | /take-cash-in-chunks | /mix-options         |
+      | mix-options         | /take-whole-pot      |                      |

--- a/features/pages/guide_page.rb
+++ b/features/pages/guide_page.rb
@@ -17,6 +17,9 @@ module Pages
 
     element :calculator, '.t-calculator'
 
+    element :next_link, '.t-next-page'
+    element :previous_link, '.t-previous-page'
+
     def aside_heading_url
       aside_heading['href']
     end

--- a/features/step_definitions/guide_steps.rb
+++ b/features/step_definitions/guide_steps.rb
@@ -46,3 +46,19 @@ end
 Then(/^I can navigate back to the start of the guide$/) do
   expect(@page.aside_heading_url).to eq(@page.primary_heading_url)
 end
+
+Then(/^next button navigates to (.*)$/) do |path|
+  if path.present?
+    expect(@page.next_link['href']).to eq(path)
+  else
+    expect(@page).not_to have_next_link
+  end
+end
+
+Then(/^previous button navigates to (.*)$/) do |path|
+  if path.present?
+    expect(@page.previous_link['href']).to eq(path)
+  else
+    expect(@page).not_to have_previous_link
+  end
+end


### PR DESCRIPTION
The next and previous links have been added to the bottom of the calculator pages.

The implementation would allow the buttons to be added to any guide page
as it uses the Taxonomy class to determine the current guide pages position in 
the navigation tree.