### PR TITLE
Modernise buildpack configuration

### DIFF
--- a/app.json
+++ b/app.json
@@ -4,7 +4,6 @@
   "website": "https://www.pensionwise.gov.uk",
   "repository": "https://github.com/guidance-guarantee-programme/pension_guidance",
   "env": {
-    "BUILDPACK_URL": "https://github.com/heroku/heroku-buildpack-multi.git",
     "LOCATIONS_TTL": "3600",
     "LOCATIONS_URL": "https://locator.pensionwise.gov.uk/locations.json",
     "NEW_RELIC_LOG": "STDOUT",
@@ -17,5 +16,13 @@
   "addons": [
     "heroku-redis",
     "logentries"
+  ],
+  "buildpacks": [
+    {
+      "url": "heroku/ruby"
+    },
+    {
+      "url": "heroku/nodejs"
+    }
   ]
 }


### PR DESCRIPTION
The multi buildpack has ceased to be. Heroku now supports multiple
buildpacks as first-class citizens so we should use that style of
configuration instead.