### PR TITLE
Configurable online booking locations

### DIFF
--- a/app/views/locations/show.html.erb
+++ b/app/views/locations/show.html.erb
@@ -43,6 +43,12 @@
   Call <strong class="t-phone"><%= @location.phone %></strong>.
 </p>
 
+<% if Locations.online_booking?(@location.id) %>
+  <p>
+    <a href="#" class="button t-book-online">Book online</a>
+  </p>
+<% end %>
+
 <% if @location.booking_location %>
   <p>
     Tell the operator that you want to book a Pension Wise appointment at

--- a/config/initializers/enabled_online_booking_locations.rb
+++ b/config/initializers/enabled_online_booking_locations.rb
@@ -1,0 +1,3 @@
+Locations.online_booking_location_uids = [
+  # Corresponding location ID(s)
+]

--- a/features/customer_booking_request.feature
+++ b/features/customer_booking_request.feature
@@ -7,3 +7,8 @@ Scenario: Customer browses an online booking enabled location
   Given a location enabled for online booking
   When I browse for the location
   Then I can book online
+
+Scenario: Customer browses a regular location
+  Given no locations are enabled for online booking
+  When I browse for the location
+  Then I cannot book online

--- a/features/customer_booking_request.feature
+++ b/features/customer_booking_request.feature
@@ -1,0 +1,9 @@
+Feature: Customer creates a Booking Request
+  As a customer
+  I want to request an appointment
+  So I can understand my pension options
+
+Scenario: Customer browses an online booking enabled location
+  Given a location enabled for online booking
+  When I browse for the location
+  Then I can book online

--- a/features/fixtures/booking_locations.json
+++ b/features/fixtures/booking_locations.json
@@ -1,0 +1,23 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "id": "ac7112c3-e3cf-45cd-a8ff-9ba827b8e7ef",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -0.0552525,
+          51.5461062
+        ]
+      },
+      "properties": {
+        "title": "Hackney",
+        "address": "300 Mare St\nHACKNEY\nLondon\nE8 1HE",
+        "booking_location_id": "",
+        "phone": "+442085256360",
+        "hours": "Monday to Friday, 9:30am to 5pm"
+      }
+    }
+  ]
+}

--- a/features/pages/location_page.rb
+++ b/features/pages/location_page.rb
@@ -9,6 +9,7 @@ module Pages
     element :address, '.t-address'
     element :phone, '.t-phone'
     element :hours, '.t-hours'
+    element :book_online, '.t-book-online'
 
     elements :breadcrumbs, '.t-breadcrumb'
   end

--- a/features/step_definitions/customer_booking_request_steps.rb
+++ b/features/step_definitions/customer_booking_request_steps.rb
@@ -2,6 +2,10 @@ Given(/^a location enabled for online booking$/) do
   Locations.online_booking_location_uids = %w(ac7112c3-e3cf-45cd-a8ff-9ba827b8e7ef)
 end
 
+Given(/^no locations are enabled for online booking$/) do
+  Locations.online_booking_location_uids = []
+end
+
 When(/^I browse for the location$/) do
   with_booking_locations do
     @page = Pages::Location.new
@@ -11,6 +15,10 @@ end
 
 Then(/^I can book online$/) do
   expect(@page.book_online).to be_visible
+end
+
+Then(/^I cannot book online$/) do
+  expect(@page).to have_no_book_online
 end
 
 def with_booking_locations

--- a/features/step_definitions/customer_booking_request_steps.rb
+++ b/features/step_definitions/customer_booking_request_steps.rb
@@ -1,0 +1,23 @@
+Given(/^a location enabled for online booking$/) do
+  Locations.online_booking_location_uids = %w(ac7112c3-e3cf-45cd-a8ff-9ba827b8e7ef)
+end
+
+When(/^I browse for the location$/) do
+  with_booking_locations do
+    @page = Pages::Location.new
+    @page.load(id: 'ac7112c3-e3cf-45cd-a8ff-9ba827b8e7ef')
+  end
+end
+
+Then(/^I can book online$/) do
+  expect(@page.book_online).to be_visible
+end
+
+def with_booking_locations
+  previous_path = Locations.geo_json_path_or_url
+  Locations.geo_json_path_or_url = Rails.root.join(*%w(features fixtures booking_locations.json))
+
+  yield
+ensure
+  Locations.geo_json_path_or_url = previous_path
+end

--- a/lib/locations.rb
+++ b/lib/locations.rb
@@ -1,6 +1,11 @@
 module Locations
   class << self
     attr_accessor :geo_json_path_or_url
+    attr_accessor :online_booking_location_uids
+  end
+
+  def self.online_booking?(uid)
+    online_booking_location_uids.include?(uid)
   end
 
   def self.nearest_to_postcode(postcode, geocoder: Geocoder,


### PR DESCRIPTION
This acts as a dumb feature flag for now. When the
`online_booking_location_uids` are specified, the corresponding locations are
enabled for online bookings and the start button is displayed to the customer.