### PR TITLE
Use opt_in as terms and conditions acceptance

### DIFF
--- a/app/forms/booking_request_form.rb
+++ b/app/forms/booking_request_form.rb
@@ -20,7 +20,7 @@ class BookingRequestForm
     step_two.validates :memorable_word, presence: true
     step_two.validates :appointment_type, inclusion: { in: %w(50-54 55-plus) }
     step_two.validates :accessibility_requirements, inclusion: { in: %w(0 1) }
-    step_two.validates :opt_in, inclusion: { in: %w(0 1) }
+    step_two.validates :opt_in, acceptance: { accept: '1' }
     step_two.validates :dc_pot, inclusion: { in: %w(yes not-sure) }
   end
 

--- a/app/views/booking_requests/step_two.html.erb
+++ b/app/views/booking_requests/step_two.html.erb
@@ -139,7 +139,7 @@
           <% if @booking_request.errors.include?(:opt_in) %>
             <span class="error-message"><%= @booking_request.errors[:opt_in].to_sentence %></span>
           <% end %>
-          <%= f.check_box :opt_in, class: 't-opt-in' %> Yes, I would like to receive marketing information
+          <%= f.check_box :opt_in, class: 't-opt-in' %> I accept the <a href="/privacy" target="_blank">terms and conditions</a>
         <% end %>
       </div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -25,6 +25,7 @@ en:
         tertiary_slot: Slot 3
         appointment_type: Age range
         dc_pot: Defined contribution pot
+        opt_in: Terms and conditions
     errors:
       models:
         appointment_summary:

--- a/features/step_definitions/customer_booking_request_steps.rb
+++ b/features/step_definitions/customer_booking_request_steps.rb
@@ -69,7 +69,7 @@ When(/^I provide my personal details$/) do
   @step_two.telephone_number.set '07715 930 459'
   @step_two.memorable_word.set 'birdperson'
   @step_two.accessibility_requirements.set false
-  @step_two.opt_in.set false
+  @step_two.opt_in.set true
 end
 
 When(/^I pass the basic eligibility requirements$/) do

--- a/spec/forms/booking_request_form_spec.rb
+++ b/spec/forms/booking_request_form_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe BookingRequestForm do
         memorable_word: 'meseeks',
         appointment_type: '55-plus',
         accessibility_requirements: '0',
-        opt_in: '0',
+        opt_in: '1',
         dc_pot: 'yes'
       )
     end
@@ -60,8 +60,8 @@ RSpec.describe BookingRequestForm do
         expect(subject).not_to be_step_two_valid
       end
 
-      it 'requires opt_in to be true or false' do
-        subject.opt_in = nil
+      it 'requires opt_in to be true' do
+        subject.opt_in = false
         expect(subject).not_to be_step_two_valid
       end
 

--- a/spec/requests/complete_booking_request_spec.rb
+++ b/spec/requests/complete_booking_request_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'POST /locations/:id/booking-request/complete', type: :request do
           memorable_word: 'meseeks',
           appointment_type: '55-plus',
           accessibility_requirements: '0',
-          opt_in: '0',
+          opt_in: '1',
           dc_pot: 'yes'
         }
       }


### PR DESCRIPTION
This field is now required, and is a reference to the customer
accepting Pension Wise's terms and conditions.