### PR TITLE
Improve static map images 

### DIFF
--- a/app/decorators/location_decorator.rb
+++ b/app/decorators/location_decorator.rb
@@ -6,6 +6,10 @@ class LocationDecorator < SimpleDelegator
     self.nearest_locations = nearest_locations
   end
 
+  def address_flattened
+    address.gsub("\n", ', ').squish
+  end
+
   def phone
     Phoner::Phone.parse(twilio_number)&.format('%A %n')
   end

--- a/app/views/locations/index.html.erb
+++ b/app/views/locations/index.html.erb
@@ -40,7 +40,7 @@
               height="300"
               alt="map showing the location of <%= location.name %> (link opens external website in new window)"
               style="border:0; position: relative;"
-              src="https://maps.googleapis.com/maps/api/staticmap?markers=<%= location.address_flattened %>&center=<%= location.address_flattened %>&size=300x300&scale=2&zoom=16&key=AIzaSyB_H8kX3vHhOJMYIoBu3_SMnxXf-NYY3Y0" />
+              src="https://maps.googleapis.com/maps/api/staticmap?markers=<%= location.address_flattened %>&center=<%= location.address_flattened %>&size=300x300&scale=2&zoom=15&key=AIzaSyB_H8kX3vHhOJMYIoBu3_SMnxXf-NYY3Y0" />
           </a>
         </div>
       </div>

--- a/app/views/locations/index.html.erb
+++ b/app/views/locations/index.html.erb
@@ -40,7 +40,7 @@
               height="300"
               alt="map showing the location of <%= location.name %> (link opens external website in new window)"
               style="border:0; position: relative;"
-              src="https://maps.googleapis.com/maps/api/staticmap?markers=<%= location.address_flattened %>&size=300x300&scale=2&zoom=16&key=AIzaSyB_H8kX3vHhOJMYIoBu3_SMnxXf-NYY3Y0" />
+              src="https://maps.googleapis.com/maps/api/staticmap?markers=<%= location.address_flattened %>&center=<%= location.address_flattened %>&size=300x300&scale=2&zoom=16&key=AIzaSyB_H8kX3vHhOJMYIoBu3_SMnxXf-NYY3Y0" />
           </a>
         </div>
       </div>

--- a/app/views/locations/index.html.erb
+++ b/app/views/locations/index.html.erb
@@ -40,7 +40,7 @@
               height="300"
               alt="map showing the location of <%= location.name %> (link opens external website in new window)"
               style="border:0; position: relative;"
-              src="https://maps.googleapis.com/maps/api/staticmap?markers=<%= location.address_flattened %>&center=<%= location.address_flattened %>&size=300x300&scale=2&zoom=15&key=AIzaSyB_H8kX3vHhOJMYIoBu3_SMnxXf-NYY3Y0" />
+              src="https://maps.googleapis.com/maps/api/staticmap?markers=<%= location.address_flattened %>&center=<%= location.address_flattened %>&size=300x300&scale=2&zoom=15&key=<%= ENV['GOOGLE_MAP_API_KEY'] %>" />
           </a>
         </div>
       </div>

--- a/app/views/locations/show.html.erb
+++ b/app/views/locations/show.html.erb
@@ -68,7 +68,7 @@
         height="450"
         alt="map showing the location of <%= @location.name %> (link opens external website in new window)"
         style="border:0; position: relative; width:100%;"
-        src="https://maps.googleapis.com/maps/api/staticmap?markers=<%= @location.address_flattened %>&center=<%= @location.address_flattened %>&size=440x330&zoom=15&scale=2&key=AIzaSyB_H8kX3vHhOJMYIoBu3_SMnxXf-NYY3Y0" />
+        src="https://maps.googleapis.com/maps/api/staticmap?markers=<%= @location.address_flattened %>&center=<%= @location.address_flattened %>&size=440x330&zoom=15&scale=2&key=<%= ENV['GOOGLE_MAP_API_KEY'] %>" />
     </a>
   </div>
 </div>

--- a/app/views/locations/show.html.erb
+++ b/app/views/locations/show.html.erb
@@ -68,7 +68,7 @@
         height="450"
         alt="map showing the location of <%= @location.name %> (link opens external website in new window)"
         style="border:0; position: relative; width:100%;"
-        src="https://maps.googleapis.com/maps/api/staticmap?markers=<%= @location.address_flattened %>&size=600x450&zoom=16&scale=2&key=AIzaSyB_H8kX3vHhOJMYIoBu3_SMnxXf-NYY3Y0" />
+        src="https://maps.googleapis.com/maps/api/staticmap?markers=<%= @location.address_flattened %>&center=<%= @location.address_flattened %>&size=600x450&zoom=16&scale=2&key=AIzaSyB_H8kX3vHhOJMYIoBu3_SMnxXf-NYY3Y0" />
     </a>
   </div>
 </div>

--- a/app/views/locations/show.html.erb
+++ b/app/views/locations/show.html.erb
@@ -68,7 +68,7 @@
         height="450"
         alt="map showing the location of <%= @location.name %> (link opens external website in new window)"
         style="border:0; position: relative; width:100%;"
-        src="https://maps.googleapis.com/maps/api/staticmap?markers=<%= @location.address %>&size=600x450&zoom=16&scale=2&key=AIzaSyB_H8kX3vHhOJMYIoBu3_SMnxXf-NYY3Y0" />
+        src="https://maps.googleapis.com/maps/api/staticmap?markers=<%= @location.address_flattened %>&size=600x450&zoom=16&scale=2&key=AIzaSyB_H8kX3vHhOJMYIoBu3_SMnxXf-NYY3Y0" />
     </a>
   </div>
 </div>

--- a/app/views/locations/show.html.erb
+++ b/app/views/locations/show.html.erb
@@ -68,7 +68,7 @@
         height="450"
         alt="map showing the location of <%= @location.name %> (link opens external website in new window)"
         style="border:0; position: relative; width:100%;"
-        src="https://maps.googleapis.com/maps/api/staticmap?markers=<%= @location.address_flattened %>&center=<%= @location.address_flattened %>&size=600x450&zoom=16&scale=2&key=AIzaSyB_H8kX3vHhOJMYIoBu3_SMnxXf-NYY3Y0" />
+        src="https://maps.googleapis.com/maps/api/staticmap?markers=<%= @location.address_flattened %>&center=<%= @location.address_flattened %>&size=440x330&zoom=15&scale=2&key=AIzaSyB_H8kX3vHhOJMYIoBu3_SMnxXf-NYY3Y0" />
     </a>
   </div>
 </div>


### PR DESCRIPTION
* Fix the address used to generate a map on the location page
* Fix centring bug - see before/after URL below
* Zoom out images to allow better viewport of area
* Extract API key to a variable

**Map URL**
**Without centring:**
https://maps.googleapis.com/maps/api/staticmap?markers=8%20Market%20Place,%20Southwark%20Park%20Road,%20Southwark,%20London,%20SE16%203UQ&size=300x300&scale=2&zoom=15&key=AIzaSyB_H8kX3vHhOJMYIoBu3_SMnxXf-NYY3Y0

**With centring:**
https://maps.googleapis.com/maps/api/staticmap?markers=8%20Market%20Place,%20Southwark%20Park%20Road,%20Southwark,%20London,%20SE16%203UQ&center=8%20Market%20Place,%20Southwark%20Park%20Road,%20Southwark,%20London,%20SE16%203UQ&size=300x300&scale=2&zoom=15&key=AIzaSyB_H8kX3vHhOJMYIoBu3_SMnxXf-NYY3Y0
