### PR TITLE
Allow 12 factor configuration for location IDs

### DIFF
--- a/config/initializers/online_booking_locations.rb
+++ b/config/initializers/online_booking_locations.rb
@@ -1,6 +1,5 @@
-Locations.online_booking_location_uids = [
-  # Corresponding location ID(s)
-]
+# Corresponding location ID(s)
+Locations.online_booking_location_uids = ENV.fetch('BOOKING_LOCATION_UIDS', '').split(',')
 
 # Booking Locations API adapter
 BookingLocations.api = if Rails.env.development?


### PR DESCRIPTION
Allows us to configure pilot booking location IDs using a comma
separated list of IDs in the `BOOKING_LOCATION_UIDS` environment
variable. Will safely evaluate to an empty array when unset.