### PR TITLE
Cache booking locations in memory

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -58,7 +58,7 @@ Rails.application.configure do
   # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
 
   # Use a different cache store in production.
-  # config.cache_store = :mem_cache_store
+  config.cache_store = :memory_store
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   config.action_controller.asset_host = ENV['ASSET_HOST']

--- a/config/initializers/online_booking_locations.rb
+++ b/config/initializers/online_booking_locations.rb
@@ -16,5 +16,6 @@ BookingLocations.api = if Rails.env.development?
                          require 'booking_locations/stub_api'
                          BookingLocations::StubApi.new
                        else
-                         BookingLocations::Api.new
+                         require 'cached_booking_locations_api'
+                         CachedBookingLocationsApi.new
                        end

--- a/lib/cached_booking_locations_api.rb
+++ b/lib/cached_booking_locations_api.rb
@@ -1,0 +1,15 @@
+class CachedBookingLocationsApi < BookingLocations::Api
+  def initialize(cache: Rails.cache)
+    @cache = cache
+  end
+
+  def find(location_id)
+    cache.fetch(location_id, expires_in: 2.hours) do
+      super
+    end
+  end
+
+  private
+
+  attr_reader :cache
+end


### PR DESCRIPTION
Use a read-through cache to store booking locations JSON in memory and
save a bunch of roundtrips to the API during the booking process. The
locations have a TTL of two hours by default.

For the timebeing we're configured to use the memory store cache, but
it may make more sense in future to use the redis cache or something
shared, not per-dyno.