### PR TITLE
Update email validation to stop ZenDesk errors

### DIFF
--- a/app/forms/annuity_registration_form.rb
+++ b/app/forms/annuity_registration_form.rb
@@ -11,17 +11,19 @@ class AnnuityRegistrationForm
 
   validates :first_name, :last_name, :phone_number, :postcode,
             presence: true
-  validates :email, format: /.+@.+\..+/
+  validates :email, format: /.+@[^\s]+\.[^\s]+/
   validates :annuity_type,
             inclusion: { in: %w(in_own_name in_group_name dont_know) }
-  validates :age, :annuity_value,
+  validates :age,
+            numericality: { greater_than: 0 }
+  validates :annuity_value,
             numericality: { greater_than: 0, allow_blank: true }
   validates :appointment_type, inclusion: { in: %w(face_to_face phone) }
 
   def message_content # rubocop:disable Metrics/MethodLength
     {
       name: name,
-      email: email,
+      email: email.strip,
       message: message,
       subject: 'Annuities Registration',
       tags: %w(annuities_registration),
@@ -35,7 +37,7 @@ class AnnuityRegistrationForm
   private
 
   def name
-    "#{first_name} #{last_name}".chomp
+    "#{first_name} #{last_name}".strip
   end
 
   def csv_field_id
@@ -51,6 +53,6 @@ class AnnuityRegistrationForm
   end
 
   def clean_for_csv_output(value)
-    value.to_s.tr(',', ';').gsub(/[\r\n]+/, ' ')
+    value.to_s.tr(',', ';').gsub(/[\r\n]+/, ' ').strip
   end
 end

--- a/spec/forms/annuities_registration_form_spec.rb
+++ b/spec/forms/annuities_registration_form_spec.rb
@@ -1,0 +1,15 @@
+RSpec.describe AnnuityRegistrationForm do
+  it { is_expected.to validate_presence_of(:first_name) }
+  it { is_expected.to validate_presence_of(:last_name) }
+  it { is_expected.to validate_presence_of(:phone_number) }
+  it { is_expected.to validate_presence_of(:postcode) }
+  it { is_expected.to validate_inclusion_of(:annuity_type).in_array(%w(in_own_name in_group_name dont_know)) }
+  it { is_expected.to validate_numericality_of(:age).is_greater_than(0) }
+  it { is_expected.to validate_numericality_of(:annuity_value).is_greater_than(0).allow_nil }
+
+  context '.email' do
+    it { is_expected.to allow_value('text@test.com').for(:email) }
+    it { is_expected.to allow_value('  text@test.com  ').for(:email) }
+    it { is_expected.not_to allow_value('text@ test .com').for(:email) }
+  end
+end


### PR DESCRIPTION
This means emails can not contain spaces and
trailing spaces are removed inline with:

https://support.zendesk.com/hc/en-us/community/posts/203455266-Requester-email-is-already-used-by-another-user