### PR TITLE
Fix question id to use '-'

### DIFF
--- a/content/pension_type_tool/question_1.md
+++ b/content/pension_type_tool/question_1.md
@@ -10,6 +10,6 @@ tags:
 
 # Find out your pension type
 
-{::yes-no-dont-know-question id="pension_type_tool/question_1"}
+{::yes-no-dont-know-question id="pension-type-tool/question-1"}
 ## Was your pension set up by your employer?
 {:/yes-no-dont-know-question}

--- a/content/pension_type_tool/question_2.md
+++ b/content/pension_type_tool/question_2.md
@@ -10,7 +10,7 @@ tags:
 
 # Find out your pension type
 
-{::yes-no-dont-know-question id="pension_type_tool/question_2"}
+{::yes-no-dont-know-question id="pension-type-tool/question-2"}
 ## Did your pension come from working for one of the following:
 
 * a local council

--- a/content/pension_type_tool/question_3.md
+++ b/content/pension_type_tool/question_3.md
@@ -10,7 +10,7 @@ tags:
 
 # Find out your pension type
 
-{::yes-no-dont-know-question id="pension_type_tool/question_3"}
+{::yes-no-dont-know-question id="pension-type-tool/question-3"}
 ## Is your pension provider one of the following:
 
 {:.two-column-list}

--- a/content/pension_type_tool/question_4.md
+++ b/content/pension_type_tool/question_4.md
@@ -11,7 +11,7 @@ tags:
 
 # Find out your pension type
 
-{::pension-start-year-question id="pension_type_tool/question_4"}
+{::pension-start-year-question id="pension-type-tool/question-4"}
 ## When did you start this pension?
 
 {:/pension-start-year-question}

--- a/spec/controllers/questions_controller_spec.rb
+++ b/spec/controllers/questions_controller_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 
 RSpec.describe QuestionsController, type: :controller do
-  subject { post 'next', question_id: 'pension_type_tool/question_1' }
+  subject { post 'next', question_id: 'pension-type-tool/question-1' }
 
   it 'correctly redirects back when no answer is provided' do
-    expect(subject).to redirect_to('http://test.host/pension_type_tool/question_1')
+    expect(subject).to redirect_to('http://test.host/pension-type-tool/question-1')
   end
 end

--- a/spec/features/questions_spec.rb
+++ b/spec/features/questions_spec.rb
@@ -1,0 +1,17 @@
+RSpec.feature 'Questions', type: :feature do
+  def self.guides_with_questions
+    GuideRepository.new.all.select do |guide|
+      guide.content =~ /{::[^\s]+-question/m
+    end
+  end
+
+  guides_with_questions.each do |guide|
+    scenario "#{guide.id} correctly deal with no answer being provided" do
+      visit "/#{guide.slug}"
+
+      page.click_on 'Next step'
+
+      expect(page.current_url).to match(guide.slug)
+    end
+  end
+end


### PR DESCRIPTION
This is required in order for the page to redirect
correctly when no answer is provided.