### PR TITLE
Fix redirection bug

### DIFF
--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -3,6 +3,6 @@ class QuestionsController < ApplicationController
     question = GuideDecorator.cached_for(GuideRepository.new.find(params[:question_id]))
     answer = question.metadata.answers[params[:response]]
 
-    redirect_to answer || params[:question_id]
+    redirect_to answer || "/#{params[:question_id]}"
   end
 end

--- a/spec/controllers/questions_controller_spec.rb
+++ b/spec/controllers/questions_controller_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+RSpec.describe QuestionsController, type: :controller do
+  subject { post 'next', question_id: 'pension_type_tool/question_1' }
+
+  it 'correctly redirects back when no answer is provided' do
+    expect(subject).to redirect_to('http://test.host/pension_type_tool/question_1')
+  end
+end


### PR DESCRIPTION
When redirecting to a string the following URL is used:

    # actionpack-4.2.7.1 lib/action_controller/metal/redirecting:89
    request.protocol + request.host_with_port + options

This means `redirect_to 'pension-type-tool/question-1'` was
redirecting to:

    https://staging-www.pensionwise.gov.ukpension-type-tool/question-1

Not sure why this issue did not present locally.