### PR TITLE
Upgrade autoprefixer to latest version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,7 +52,7 @@ GEM
       robotex (>= 1.0.0)
     arel (6.0.3)
     ast (2.3.0)
-    autoprefixer-rails (6.4.0.1)
+    autoprefixer-rails (6.5.4)
       execjs
     babel-source (5.8.35)
     babel-transpiler (0.7.0)

--- a/config/autoprefixer.yml
+++ b/config/autoprefixer.yml
@@ -1,0 +1,4 @@
+browsers:
+  - "last 2 versions"
+  - "IE > 8"
+  - "and_chr > 50"


### PR DESCRIPTION
- 6.4.0.1 -> 6.5.4
- See https://github.com/ai/autoprefixer-rails/blob/master/CHANGELOG.md for more details