### PR TITLE
Fix npm build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
   - secure: MdrB+5oJX74bc7wSPut3vANmXUlvQN+pJyagxE+tuWWadKb5F4oAAXU2/BtrMqD9f/lxs2d+lh3AxKIWgN/ZUyxNxWZPk8958pqaTbc8eAcYLag4E2fqqyafkJZYW5Dny1lkoIzdmxn4FPHdp8WTfXsnOSmDa56fSj5DwBe4cF0=
 before_install:
 - echo -e "machine github.com\n  login $CI_USER_TOKEN" >> ~/.netrc
+- if [[ `npm -v` != 3* ]]; then npm i -g npm@3; fi
 before_script:
 - "[ -d .downloads ] || mkdir .downloads"
 - "(cd .downloads; [ -d prince-9.0r5-linux-amd64-static ] || curl -s http://www.princexml.com/download/prince-9.0r5-linux-amd64-static.tar.gz | tar xzf -)"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "jscs": "latest",
     "jshint": "latest",
     "imageoptim": "^0.4.1",
-    "phantomjs": ">= 1.9.16",
+    "phantomjs-prebuilt": ">= 2.1.12",
     "svgexport": "^0.2.8"
   },
   "scripts": {


### PR DESCRIPTION
Pension Guidance builds started failing, so this fixes it by forcing a newer version of npm

``
Done. Phantomjs binary available at /home/travis/build/guidance-guarantee-programme/pension_guidance/node_modules/phantomjs/lib/phantom/bin/phantomjs
npm ERR! EEXIST, open '/home/travis/.npm/05e49da9-is-npm-lodash-4-16-1-package-tgz.lock'
File exists: /home/travis/.npm/05e49da9-is-npm-lodash-4-16-1-package-tgz.lock
Move it away, and try again. 
npm ERR! System Linux 3.13.0-40-generic
npm ERR! command "/home/travis/.nvm/v0.10.36/bin/node" "/home/travis/.nvm/v0.10.36/bin/npm" "install"
npm ERR! cwd /home/travis/build/guidance-guarantee-programme/pension_guidance
npm ERR! node -v v0.10.36
npm ERR! npm -v 1.4.28
npm ERR! path /home/travis/.npm/05e49da9-is-npm-lodash-4-16-1-package-tgz.lock
npm ERR! code EEXIST
npm ERR! errno 47
npm ERR! not ok code 0
The command "npm install" failed and exited with 47 during .
Your build has been stopped.
``