### PR TITLE
Rely on gem-specified phantomjs binary

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "jscs": "latest",
     "jshint": "latest",
     "imageoptim": "^0.4.1",
-    "phantomjs-prebuilt": ">= 2.1.12",
     "svgexport": "^0.2.8"
   },
   "scripts": {


### PR DESCRIPTION
We should simply rely on the gem-specific phantomjs binary. Version
mismatches between the locked `1.9.8.0` and your local binary won't
cause an issue in development / test.