### PR TITLE
Disable multiple submissions

### DIFF
--- a/app/views/booking_requests/step_two.html.erb
+++ b/app/views/booking_requests/step_two.html.erb
@@ -181,7 +181,7 @@
       </div>
 
       <div class="form-group">
-        <%= f.submit 'Submit booking request', class: 'button t-submit' %>
+        <%= f.submit 'Submit booking request', class: 'button t-submit', data: { disable_with: 'Please wait...' } %>
       </div>
 
     <% end %>


### PR DESCRIPTION
Some users are submitting this form twice and creating duplicate
booking requests.