### PR TITLE
Swallow ZenDesk errors

### DIFF
--- a/lib/zen_desk/client.rb
+++ b/lib/zen_desk/client.rb
@@ -7,8 +7,14 @@ module ZenDesk
       @client = client
     end
 
+    def create_ticket(options)
+      create_ticket!(options)
+    rescue ZendeskAPI::Error::RecordInvalid => e
+      Bugsnag.notify(e)
+    end
+
     # rubocop:disable Metrics/ParameterLists
-    def create_ticket(name:, email:, message:, subject:, tags:, custom_fields: nil)
+    def create_ticket!(name:, email:, message:, subject:, tags:, custom_fields: nil)
       ticket = {
         subject: subject,
         requester: { name: name, email: email },

--- a/spec/lib/zen_desk/client_spec.rb
+++ b/spec/lib/zen_desk/client_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe ZenDesk::Client do
   let(:ticket_class) { double }
-  let(:client) { double.as_null_object }
+  let(:client) { double }
 
   subject { described_class.new(ticket_class: ticket_class, client: client) }
 
@@ -22,5 +22,34 @@ RSpec.describe ZenDesk::Client do
       subject: 'Online booking test',
       tags: %w(online_booking)
     )
+  end
+
+  context 'when a ZendeskAPI::Error::ClientError error happens' do
+    before do
+      allow(ticket_class).to receive(:create!).and_raise(ZendeskAPI::Error::RecordInvalid, {})
+    end
+
+    it 'reports the error to BugSnag' do
+      expect(Bugsnag).to receive(:notify)
+      subject.create_ticket(
+        name: 'Ben',
+        email: 'ben@example.com',
+        message: 'Awesome!',
+        subject: 'Online booking test',
+        tags: %w(online_booking)
+      )
+    end
+
+    it 'does not raise an error' do
+      expect do
+        subject.create_ticket(
+          name: 'Ben',
+          email: 'ben@example.com',
+          message: 'Awesome!',
+          subject: 'Online booking test',
+          tags: %w(online_booking)
+        )
+      end.not_to raise_error
+    end
   end
 end


### PR DESCRIPTION
Stop errors from the ZenDesk API from being
reported to end-users. Error will be raised
to bugsnag and need to be manually handled.