### PR TITLE
Remove sidebar navigation on location page

### DIFF
--- a/app/views/locations/show.html.erb
+++ b/app/views/locations/show.html.erb
@@ -66,23 +66,3 @@
 <p>
   You can also book in person by visiting any Citizens Advice bureau.
 </p>
-
-<% content_for :sidebar do %>
-  <div class="link-promo ga-elsewhere-sidebar">
-    <h2 class="link-promo__heading">Elsewhere on Pension Wise</h2>
-    <ul class="link-promo__list">
-      <li class="link-promo__item t-link-promo__item">
-        <a href="/pension-pot-options">What you can do with your pension pot</a>
-      </li>
-      <li class="link-promo__item t-link-promo__item">
-        <a href="/6-steps-you-need-to-take">6 steps you need to take</a>
-      </li>
-      <li class="link-promo__item t-link-promo__item">
-        <a href="/pension-types">Know your pension type</a>
-      </li>
-      <li class="link-promo__item t-link-promo__item">
-        <a href="/tax">Tax you pay on your pension</a>
-      </li>
-    </ul>
-  </div>
-<% end %>

--- a/features/step_definitions/location_steps.rb
+++ b/features/step_definitions/location_steps.rb
@@ -123,13 +123,3 @@ end
 Then(/^there are no search results to return to$/) do
   expect(Pages::Location.new).to_not have_back_to_results
 end
-
-Then(/^I am provided with next steps$/) do
-  page = Pages::Location.new
-
-  expect(page.link_promo_items.map(&:text))
-    .to eq(['What you can do with your pension pot',
-            '6 steps you need to take',
-            'Know your pension type',
-            'Tax you pay on your pension'])
-end

--- a/features/view_face-to-face_appointment_location_details.feature
+++ b/features/view_face-to-face_appointment_location_details.feature
@@ -16,7 +16,6 @@ Scenario: Bookmark a appointment location
   And I have bookmarked the page
   When I visit the bookmarked page
   Then I should see the details of that appointment location
-  And I am provided with next steps
 
 Scenario: Appointment location that handles its own booking
   When I view the details of an appointment location that handles its own booking


### PR DESCRIPTION
We removed all the sidebar navigation a while back, but
this bit must have been missed. It was also pointing some pages
that no longer exist.