### PR TITLE
Use smaller table style for guaranteed income facts

### DIFF
--- a/content/guaranteed_income.md
+++ b/content/guaranteed_income.md
@@ -39,6 +39,7 @@ If the insurance company you bought your annuity with goes bust the [Financial S
 
 There are lots of different types of annuity and you can shop around – you don’t have to buy one from your current pension provider.
 
+{:.table-font-xsmall}
 | Type | How it works
 -|-
 Single life | Paid just to you, either for life or for a fixed number of years.

--- a/content/when_you_die.md
+++ b/content/when_you_die.md
@@ -1,5 +1,5 @@
 ---
-description: What happens to your defined contribution pension when you die, including the tax your beneficiary pays. 
+description: What happens to your defined contribution pension when you die, including the tax your beneficiary pays.
 ---
 
 # Your pension when you die
@@ -45,6 +45,7 @@ You can choose who you want to receive any money left in your pot after you die.
 
 ## Tax your beneficiary pays
 
+{:.table-font-xsmall}
 Inheritance | Your age when you die | Tax they pay
 -|-|-|-
 Unused cash you took from your pot | Any age | Inheritance Tax based on the size of your estate


### PR DESCRIPTION
The default font size was increased in the govuk elements ugprade.
This change uses the smaller version of the table font style but
still remains accessible.