### PR TITLE
Show chosen appointment slots on step two of booking request

### DIFF
--- a/app/assets/stylesheets/vendor/_slot-picker.scss
+++ b/app/assets/stylesheets/vendor/_slot-picker.scss
@@ -16,6 +16,14 @@
   }
 }
 
+.SlotPicker--read-only {
+  .SlotPicker-choice {
+    .SlotPicker-choiceInner {
+      padding-right: 0;
+    }
+  }
+}
+
 .SlotPicker-day {
   font-size: 85%;
   margin-left: 0;

--- a/app/helpers/booking_requests_helper.rb
+++ b/app/helpers/booking_requests_helper.rb
@@ -1,0 +1,25 @@
+module BookingRequestsHelper
+  def slot_as_formatted_date(slot_text)
+    Date.parse(slot_properties(slot_text)[:date]).strftime('%A, %b %e')
+  end
+
+  def slot_period(slot_text)
+    slot_properties(slot_text)[:from] == '0900' ? 'Morning' : 'Afternoon'
+  end
+
+  def slot_duration
+    '60 minutes'
+  end
+
+  private
+
+  def slot_properties(slot_text)
+    date, from, to = slot_text.match(/\A(\d{4}-\d{2}-\d{2})-(\d{4})-(\d{4})\z/).captures
+
+    {
+      date: date,
+      from: from,
+      to: to
+    }
+  end
+end

--- a/app/views/booking_requests/step_one.html.erb
+++ b/app/views/booking_requests/step_one.html.erb
@@ -118,7 +118,7 @@
       Afternoon
       {{/ifCond}}
   </strong>
-    <span class="SlotPicker-duration">45 mins</span>
+    <span class="SlotPicker-duration"><%= slot_duration %></span>
   </label>
 </script>
 

--- a/app/views/booking_requests/step_two.html.erb
+++ b/app/views/booking_requests/step_two.html.erb
@@ -126,7 +126,15 @@
 
       <div class="form-group">
         <%= f.submit 'Submit booking request', class: 'button t-submit' %>
-        <%= link_to 'Go back to change your chosen dates',
+      </div>
+
+    <% end %>
+  </div>
+
+  <div class="l-column-third">
+    <h2>Your time preferences</h2>
+    <p>Your chosen appointment times are below.</p>
+    <p>Need to change? <%= link_to 'Go back to calendar',
           booking_request_step_one_location_path(
             id: location_id,
             booking_request: {
@@ -135,10 +143,41 @@
               tertiary_slot: @booking_request.tertiary_slot
             }
           ),
-          class: 'button t-back'
-        %>
-      </div>
+          class: 't-back'
+        %>.</p>
 
-    <% end %>
+    <div class="SlotPicker-choices is-chosen SlotPicker--selected SlotPicker--read-only">
+     <div class="SlotPicker-choice is-chosen">
+       <div class="SlotPicker-choiceInner">
+         <div class="SlotPicker-position"><span>1</span></div>
+         <div class="SlotPicker-choiceContent">
+           <p class="SlotPicker-date"><%= slot_as_formatted_date(@booking_request.primary_slot) %></p>
+           <p class="SlotPicker-time">
+           <%= slot_period(@booking_request.primary_slot) %>, <%= slot_duration %></p>
+         </div>
+       </div>
+     </div>
+
+     <div class="SlotPicker-choice is-chosen">
+       <div class="SlotPicker-choiceInner">
+         <div class="SlotPicker-position"><span>2</span></div>
+         <div class="SlotPicker-choiceContent">
+           <p class="SlotPicker-date"><%= slot_as_formatted_date(@booking_request.secondary_slot) %></p>
+           <p class="SlotPicker-time">
+           <%= slot_period(@booking_request.secondary_slot) %>, <%= slot_duration %></p>
+         </div>
+       </div>
+     </div>
+
+     <div class="SlotPicker-choice is-chosen">
+       <div class="SlotPicker-choiceInner">
+         <div class="SlotPicker-position"><span>3</span></div>
+         <div class="SlotPicker-choiceContent">
+           <p class="SlotPicker-date"><%= slot_as_formatted_date(@booking_request.tertiary_slot) %></p>
+           <p class="SlotPicker-time">
+           <%= slot_period(@booking_request.tertiary_slot) %>, <%= slot_duration %></p>
+         </div>
+       </div>
+     </div>
   </div>
 </div>


### PR DESCRIPTION
To ensure the customer can see what times they have chosen before
submitting the remainder of their details. They also have the option
to go back and change the slots using the link provided.