### PR TITLE
Reliably detect / install phantomjs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,6 @@ gem 'zendesk_api'
 group :development, :test do
   gem 'jasmine-jquery-rails'
   gem 'jasmine-rails'
-  gem 'phantomjs', '1.9.8.0'
   gem 'pry-rails'
   gem 'rspec-rails', '~> 3.0'
 end
@@ -59,6 +58,7 @@ group :test do
   gem 'launchy'
   gem 'pdf-inspector', require: 'pdf/inspector'
   gem 'poltergeist'
+  gem 'phantomjs-binaries'
   gem 'scss-lint', '~> 0.30'
   gem 'shoulda-matchers'
   gem 'site_prism'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -136,9 +136,9 @@ GEM
       activesupport (>= 4.0)
       loofah (>= 2.0)
       nokogiri (~> 1.6)
-    jasmine-core (2.3.4)
+    jasmine-core (2.5.2)
     jasmine-jquery-rails (2.0.3)
-    jasmine-rails (0.11.0)
+    jasmine-rails (0.14.1)
       jasmine-core (>= 1.3, < 3.0)
       phantomjs (>= 1.9)
       railties (>= 3.2.0)
@@ -155,14 +155,13 @@ GEM
     method_source (0.8.2)
     mime-types (2.99.2)
     mini_portile2 (2.1.0)
-    minitest (5.9.0)
+    minitest (5.9.1)
     multi_json (1.11.2)
     multi_test (0.1.2)
     multipart-post (2.0.0)
     newrelic_rpm (3.12.0.288)
-    nokogiri (1.6.8)
+    nokogiri (1.6.8.1)
       mini_portile2 (~> 2.1.0)
-      pkg-config (~> 1.1.7)
     parallel (1.9.0)
     parser (2.3.1.2)
       ast (~> 2.2)
@@ -174,10 +173,11 @@ GEM
       hashery (~> 2.0)
       ruby-rc4
       ttfunk
-    phantomjs (1.9.8.0)
+    phantomjs (2.1.1.0)
+    phantomjs-binaries (2.1.1.1)
+      sys-uname (= 0.9.0)
     phoner (1.0.1)
       activesupport
-    pkg-config (1.1.7)
     poltergeist (1.6.0)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
@@ -229,7 +229,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rainbow (2.1.0)
-    rake (11.2.2)
+    rake (11.3.0)
     redis (3.2.1)
     rgeo (0.3.20)
     rgeo-geojson (0.3.1)
@@ -295,11 +295,13 @@ GEM
       babel-source (>= 5.8.11)
       babel-transpiler
       sprockets (>= 3.0.0)
-    sprockets-rails (3.1.1)
+    sprockets-rails (3.2.0)
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     structured_warnings (0.2.0)
+    sys-uname (0.9.0)
+      ffi (>= 1.0.0)
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.5)
@@ -367,7 +369,7 @@ DEPENDENCIES
   nokogiri
   output-templates (~> 4.4.2)!
   pdf-inspector
-  phantomjs (= 1.9.8.0)
+  phantomjs-binaries
   phoner
   poltergeist
   postcodes_io
@@ -402,4 +404,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.12.5
+   1.13.1


### PR DESCRIPTION
This bumps us to the latest phantomjs via recent compatibility updates
made in `jasmine-rails`.