### PR TITLE
Use normal links in tax options table

### DIFF
--- a/app/assets/stylesheets/components/_options-table.scss
+++ b/app/assets/stylesheets/components/_options-table.scss
@@ -11,12 +11,6 @@
     width: 33%;
   }
 
-  a,
-  a:visited {
-    color: $color-black;
-    text-decoration: none;
-  }
-
   a:hover {
     text-decoration: underline;
   }


### PR DESCRIPTION
This change has been made in an attempt to reduce bounce rates
from this page.

We believe that adding the underline and normal link text color
will help prompt users to click through.