### PR TITLE
Upgrade govuk_template to version 0.19.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,7 +123,7 @@ GEM
     govuk_frontend_toolkit (4.16.1)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_template (0.18.0)
+    govuk_template (0.19.1)
       rails (>= 3.1)
     hashery (2.1.1)
     hashie (3.4.4)
@@ -153,9 +153,9 @@ GEM
     mail (2.6.4)
       mime-types (>= 1.16, < 4)
     method_source (0.8.2)
-    mime-types (2.99.2)
+    mime-types (2.99.3)
     mini_portile2 (2.1.0)
-    minitest (5.9.1)
+    minitest (5.10.0)
     multi_json (1.11.2)
     multi_test (0.1.2)
     multipart-post (2.0.0)
@@ -194,7 +194,7 @@ GEM
     pry-rails (0.3.4)
       pry (>= 0.9.10)
     puma (3.4.0)
-    rack (1.6.4)
+    rack (1.6.5)
     rack-contrib (1.2.0)
       rack (>= 0.9.1)
     rack-test (0.6.3)
@@ -302,7 +302,7 @@ GEM
     structured_warnings (0.2.0)
     sys-uname (0.9.0)
       ffi (>= 1.0.0)
-    thor (0.19.1)
+    thor (0.19.4)
     thread_safe (0.3.5)
     tilt (2.0.5)
     timecop (0.7.4)
@@ -404,4 +404,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.13.3
+   1.13.6

--- a/app/assets/stylesheets/components/govspeak/_form-download.scss
+++ b/app/assets/stylesheets/components/govspeak/_form-download.scss
@@ -17,8 +17,4 @@
       background-size: 25px 25px;
     }
   }
-
-  a[rel="external"]:after {
-    content: none;
-  }
 }

--- a/app/assets/stylesheets/components/govspeak/_info-notice.scss
+++ b/app/assets/stylesheets/components/govspeak/_info-notice.scss
@@ -11,10 +11,6 @@
     margin: .75em 0;
     padding-right: 1em;
   }
-
-  a[rel="external"] {
-    display: inline;
-  }
 }
 
 

--- a/app/assets/stylesheets/layout/_common_page_structure.scss
+++ b/app/assets/stylesheets/layout/_common_page_structure.scss
@@ -14,18 +14,3 @@
   @extend %site-width-container;
   @extend %contain-floats;
 }
-
-.l-footer-meta {
-  a[rel="external"] {
-    &:after {
-      content: "\A0\A0\A0\A0\A0";
-      background-position: right 3px;
-    }
-
-    &:hover {
-      &:after {
-        background-position: right -385px;
-      }
-    }
-  }
-}


### PR DESCRIPTION
The most visible changes from this upgrade are a slight modification to the GOVUK logo, removing of the external link icon (see accessibility link in footer), and a fix for relative URLs in printing pension wise pages.

Full list of changes:

Remove generated gov.uk from relative print links
https://github.com/alphagov/govuk_template/pull/234

Fix extended footer on certain pages
https://github.com/alphagov/govuk_template/pull/177

Degrade gracefully when external JS can’t be loaded
https://github.com/alphagov/govuk_template/pull/248

Add docs for adding tabindex="-1" to fix the skiplink
https://github.com/alphagov/govuk_template/pull/250

Logo fixes
https://github.com/alphagov/govuk_template/pull/237

Remove external links styles
https://github.com/alphagov/govuk_template/pull/231

Don’t include both html5shiv and html5shiv-printshiv
https://github.com/alphagov/govuk_template/pull/254

Update govuk_frontend_toolkit to 5.0.0
https://github.com/alphagov/govuk_template/pull/256

Fixed scala compilation failure for play template
https://github.com/alphagov/govuk_template/pull/261