### PR TITLE
Remove fieldset which does not have a legend

### DIFF
--- a/app/views/appointment_summaries/new.html.erb
+++ b/app/views/appointment_summaries/new.html.erb
@@ -73,9 +73,9 @@
     <% end %>
   </fieldset>
 
-  <fieldset class="form-group">
+  <div class="form-group">
     <%= f.submit 'View summary', class: 'button t-appointment-summary-submit' %>
-  </fieldset>
+  </div>
 <% end %>
 
 <% content_for :body_end do %>


### PR DESCRIPTION
<img width="753" alt="screen shot 2016-12-06 at 10 47 58" src="https://cloud.githubusercontent.com/assets/6049076/20922833/78f6303e-bba1-11e6-8500-87da7fbac018.png">


- fieldsets should have a legend, but there is no need
  for a legend at this part of the form so turn it
  into a DIV so that it keeps the form-group class