### PR TITLE
Bump the quality of static maps

### DIFF
--- a/app/views/locations/index.html.erb
+++ b/app/views/locations/index.html.erb
@@ -38,6 +38,7 @@
           <a href="https://maps.google.com/maps?q=<%= location.address_flattened %>" target="_blank">
             <img
               height="300"
+              alt="map showing the location of <%= location.name %> (link opens external website in new window)"
               style="border:0; position: relative;"
               src="https://maps.googleapis.com/maps/api/staticmap?markers=<%= location.address_flattened %>&size=300x300&scale=2&zoom=16&key=AIzaSyB_H8kX3vHhOJMYIoBu3_SMnxXf-NYY3Y0" />
           </a>

--- a/app/views/locations/index.html.erb
+++ b/app/views/locations/index.html.erb
@@ -39,7 +39,7 @@
             <img
               height="300"
               style="border:0; position: relative;"
-              src="https://maps.googleapis.com/maps/api/staticmap?markers=<%= location.address_flattened %>&size=300x300&zoom=16&key=AIzaSyB_H8kX3vHhOJMYIoBu3_SMnxXf-NYY3Y0" />
+              src="https://maps.googleapis.com/maps/api/staticmap?markers=<%= location.address_flattened %>&size=300x300&scale=2&zoom=16&key=AIzaSyB_H8kX3vHhOJMYIoBu3_SMnxXf-NYY3Y0" />
           </a>
         </div>
       </div>

--- a/app/views/locations/show.html.erb
+++ b/app/views/locations/show.html.erb
@@ -66,6 +66,7 @@
     <a href="https://maps.google.com/maps?q=<%= @location.address %>" target="_blank">
       <img
         height="450"
+        alt="map showing the location of <%= @location.name %> (link opens external website in new window)"
         style="border:0; position: relative; width:100%;"
         src="https://maps.googleapis.com/maps/api/staticmap?markers=<%= @location.address %>&size=600x450&zoom=16&scale=2&key=AIzaSyB_H8kX3vHhOJMYIoBu3_SMnxXf-NYY3Y0" />
     </a>

--- a/app/views/locations/show.html.erb
+++ b/app/views/locations/show.html.erb
@@ -67,7 +67,7 @@
       <img
         height="450"
         style="border:0; position: relative; width:100%;"
-        src="https://maps.googleapis.com/maps/api/staticmap?markers=<%= @location.address %>&size=600x450&zoom=16&key=AIzaSyB_H8kX3vHhOJMYIoBu3_SMnxXf-NYY3Y0" />
+        src="https://maps.googleapis.com/maps/api/staticmap?markers=<%= @location.address %>&size=600x450&zoom=16&scale=2&key=AIzaSyB_H8kX3vHhOJMYIoBu3_SMnxXf-NYY3Y0" />
     </a>
   </div>
 </div>


### PR DESCRIPTION
Prior to this change they were a little fuzzy as they were being scaled
as `1` instead of `2` which is our maximum permitted quality on the
free plan.

### Before

<img width="379" alt="screen shot 2016-11-16 at 13 16 04" src="https://cloud.githubusercontent.com/assets/41963/20345315/50e3d3be-abff-11e6-90c3-53ea13fcd6e0.png">

### After

<img width="370" alt="screen shot 2016-11-16 at 13 15 18" src="https://cloud.githubusercontent.com/assets/41963/20345322/5796e796-abff-11e6-98cd-7a4c12ab7c6e.png">
