### PR TITLE
Fix intermittently failing tests by disabling jQuery animations in test environment

### DIFF
--- a/app/views/layouts/_base.html.erb
+++ b/app/views/layouts/_base.html.erb
@@ -93,6 +93,18 @@
   </script>
   <%# End UserZoom intercept %>
 
+  <% if Rails.env.test? %>
+    <%#
+    Disable jQuery animations in the test environment to
+    increase speed of the test suite and give us a more
+    consistent DOM to make assertions against. Without this,
+    we were seeing frequent intermittent test failures.
+    %>
+    <script>
+      $.fx.off = true;
+    </script>
+  <% end %>
+
   <%= yield :after_script %>
 <% end %>
 


### PR DESCRIPTION
In order to fix the following error: -

``And I provide my personal details                # features/step_definitions/customer_booking_request_steps.rb:62
      expected `#<Pages::BookingStepTwo:0x007ff751ff1770 @addressable_url_matcher=#<SitePrism::AddressableUrlMatcher:0x007ff751ff07d0 @pattern="/locations/{id}/booking-request/step-two", @substitutions={"{id}"=>"tlifxq"}, @reverse_substitutions={"tlifxq"=>"{id}"}, @component_templates={:path=>#<Addressable::Template:0x3ffba8ff1958 PATTERN:/locations/{id}/booking-request/step-two>}>>.displayed?` to return true, got false (RSpec::Expectations::ExpectationNotMetError)
      ./features/support/booking_requests.rb:5:in `block in <top (required)>'
      ./features/support/booking_locations.rb:7:in `block in <top (required)>'
      features/customer_booking_request.feature:24:in `And I provide my personal details'
``

which often crops up when running the build.