### PR TITLE
Online booking customer details page tweaks

### DIFF
--- a/app/forms/booking_request_form.rb
+++ b/app/forms/booking_request_form.rb
@@ -21,7 +21,7 @@ class BookingRequestForm
     step_two.validates :appointment_type, inclusion: { in: %w(50-54 55-plus) }
     step_two.validates :accessibility_requirements, inclusion: { in: %w(0 1) }
     step_two.validates :opt_in, inclusion: { in: %w(0 1) }
-    step_two.validates :dc_pot, acceptance: { accept: '1' }
+    step_two.validates :dc_pot, inclusion: { in: %w(yes not-sure) }
   end
 
   def initialize(location_id, opts)

--- a/app/views/booking_requests/step_two.html.erb
+++ b/app/views/booking_requests/step_two.html.erb
@@ -3,7 +3,7 @@
     <h1>Your details</h1>
 
     <% if @booking_request.errors.any? %>
-      <div class="l-column-two-thirds error-summary t-errors" role="group" aria-labelledby="error-summary-heading-example-1" tabindex="-1">
+      <div class="error-summary t-errors" role="group" aria-labelledby="error-summary-heading-example-1" tabindex="-1">
         <h1 class="heading-medium error-summary-heading" id="error-summary-heading-example-1">
           There was a problem with your details
         </h1>
@@ -78,21 +78,49 @@
           <% end %>
 
           <%= f.label :appointment_type, value: 'under-50', class: 'block-label' do %>
-              <%= f.radio_button :appointment_type, 'under-50', checked: false,
+              <%= f.radio_button :appointment_type, 'under-50',
                                  class: 't-appointment-type-1' %>
               Under 50
           <% end %>
 
           <%= f.label :appointment_type, value: '50-54', class: 'block-label' do %>
-              <%= f.radio_button :appointment_type, '50-54', checked: false,
+              <%= f.radio_button :appointment_type, '50-54',
                                  class: 't-appointment-type-2' %>
               50 to 54
           <% end %>
 
           <%= f.label :appointment_type, value: '55-plus', class: 'block-label' do %>
-            <%= f.radio_button :appointment_type, '55-plus', checked: false,
+            <%= f.radio_button :appointment_type, '55-plus',
                                  class: 't-appointment-type-3' %>
             55 or over
+          <% end %>
+        </fieldset>
+      </div>
+
+      <div class="form-group <%= 'error' if @booking_request.errors.include?(:dc_pot) %>">
+        <fieldset class="inline">
+          <legend>Do you have a defined contribution pension pot?</legend>
+
+          <% if @booking_request.errors.include?(:dc_pot) %>
+            <span class="error-message"><%= @booking_request.errors[:dc_pot].to_sentence %></span>
+          <% end %>
+
+          <%= f.label :dc_pot, value: 'yes', class: 'block-label' do %>
+              <%= f.radio_button :dc_pot, 'yes',
+                                 class: 't-dc-pot-1' %>
+              Yes
+          <% end %>
+
+          <%= f.label :dc_pot, value: 'no', class: 'block-label' do %>
+              <%= f.radio_button :dc_pot, 'no',
+                                 class: 't-dc-pot-2' %>
+              No
+          <% end %>
+
+          <%= f.label :dc_pot, value: 'not-sure', class: 'block-label' do %>
+            <%= f.radio_button :dc_pot, 'not-sure',
+                                 class: 't-dc-pot-3' %>
+            Not sure
           <% end %>
         </fieldset>
       </div>
@@ -112,15 +140,6 @@
             <span class="error-message"><%= @booking_request.errors[:opt_in].to_sentence %></span>
           <% end %>
           <%= f.check_box :opt_in, class: 't-opt-in' %> Yes, I would like to receive marketing information
-        <% end %>
-      </div>
-
-      <div class="form-group <%= 'error' if @booking_request.errors.include?(:dc_pot) %>">
-        <%= f.label :dc_pot do %>
-          <% if @booking_request.errors.include?(:dc_pot) %>
-            <span class="error-message"><%= @booking_request.errors[:dc_pot].to_sentence %></span>
-          <% end %>
-          <%= f.check_box :dc_pot, class: 't-dc-pot' %> I have a defined contribution pension pot
         <% end %>
       </div>
 

--- a/features/pages/booking_step_two.rb
+++ b/features/pages/booking_step_two.rb
@@ -10,7 +10,10 @@ module Pages
     element :memorable_word, '.t-memorable-word'
     element :accessibility_requirements, '.t-accessibility-requirements'
     element :opt_in, '.t-opt-in'
-    element :dc_pot, '.t-dc-pot'
+
+    element :dc_pot_yes, '.t-dc-pot-1'
+    element :dc_pot_no, '.t-dc-pot-2'
+    element :dc_pot_not_sure, '.t-dc-pot-3'
 
     element :under_fifty, '.t-appointment-type-1'
     element :fifty_to_fifty_four, '.t-appointment-type-2'

--- a/features/step_definitions/customer_booking_request_steps.rb
+++ b/features/step_definitions/customer_booking_request_steps.rb
@@ -74,7 +74,7 @@ end
 
 When(/^I pass the basic eligibility requirements$/) do
   @step_two.fifty_to_fifty_four.set true
-  @step_two.dc_pot.set true
+  @step_two.dc_pot_yes.set true
 end
 
 When(/^I submit my completed Booking Request$/) do

--- a/lib/booking_requests/api_mapper.rb
+++ b/lib/booking_requests/api_mapper.rb
@@ -11,7 +11,7 @@ module BookingRequests
           age_range: booking_request.appointment_type,
           accessibility_requirements: booking_request.accessibility_requirements,
           marketing_opt_in: booking_request.opt_in,
-          defined_contribution_pot: booking_request.dc_pot,
+          defined_contribution_pot: dc_pot_as_boolean(booking_request.dc_pot),
           slots: [
             slot(1, booking_request.primary_slot),
             slot(2, booking_request.secondary_slot),
@@ -30,6 +30,10 @@ module BookingRequests
         from: from,
         to: to
       }
+    end
+
+    def self.dc_pot_as_boolean(dc_pot)
+      %w(yes not-sure).any? { |type| dc_pot.include?(type) }
     end
   end
 end

--- a/spec/forms/booking_request_form_spec.rb
+++ b/spec/forms/booking_request_form_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe BookingRequestForm do
         appointment_type: '55-plus',
         accessibility_requirements: '0',
         opt_in: '0',
-        dc_pot: '1'
+        dc_pot: 'yes'
       )
     end
 

--- a/spec/lib/booking_requests/api_mapper_spec.rb
+++ b/spec/lib/booking_requests/api_mapper_spec.rb
@@ -14,30 +14,46 @@ RSpec.describe BookingRequests::ApiMapper do
       appointment_type: '55-plus',
       accessibility_requirements: false,
       opt_in: false,
-      dc_pot: true
+      dc_pot: 'yes'
     )
   end
 
-  subject { described_class.map(booking_request) }
+  context 'mapping the booking_request form' do
+    subject { described_class.map(booking_request) }
 
-  it 'maps from the `BookingRequestForm` to requisite payload' do
-    expect(subject).to eq(
-      booking_request: {
-        location_id: location_id,
-        name: 'Lucius Needful',
-        email: 'lucius@example.com',
-        phone: '0208 244 3987',
-        memorable_word: 'meseeks',
-        age_range: '55-plus',
-        accessibility_requirements: false,
-        marketing_opt_in: false,
-        defined_contribution_pot: true,
-        slots: [
-          { priority: 1, date: '2016-01-01', from: '0900', to: '1300' },
-          { priority: 2, date: '2016-01-01', from: '1300', to: '1700' },
-          { priority: 3, date: '2016-01-02', from: '0900', to: '1300' }
-        ]
-      }
-    )
+    it 'maps from the `BookingRequestForm` to requisite payload' do
+      expect(subject).to eq(
+        booking_request: {
+          location_id: location_id,
+          name: 'Lucius Needful',
+          email: 'lucius@example.com',
+          phone: '0208 244 3987',
+          memorable_word: 'meseeks',
+          age_range: '55-plus',
+          accessibility_requirements: false,
+          marketing_opt_in: false,
+          defined_contribution_pot: true,
+          slots: [
+            { priority: 1, date: '2016-01-01', from: '0900', to: '1300' },
+            { priority: 2, date: '2016-01-01', from: '1300', to: '1700' },
+            { priority: 3, date: '2016-01-02', from: '0900', to: '1300' }
+          ]
+        }
+      )
+    end
+  end
+
+  context 'coerces the `dc_pot` strings to booleans' do
+    it 'coerces `yes` to true' do
+      expect(described_class.dc_pot_as_boolean('yes')).to be true
+    end
+
+    it 'coerces `not-sure` to true' do
+      expect(described_class.dc_pot_as_boolean('not-sure')).to be true
+    end
+
+    it 'coerces `no` to false' do
+      expect(described_class.dc_pot_as_boolean('no')).to be false
+    end
   end
 end

--- a/spec/requests/complete_booking_request_spec.rb
+++ b/spec/requests/complete_booking_request_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'POST /locations/:id/booking-request/complete', type: :request do
           appointment_type: '55-plus',
           accessibility_requirements: '0',
           opt_in: '0',
-          dc_pot: '1'
+          dc_pot: 'yes'
         }
       }
 


### PR DESCRIPTION
* Allow validation summary to stretch to full width of container
* Persist radio button values on error state
* Rephrase `dc_pot` question as Yes, no, not sure. Yes and not sure are valid.

@benlovell that change to `dc_pot` might need some thinking on the [planner](https://github.com/guidance-guarantee-programme/planner/blob/master/spec/requests/create_a_booking_request_spec.rb#L74) side of things. Ideally we would store the exact answer the user provided, but I suppose we could coerce to `true` if easier?