### PR TITLE
Escape the address before using in URL

### DIFF
--- a/app/decorators/location_decorator.rb
+++ b/app/decorators/location_decorator.rb
@@ -6,8 +6,8 @@ class LocationDecorator < SimpleDelegator
     self.nearest_locations = nearest_locations
   end
 
-  def address_flattened
-    address.gsub("\n", ', ').squish
+  def address_encoded
+    @address_encoded ||= ERB::Util.url_encode(address.gsub("\n", ', ').squish)
   end
 
   def phone

--- a/app/decorators/location_search_result_decorator.rb
+++ b/app/decorators/location_search_result_decorator.rb
@@ -1,6 +1,6 @@
 class LocationSearchResultDecorator < SimpleDelegator
-  def address_flattened
-    address.gsub("\n", ', ').squish
+  def address_encoded
+    @address_encoded ||= ERB::Util.url_encode(address.gsub("\n", ', ').squish)
   end
 
   def distance

--- a/app/views/locations/index.html.erb
+++ b/app/views/locations/index.html.erb
@@ -35,12 +35,12 @@
         </div>
 
         <div class="l-column-third">
-          <a href="https://maps.google.com/maps?q=<%= location.address_flattened %>" target="_blank">
+          <a href="https://maps.google.com/maps?q=<%= location.address_encoded %>" target="_blank">
             <img
               height="300"
               alt="map showing the location of <%= location.name %> (link opens external website in new window)"
               style="border:0; position: relative;"
-              src="https://maps.googleapis.com/maps/api/staticmap?markers=<%= location.address_flattened %>&center=<%= location.address_flattened %>&size=300x300&scale=2&zoom=15&key=<%= ENV['GOOGLE_MAP_API_KEY'] %>" />
+              src="https://maps.googleapis.com/maps/api/staticmap?markers=<%= location.address_encoded %>&center=<%= location.address_encoded %>&size=300x300&scale=2&zoom=15&key=<%= ENV['GOOGLE_MAP_API_KEY'] %>" />
           </a>
         </div>
       </div>

--- a/app/views/locations/show.html.erb
+++ b/app/views/locations/show.html.erb
@@ -68,7 +68,7 @@
         height="450"
         alt="map showing the location of <%= @location.name %> (link opens external website in new window)"
         style="border:0; position: relative; width:100%;"
-        src="https://maps.googleapis.com/maps/api/staticmap?markers=<%= @location.address_flattened %>&center=<%= @location.address_flattened %>&size=440x330&zoom=15&scale=2&key=<%= ENV['GOOGLE_MAP_API_KEY'] %>" />
+        src="https://maps.googleapis.com/maps/api/staticmap?markers=<%= @location.address_encoded %>&center=<%= @location.address_encoded %>&size=440x330&zoom=15&scale=2&key=<%= ENV['GOOGLE_MAP_API_KEY'] %>" />
     </a>
   </div>
 </div>

--- a/spec/decorators/location_search_result_decorator_spec.rb
+++ b/spec/decorators/location_search_result_decorator_spec.rb
@@ -5,6 +5,11 @@ RSpec.describe LocationSearchResultDecorator do
 
   subject(:decorator) { described_class.new(search_result) }
 
-  specify { expect(decorator.address_flattened).to eq('Street, Town, Postcode') }
+  specify { expect(decorator.address_encoded).to eq('Street%2C%20Town%2C%20Postcode') }
   specify { expect(decorator.distance).to eq('1.05') }
+
+  context 'when address contains special characters' do
+    let(:address) { "Road & Street\nTown\nPostcode" }
+    specify { expect(decorator.address_encoded).to eq('Road%20%26%20Street%2C%20Town%2C%20Postcode') }
+  end
 end


### PR DESCRIPTION
This fixes a bug when the address contains '&' 
resulting in an error from Google maps