### PR TITLE
Capture `date_of_birth` when booking

### DIFF
--- a/app/controllers/booking_requests_controller.rb
+++ b/app/controllers/booking_requests_controller.rb
@@ -44,6 +44,8 @@ class BookingRequestsController < ApplicationController
   helper_method :location_id
 
   def booking_request_params # rubocop:disable Metrics/MethodLength
+    munge_date_params!
+
     params
       .fetch(:booking_request, {})
       .permit(
@@ -55,10 +57,22 @@ class BookingRequestsController < ApplicationController
         :email,
         :telephone_number,
         :memorable_word,
-        :appointment_type,
+        :date_of_birth,
         :accessibility_requirements,
         :opt_in,
         :dc_pot
       )
+  end
+
+  def munge_date_params!
+    booking_params = params[:booking_request]
+
+    if booking_params
+      year  = booking_params.delete('date_of_birth(1i)')
+      month = booking_params.delete('date_of_birth(2i)')
+      day   = booking_params.delete('date_of_birth(3i)')
+    end
+
+    booking_params[:date_of_birth] = "#{year}-#{month}-#{day}" if year && month && day
   end
 end

--- a/app/views/booking_requests/step_two.html.erb
+++ b/app/views/booking_requests/step_two.html.erb
@@ -75,7 +75,7 @@
             <span class="form-label-bold">
               Date of birth
             </span>
-            <span class="form-hint" id="dob-hint">For example, 31 3 1980</span>
+            <span class="form-hint" id="dob-hint">You must be aged 50 or over to book an appointment. For example, 31 3 1950</span>
           </legend>
           <div class="form-date">
             <div class="form-group form-group-day">

--- a/app/views/booking_requests/step_two.html.erb
+++ b/app/views/booking_requests/step_two.html.erb
@@ -69,32 +69,57 @@
         <%= f.text_field :memorable_word, class: 't-memorable-word form-control' %>
       </div>
 
-      <div class="form-group <%= 'error' if @booking_request.errors.include?(:appointment_type) %>">
-        <fieldset class="inline">
-          <legend>Your age</legend>
-
-          <% if @booking_request.errors.include?(:appointment_type) %>
-            <span class="error-message"><%= @booking_request.errors[:appointment_type].to_sentence %></span>
-          <% end %>
-
-          <%= f.label :appointment_type, value: 'under-50', class: 'block-label' do %>
-              <%= f.radio_button :appointment_type, 'under-50',
-                                 class: 't-appointment-type-1' %>
-              Under 50
-          <% end %>
-
-          <%= f.label :appointment_type, value: '50-54', class: 'block-label' do %>
-              <%= f.radio_button :appointment_type, '50-54',
-                                 class: 't-appointment-type-2' %>
-              50 to 54
-          <% end %>
-
-          <%= f.label :appointment_type, value: '55-plus', class: 'block-label' do %>
-            <%= f.radio_button :appointment_type, '55-plus',
-                                 class: 't-appointment-type-3' %>
-            55 or over
-          <% end %>
-        </fieldset>
+      <div class="form-group <%= 'error' if @booking_request.errors.include?(:date_of_birth) %>">
+        <label>
+          <span class="sr-only">Date of birth</span>
+          <%=
+            f.number_field(
+              'date_of_birth(3i)',
+              id: "#{f.object_name}_date_of_birth_3i",
+              use_label: false,
+              value: f.object.date_of_birth.try(:day),
+              placeholder: 'DD',
+              class: 'f-dob__input js-dob-day t-date-of-birth-day',
+              pattern: '[0-9]*',
+              min: 1,
+              max: 31,
+              'aria-describedby': 'dob-hint'
+            )
+          %>
+        </label>
+        <label>
+          <span class="sr-only">Date of birth</span>
+          <%=
+            f.number_field(
+              'date_of_birth(2i)',
+              id: "#{f.object_name}_date_of_birth_2i",
+              use_label: false,
+              value: f.object.date_of_birth.try(:month),
+              placeholder: 'MM',
+              class: 'form-dob__input js-dob-month t-date-of-birth-month',
+              pattern: '[0-9]*',
+              min: 1,
+              max: 12
+            )
+          %>
+        </label>
+        <label>
+          <span class="sr-only">Date of birth</span>
+          <%=
+            f.number_field(
+              'date_of_birth(1i)',
+              id: "#{f.object_name}_date_of_birth_1i",
+              use_label: false,
+              value: f.object.date_of_birth.try(:year),
+              placeholder: 'YYYY',
+              class: 'form-dob__input form-dob__input--year js-dob-year t-date-of-birth-year',
+              pattern: '[0-9]*',
+              min: 120.years.ago.year,
+              max: Date.today.year
+            )
+          %>
+        </label>
+        <span class="help-block" id="dob-hint">For example, 31 3 1950</span>
       </div>
 
       <div class="form-group <%= 'error' if @booking_request.errors.include?(:dc_pot) %>">

--- a/app/views/booking_requests/step_two.html.erb
+++ b/app/views/booking_requests/step_two.html.erb
@@ -70,56 +70,68 @@
       </div>
 
       <div class="form-group <%= 'error' if @booking_request.errors.include?(:date_of_birth) %>">
-        <label>
-          <span class="sr-only">Date of birth</span>
-          <%=
-            f.number_field(
-              'date_of_birth(3i)',
-              id: "#{f.object_name}_date_of_birth_3i",
-              use_label: false,
-              value: f.object.date_of_birth.try(:day),
-              placeholder: 'DD',
-              class: 'f-dob__input js-dob-day t-date-of-birth-day',
-              pattern: '[0-9]*',
-              min: 1,
-              max: 31,
-              'aria-describedby': 'dob-hint'
-            )
-          %>
-        </label>
-        <label>
-          <span class="sr-only">Date of birth</span>
-          <%=
-            f.number_field(
-              'date_of_birth(2i)',
-              id: "#{f.object_name}_date_of_birth_2i",
-              use_label: false,
-              value: f.object.date_of_birth.try(:month),
-              placeholder: 'MM',
-              class: 'form-dob__input js-dob-month t-date-of-birth-month',
-              pattern: '[0-9]*',
-              min: 1,
-              max: 12
-            )
-          %>
-        </label>
-        <label>
-          <span class="sr-only">Date of birth</span>
-          <%=
-            f.number_field(
-              'date_of_birth(1i)',
-              id: "#{f.object_name}_date_of_birth_1i",
-              use_label: false,
-              value: f.object.date_of_birth.try(:year),
-              placeholder: 'YYYY',
-              class: 'form-dob__input form-dob__input--year js-dob-year t-date-of-birth-year',
-              pattern: '[0-9]*',
-              min: 120.years.ago.year,
-              max: Date.today.year
-            )
-          %>
-        </label>
-        <span class="help-block" id="dob-hint">For example, 31 3 1950</span>
+        <fieldset>
+          <legend>
+            <span class="form-label-bold">
+              Date of birth
+            </span>
+            <span class="form-hint" id="dob-hint">For example, 31 3 1980</span>
+          </legend>
+          <div class="form-date">
+            <div class="form-group form-group-day">
+              <label class="form-label" for="<%= f.object_name %>_date_of_birth_3i">Day</label>
+              <%=
+                f.number_field(
+                  'date_of_birth(3i)',
+                  id: "#{f.object_name}_date_of_birth_3i",
+                  use_label: false,
+                  value: f.object.date_of_birth.try(:day),
+                  placeholder: 'DD',
+                  class: 'f-dob__input form-control js-dob-day t-date-of-birth-day',
+                  pattern: '[0-9]*',
+                  min: 1,
+                  max: 31,
+                  'aria-describedby': 'dob-hint'
+                )
+              %>
+            </div>
+            <div class="form-group form-group-month">
+              <label class="form-label" for="<%= f.object_name %>_date_of_birth_2i">Month</label>
+              <%=
+                f.number_field(
+                  'date_of_birth(2i)',
+                  id: "#{f.object_name}_date_of_birth_2i",
+                  use_label: false,
+                  value: f.object.date_of_birth.try(:month),
+                  placeholder: 'MM',
+                  class: 'form-dob__input form-control js-dob-month t-date-of-birth-month',
+                  pattern: '[0-9]*',
+                  min: 1,
+                  max: 12
+                )
+              %>
+            </div>
+            <div class="form-group form-group-year">
+              <label class="form-label" for="<%= f.object_name %>_date_of_birth_1i">Year</label>
+              <%=
+                f.number_field(
+                  'date_of_birth(1i)',
+                  id: "#{f.object_name}_date_of_birth_1i",
+                  use_label: false,
+                  value: f.object.date_of_birth.try(:year),
+                  placeholder: 'YYYY',
+                  class: 'form-dob__input form-control form-dob__input--year js-dob-year t-date-of-birth-year',
+                  pattern: '[0-9]*',
+                  min: 120.years.ago.year,
+                  max: Date.today.year
+                )
+              %>
+            </div>
+          </div>
+          <% if @booking_request.errors.include?(:date_of_birth) %>
+            <span class="error-message"><%= @booking_request.errors[:date_of_birth].to_sentence %></span>
+          <% end %>
+        </fieldset>
       </div>
 
       <div class="form-group <%= 'error' if @booking_request.errors.include?(:dc_pot) %>">

--- a/features/pages/booking_step_two.rb
+++ b/features/pages/booking_step_two.rb
@@ -6,6 +6,9 @@ module Pages
     element :first_name, '.t-first-name'
     element :last_name, '.t-last-name'
     element :email, '.t-email'
+    element :date_of_birth_day, '.t-date-of-birth-day'
+    element :date_of_birth_month, '.t-date-of-birth-month'
+    element :date_of_birth_year, '.t-date-of-birth-year'
     element :telephone_number, '.t-telephone-number'
     element :memorable_word, '.t-memorable-word'
     element :accessibility_requirements, '.t-accessibility-requirements'
@@ -14,10 +17,6 @@ module Pages
     element :dc_pot_yes, '.t-dc-pot-1'
     element :dc_pot_no, '.t-dc-pot-2'
     element :dc_pot_not_sure, '.t-dc-pot-3'
-
-    element :under_fifty, '.t-appointment-type-1'
-    element :fifty_to_fifty_four, '.t-appointment-type-2'
-    element :over_fifty, '.t-appointment-type-3'
 
     element :submit, '.t-submit'
     element :back, '.t-back'

--- a/features/step_definitions/customer_booking_request_steps.rb
+++ b/features/step_definitions/customer_booking_request_steps.rb
@@ -73,7 +73,10 @@ When(/^I provide my personal details$/) do
 end
 
 When(/^I pass the basic eligibility requirements$/) do
-  @step_two.fifty_to_fifty_four.set true
+  @step_two.date_of_birth_day.set '01'
+  @step_two.date_of_birth_month.set '01'
+  @step_two.date_of_birth_year.set '1950'
+
   @step_two.dc_pot_yes.set true
 end
 

--- a/lib/booking_requests/api_mapper.rb
+++ b/lib/booking_requests/api_mapper.rb
@@ -10,6 +10,7 @@ module BookingRequests
           phone: booking_request.telephone_number,
           memorable_word: booking_request.memorable_word,
           age_range: booking_request.appointment_type,
+          date_of_birth: booking_request.date_of_birth.iso8601,
           accessibility_requirements: booking_request.accessibility_requirements,
           marketing_opt_in: booking_request.opt_in,
           defined_contribution_pot: dc_pot_as_boolean(booking_request.dc_pot),

--- a/spec/forms/booking_request_form_spec.rb
+++ b/spec/forms/booking_request_form_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe BookingRequestForm do
         email: 'lucius@example.com',
         telephone_number: '0208 244 3987',
         memorable_word: 'meseeks',
-        appointment_type: '55-plus',
+        date_of_birth: '1950-01-01',
         accessibility_requirements: '0',
         opt_in: '1',
         dc_pot: 'yes'
@@ -49,8 +49,15 @@ RSpec.describe BookingRequestForm do
         expect(subject).not_to be_step_two_valid
       end
 
+      it 'requires a valid DOB' do
+        subject.date_of_birth = '--01'
+        expect(subject).not_to be_step_two_valid
+      end
+
       it 'requires appointment_type to be within permitted values' do
-        subject.appointment_type = 'under-50'
+        subject.date_of_birth = '2010-01-01'
+
+        expect(subject.appointment_type).to eq('under-50')
         expect(subject).not_to be_step_two_valid
         expect(subject).not_to be_eligible
       end

--- a/spec/lib/booking_requests/api_mapper_spec.rb
+++ b/spec/lib/booking_requests/api_mapper_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe BookingRequests::ApiMapper do
       telephone_number: '0208 244 3987',
       memorable_word: 'meseeks',
       appointment_type: '55-plus',
+      date_of_birth: '1950-01-01',
       accessibility_requirements: false,
       opt_in: false,
       dc_pot: 'yes'
@@ -34,6 +35,7 @@ RSpec.describe BookingRequests::ApiMapper do
           phone: '0208 244 3987',
           memorable_word: 'meseeks',
           age_range: '55-plus',
+          date_of_birth: '1950-01-01',
           accessibility_requirements: false,
           marketing_opt_in: false,
           defined_contribution_pot: true,

--- a/spec/requests/complete_booking_request_spec.rb
+++ b/spec/requests/complete_booking_request_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'POST /locations/:id/booking-request/complete', type: :request do
           email: 'lucius@example.com',
           telephone_number: '0208 244 3987',
           memorable_word: 'meseeks',
-          appointment_type: '55-plus',
+          date_of_birth: '1940-01-01',
           accessibility_requirements: '0',
           opt_in: '1',
           dc_pot: 'yes'


### PR DESCRIPTION
Makes the `date_of_birth` mandatory. The appointment type is now
inferred from the given date of birth. Both attributes are still passed
to the bookings API to maintain compatibility.

The validation works as you'd expect. When an invalid date (missing a
component) is given this does not trigger the eligibility check. When a
valid (as-in all components of the date are provided) the eligibility
check is triggered, based off the inferred appointment type.

The form looks pretty bad at the moment as I lifted it almost verbatim from
tap. @Guntrisoft - work your magic?