### PR TITLE
Simplify the guide implementation

### DIFF
--- a/app/decorators/guide_decorator.rb
+++ b/app/decorators/guide_decorator.rb
@@ -1,20 +1,5 @@
-class GuideDecorator
-  delegate(
-    :id,
-    :slug,
-    :concise_label,
-    :description,
-    :option?,
-    :related_to_journey?,
-    :related_to_appointments?,
-    :related_to_booking?,
-    :==,
-    to: :guide
-  )
-
-  def initialize(guide)
-    @guide = guide
-  end
+class GuideDecorator < SimpleDelegator
+  delegate :concise_label, :description, to: :metadata
 
   def url
     "/#{slug}"
@@ -25,7 +10,7 @@ class GuideDecorator
   end
 
   def label
-    guide.label.presence || title
+    metadata.label.presence || title
   end
 
   def content
@@ -51,7 +36,9 @@ class GuideDecorator
 
   private
 
-  attr_reader :guide
+  def guide
+    __getobj__
+  end
 
   def content_document
     @content_document ||= Nokogiri::HTML(content)

--- a/app/models/guide.rb
+++ b/app/models/guide.rb
@@ -1,25 +1,11 @@
 class Guide
-  extend Forwardable
-
-  Metadata = Class.new do
-    attr_accessor :label, :concise_label, :description, :tags
-
-    def initialize(label: nil, concise_label: nil, description: nil, tags: nil)
-      self.label = label
-      self.concise_label = concise_label
-      self.description = description
-      self.tags = tags
-    end
-  end
-
-  attr_reader :id, :content, :content_type
-  def_delegators :@metadata, :label, :concise_label, :description, :tags
+  attr_reader :id, :content, :content_type, :metadata
 
   def initialize(id, content: '', content_type: nil, metadata: nil)
     @id = id
     @content = content
     @content_type = content_type
-    @metadata = metadata
+    @metadata = OpenStruct.new(metadata)
   end
 
   def ==(other)
@@ -49,6 +35,6 @@ class Guide
   private
 
   def tagged_with?(tag)
-    Array(tags).include?(tag)
+    Array(metadata.tags).include?(tag)
   end
 end

--- a/app/repositories/guide_repository.rb
+++ b/app/repositories/guide_repository.rb
@@ -33,15 +33,11 @@ class GuideRepository
   def read_guide(id, path)
     content_type = file_content_type(path)
     source = FrontMatterParser.new(File.read(path))
-    metadata = Guide::Metadata.new(label: source.front_matter['label'],
-                                   concise_label: source.front_matter['concise_label'],
-                                   description: source.front_matter['description'],
-                                   tags: source.front_matter['tags'])
 
     Guide.new(id,
               content: source.content,
               content_type: content_type,
-              metadata: metadata)
+              metadata: source.front_matter)
   end
 
   def file_content_type(path)

--- a/lib/front_matter_parser.rb
+++ b/lib/front_matter_parser.rb
@@ -14,6 +14,6 @@ class FrontMatterParser
   def parse!
     match_result = source.match(/(?<front_matter>^---$.*?^---$\n)?(?<content>.*)/m)
     self.content = match_result[:content]
-    self.front_matter = YAML.load(match_result[:front_matter]) rescue {}
+    self.front_matter = match_result[:front_matter].present? ? YAML.load(match_result[:front_matter]) : {}
   end
 end

--- a/spec/decorators/guide_decorator_spec.rb
+++ b/spec/decorators/guide_decorator_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe GuideDecorator, type: :decorator do
   end
 
   describe '#label' do
-    let(:guide) { double(label: label, title: title) }
+    let(:guide) { double(metadata: metadata, title: title) }
     let(:title) { double }
 
     subject { decorator.label }
@@ -56,6 +56,7 @@ RSpec.describe GuideDecorator, type: :decorator do
 
     context 'when the guide specifies a label' do
       let(:label) { 'Document label' }
+      let(:metadata) { double(label: label) }
 
       it 'returns the label' do
         is_expected.to eq(label)
@@ -63,7 +64,7 @@ RSpec.describe GuideDecorator, type: :decorator do
     end
 
     context 'when the guide specifies a blank label' do
-      let(:label) { '' }
+      let(:metadata) { double(label: '') }
 
       it 'returns the title' do
         is_expected.to eq(title)
@@ -71,7 +72,7 @@ RSpec.describe GuideDecorator, type: :decorator do
     end
 
     context 'when the guide specifies no label' do
-      let(:label) { nil }
+      let(:metadata) { double(label: nil) }
 
       it 'returns the title' do
         is_expected.to eq(title)

--- a/spec/decorators/shared_examples_for_a_guide_decorator.rb
+++ b/spec/decorators/shared_examples_for_a_guide_decorator.rb
@@ -4,7 +4,8 @@ RSpec.shared_examples 'a guide decorator' do
     let(:slug) { '/foo' }
     let(:description) { 'The test description' }
 
-    let(:decorator) { described_class.new(instance_spy(Guide, id: id, slug: slug, description: description)) }
+    let(:metadata) { double(description: description) }
+    let(:decorator) { described_class.new(instance_spy(Guide, id: id, slug: slug, metadata: metadata)) }
 
     describe '#id' do
       subject { decorator.id }

--- a/spec/models/guide_spec.rb
+++ b/spec/models/guide_spec.rb
@@ -8,20 +8,30 @@ RSpec.describe Guide, type: :model do
   let(:tags) { [] }
 
   let(:metadata) do
-    Guide::Metadata.new(label: label,
-                        concise_label: concise_label,
-                        description: description,
-                        tags: tags)
+    {
+      label: label,
+      concise_label: concise_label,
+      description: description,
+      tags: tags
+    }
   end
 
   subject(:guide) do
     described_class.new(id, content: content, content_type: content_type, metadata: metadata)
   end
 
-  %i(id content content_type label concise_label description tags).each do |attr|
+  %i(id content content_type).each do |attr|
     describe "##{attr}" do
       it "returns the initialised #{attr}" do
         expect(guide.public_send(attr)).to eq(public_send(attr))
+      end
+    end
+  end
+
+  %i(label concise_label description tags).each do |attr|
+    describe "##{attr}" do
+      it "returns the initialised #{attr}" do
+        expect(guide.metadata.public_send(attr)).to eq(public_send(attr))
       end
     end
   end

--- a/spec/repositories/guide_repository_spec.rb
+++ b/spec/repositories/guide_repository_spec.rb
@@ -22,11 +22,11 @@ RSpec.describe GuideRepository do
       end
 
       specify 'with the correct label' do
-        expect(find.label).to eq(expected_label)
+        expect(find.metadata.label).to eq(expected_label)
       end
 
       specify 'with the correct description' do
-        expect(find.description).to eq(expected_description)
+        expect(find.metadata.description).to eq(expected_description)
       end
 
       specify 'with the correct content type' do

--- a/spec/services/create_category_navigation_spec.rb
+++ b/spec/services/create_category_navigation_spec.rb
@@ -4,11 +4,11 @@ RSpec.describe CreateCategoryNavigation do
   let(:foo_category) { instance_double(Category, id: double, title: 'Foo category') }
   let(:bar_category) { instance_double(Category, id: double, title: 'Bar category') }
 
-  let(:foo_guide) { instance_double(Guide, content_type: :govspeak, id: 'foo', slug: 'foo', label: 'Foo') }
-  let(:bar_guide) { instance_double(Guide, content_type: :govspeak, id: 'bar', slug: 'bar', label: 'Bar') }
-  let(:baz_guide) { instance_double(Guide, content_type: :govspeak, id: 'baz', slug: 'baz', label: 'Baz') }
-  let(:qux_guide) { instance_double(Guide, content_type: :govspeak, id: 'qux', slug: 'qux', label: 'Qux') }
-  let(:norf_guide) { instance_double(Guide, content_type: :govspeak, id: 'norf', slug: 'norf', label: 'Norf') }
+  let(:foo_guide) { instance_double(Guide, content_type: :govspeak, id: 'foo', slug: 'foo') }
+  let(:bar_guide) { instance_double(Guide, content_type: :govspeak, id: 'bar', slug: 'bar') }
+  let(:baz_guide) { instance_double(Guide, content_type: :govspeak, id: 'baz', slug: 'baz') }
+  let(:qux_guide) { instance_double(Guide, content_type: :govspeak, id: 'qux', slug: 'qux') }
+  let(:norf_guide) { instance_double(Guide, content_type: :govspeak, id: 'norf', slug: 'norf') }
 
   let(:category_id) { 'foo' }
 

--- a/spec/view_models/navigation_spec.rb
+++ b/spec/view_models/navigation_spec.rb
@@ -4,25 +4,11 @@ RSpec.describe Navigation do
   let(:foo_category) { instance_double(Category, id: double, slug: double, title: 'Foo category') }
   let(:bar_category) { instance_double(Category, id: double, slug: double, title: 'Bar category') }
 
-  let(:foo_guide) do
-    instance_double(Guide, content_type: :govspeak, id: 'foo', slug: 'foo', label: 'Foo', option?: double)
-  end
-
-  let(:bar_guide) do
-    instance_double(Guide, content_type: :govspeak, id: 'bar', slug: 'bar', label: 'Bar', option?: double)
-  end
-
-  let(:baz_guide) do
-    instance_double(Guide, content_type: :govspeak, id: 'baz', slug: 'baz', label: 'Baz', option?: double)
-  end
-
-  let(:qux_guide) do
-    instance_double(Guide, content_type: :govspeak, id: 'qux', slug: 'qux', label: 'Qux', option?: double)
-  end
-
-  let(:norf_guide) do
-    instance_double(Guide, content_type: :govspeak, id: 'norf', slug: 'norf', label: 'Norf', option?: double)
-  end
+  let(:foo_guide) { guide_for('foo') }
+  let(:bar_guide) { guide_for('bar') }
+  let(:baz_guide) { guide_for('baz') }
+  let(:qux_guide) { guide_for('qux') }
+  let(:norf_guide) { guide_for('norf') }
 
   let(:taxonomy) do
     Tree::TreeNode.new('home').tap do |root|
@@ -59,7 +45,7 @@ RSpec.describe Navigation do
 
       expect(items.first).to be_a(Navigation::Item)
       expect(items.first.id).to eq(foo_guide.id)
-      expect(items.first.label).to eq(foo_guide.label)
+      expect(items.first.label).to eq(foo_guide.metadata.label)
     end
 
     it 'groups guides within a topic' do
@@ -67,13 +53,13 @@ RSpec.describe Navigation do
       items = topic.items
 
       expect(items[0][0].id).to eq(bar_guide.id)
-      expect(items[0][0].label).to eq(bar_guide.label)
+      expect(items[0][0].label).to eq(bar_guide.metadata.label)
 
       expect(items[0][1].id).to eq(baz_guide.id)
-      expect(items[0][1].label).to eq(baz_guide.label)
+      expect(items[0][1].label).to eq(baz_guide.metadata.label)
 
       expect(items[1][0].id).to eq(qux_guide.id)
-      expect(items[1][0].label).to eq(qux_guide.label)
+      expect(items[1][0].label).to eq(qux_guide.metadata.label)
     end
 
     it 'groups orphaned guides into a more topic' do
@@ -84,7 +70,12 @@ RSpec.describe Navigation do
       expect(topic.label).to eq('More…')
 
       expect(guides.first.id).to eq(norf_guide.id)
-      expect(guides.first.label).to eq(norf_guide.label)
+      expect(guides.first.label).to eq(norf_guide.metadata.label)
     end
+  end
+
+  def guide_for(name)
+    metadata = { label: name.titlecase }
+    GuideDecorator.new(Guide.new(name, content_type: :govspeak, content: '', metadata: metadata))
   end
 end


### PR DESCRIPTION
This change is designed to simplify the process of 
adding metadata to a guide page. 

Previously all fields needed to be declared in 
multiple places and explicitly initialised. 

This change is a small improvement to the existing
codebase with the goal of simplifying the current 
process. This change has been scope limited and is
not intended to fix all the outstanding issues.