### PR TITLE
Improved accessibility of mobile version of the site navigation

### DIFF
--- a/app/assets/javascripts/mobile-nav-toggler.js
+++ b/app/assets/javascripts/mobile-nav-toggler.js
@@ -8,7 +8,16 @@
 
       $trigger.click(function(e) {
         e.preventDefault();
-        $target.toggleClass('active');
+
+        if ($target.hasClass('active')) {
+          $target.removeClass('active');
+          $target.attr('aria-hidden', true);
+          $trigger.attr('aria-expanded', false);
+        } else {
+          $target.addClass('active');
+          $target.attr('aria-hidden', false);
+          $trigger.attr('aria-expanded', true);
+        }
       });
     }
   };

--- a/app/assets/stylesheets/components/_nav.scss
+++ b/app/assets/stylesheets/components/_nav.scss
@@ -163,25 +163,28 @@
   }
 
 
-  .nav__mobile-link:link,
-  .nav__mobile-link:visited {
+  .nav__mobile-toggler {
+    background: none;
+    border: 0;
+    color: $navigation-mobile-nav;
+    cursor: pointer;
     font-size: 24px;
     font-weight: 700;
+    line-height: 1.25em;
+    padding: 0 0 0 1.25em;
     position: relative;
-    padding-left: 1.25em;
-    color: $navigation-mobile-nav;
     text-decoration: none;
 
     &:before {
-      content: "";
-      position: absolute;
-      left: 0;
-      top: .25em;
-      width: 1em;
-      height: .15em;
       background: $navigation-mobile-nav;
       box-shadow: 0 .25em 0 0 $navigation-mobile-nav,
                   0 .5em 0 0 $navigation-mobile-nav;
+      content: "";
+      height: .15em;
+      left: 0;
+      position: absolute;
+      top: .22em;
+      width: 1em;
     }
   }
 }

--- a/app/views/components/_nav.html.erb
+++ b/app/views/components/_nav.html.erb
@@ -1,9 +1,9 @@
 <div class="nav">
   <div class="nav__mobile">
-    <a href="#" class="nav__mobile-link js-nav-toggler">Menu</a>
+    <button class="nav__mobile-toggler js-nav-toggler" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
   </div>
 
-  <ul class="nav__list js-nav">
+  <ul class="nav__list js-nav" id="mobile-menu" aria-hidden="true">
     <%= navigation_topics(navigation.topics) %>
   </ul>
 </div>


### PR DESCRIPTION
<img width="242" alt="screen shot 2016-12-06 at 13 00 01" src="https://cloud.githubusercontent.com/assets/6049076/20926372/eb947832-bbb3-11e6-92b6-ecc52b9e689d.png">

- Altered menu link to be a button which better describes
  that it's going to do something interactive when clicked on
- Added aria-expanded=true/false to read out to screen reader
  users that the item that it controls is collapsed, and reads
  out that it's expanded when clicked on
- Added aria-hidden=true on the menu items by default, and then
  turned this to true when button is clicked on, so that menu
  items are only read out when the menu is expanded
- Added aria-controls for screenreaders which support it, so
  a user can jump directly to the menu from the button