### PR TITLE
Include `booking_location_id` in JSON payload

### DIFF
--- a/app/forms/booking_request_form.rb
+++ b/app/forms/booking_request_form.rb
@@ -37,6 +37,8 @@ class BookingRequestForm
     @booking_location ||= BookingLocations.find(location_id)
   end
 
+  delegate :id, to: :booking_location, prefix: :booking_location
+
   def location_name
     booking_location.name_for(location_id)
   end

--- a/lib/booking_requests/api_mapper.rb
+++ b/lib/booking_requests/api_mapper.rb
@@ -3,6 +3,7 @@ module BookingRequests
     def self.map(booking_request) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
       {
         booking_request: {
+          booking_location_id: booking_request.booking_location_id,
           location_id: booking_request.location_id,
           name: "#{booking_request.first_name} #{booking_request.last_name}",
           email: booking_request.email,

--- a/spec/lib/booking_requests/api_mapper_spec.rb
+++ b/spec/lib/booking_requests/api_mapper_spec.rb
@@ -1,6 +1,9 @@
 RSpec.describe BookingRequests::ApiMapper do
+  let(:booking_location_id) { SecureRandom.uuid }
   let(:location_id) { SecureRandom.uuid }
   let(:booking_request) do
+    allow(BookingLocations).to receive(:find).and_return(double(id: booking_location_id))
+
     BookingRequestForm.new(
       location_id,
       primary_slot: '2016-01-01-0900-1300',
@@ -24,6 +27,7 @@ RSpec.describe BookingRequests::ApiMapper do
     it 'maps from the `BookingRequestForm` to requisite payload' do
       expect(subject).to eq(
         booking_request: {
+          booking_location_id: booking_location_id,
           location_id: location_id,
           name: 'Lucius Needful',
           email: 'lucius@example.com',


### PR DESCRIPTION
The planner API for booking requests expects this now.

The rationale for this is we can make more efficient lookups for location
sub-trees in the planner frontend, when querying for location-specific
booking requests. This would be in the context of a booking's manager who is
only permitted to view bookings within their own location sub-tree.