### PR TITLE
Disallow '\' and '/' in email

### DIFF
--- a/app/forms/annuity_registration_form.rb
+++ b/app/forms/annuity_registration_form.rb
@@ -11,7 +11,7 @@ class AnnuityRegistrationForm
 
   validates :first_name, :last_name, :phone_number, :postcode,
             presence: true
-  validates :email, format: /.+@[^\s]+\.[^\s]+/
+  validates :email, format: %r{[^\s/\\]+@[^\s/\\]+\.[^\s/\\]+}
   validates :annuity_type,
             inclusion: { in: %w(in_own_name in_group_name dont_know) }
   validates :age,

--- a/spec/forms/annuities_registration_form_spec.rb
+++ b/spec/forms/annuities_registration_form_spec.rb
@@ -11,5 +11,6 @@ RSpec.describe AnnuityRegistrationForm do
     it { is_expected.to allow_value('text@test.com').for(:email) }
     it { is_expected.to allow_value('  text@test.com  ').for(:email) }
     it { is_expected.not_to allow_value('text@ test .com').for(:email) }
+    it { is_expected.not_to allow_value('text@n/a.com').for(:email) }
   end
 end


### PR DESCRIPTION
This is related to: https://app.bugsnag.com/hm-treasury-1/pension-guidance/errors/57d6a75fb3a75eb54c344639?event_id=57d6a75f4200b912001d9f75&pivot_tab=event

Validation email validation updated to avoid this error in the future.