### PR TITLE
Open feedback tickets from the customer

### DIFF
--- a/app/forms/booking_feedback_form.rb
+++ b/app/forms/booking_feedback_form.rb
@@ -8,12 +8,10 @@ class BookingFeedbackForm
   validates :message, presence: true
 
   def message_content
-    %(
-      Name: #{name}
-      Email: #{email}
-
-      Message:
-      #{message}
-    )
+    {
+      name: name,
+      email: email,
+      message: message
+    }
   end
 end

--- a/lib/feedback.rb
+++ b/lib/feedback.rb
@@ -1,7 +1,7 @@
 module Feedback
   mattr_accessor :api
 
-  def self.create_ticket(message)
-    api.create_ticket(message)
+  def self.create_ticket(message_options)
+    api.create_ticket(message_options)
   end
 end

--- a/lib/feedback/stub_client.rb
+++ b/lib/feedback/stub_client.rb
@@ -1,6 +1,6 @@
 module Feedback
   class StubClient
-    def create_ticket(message)
+    def create_ticket(*)
       # noop
     end
   end

--- a/lib/feedback/zen_desk_client.rb
+++ b/lib/feedback/zen_desk_client.rb
@@ -7,12 +7,12 @@ module Feedback
       @client = client
     end
 
-    def create_ticket(message)
+    def create_ticket(name:, email:, message:)
       ticket_class.create!(
         client,
         subject: 'Online Booking feedback',
+        requester: { name: name, email: email },
         comment: { value: message },
-        submitter_id: ENV['ZENDESK_API_SUBMITTER_ID'],
         tags: %w(online_booking)
       )
     end

--- a/spec/lib/feedback/zen_desk_client_spec.rb
+++ b/spec/lib/feedback/zen_desk_client_spec.rb
@@ -8,11 +8,12 @@ RSpec.describe Feedback::ZenDeskClient do
     expect(ticket_class).to receive(:create!).with(
       client,
       hash_including(
+        requester: { name: 'Ben', email: 'ben@example.com' },
         comment: { value: 'Awesome!' },
         tags: %w(online_booking)
       )
     )
 
-    subject.create_ticket('Awesome!')
+    subject.create_ticket(name: 'Ben', email: 'ben@example.com', message: 'Awesome!')
   end
 end


### PR DESCRIPTION
Reworks the ticket creation to make them appear as though they're sent
directly from the customer. This allows us to track customer
interactions in zendesk much more efficiently.