### PR TITLE
Enable CSRF protection where possible

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 class ApplicationController < ActionController::Base
   include Breadcrumbs
 
-  protect_from_forgery
+  protect_from_forgery with: :exception
 
   helper_method :footer?
 

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -1,4 +1,6 @@
 class QuestionsController < ApplicationController
+  skip_before_action :verify_authenticity_token
+
   def next
     question = GuideDecorator.cached_for(GuideRepository.new.find(params[:question_id]))
     answer = question.metadata.answers[params[:response]]

--- a/app/views/layouts/_base.html.erb
+++ b/app/views/layouts/_base.html.erb
@@ -1,4 +1,6 @@
 <% content_for :head do %>
+  <%= csrf_meta_tag %>
+
   <!--[if gt IE 8]><!--><%= stylesheet_link_tag 'pensions-guidance', media: 'screen' %><!--<![endif]-->
   <!--[if IE 6]><%= stylesheet_link_tag 'pensions-guidance-ie6', media: 'screen' %><![endif]-->
   <!--[if IE 7]><%= stylesheet_link_tag 'pensions-guidance-ie7', media: 'screen' %><![endif]-->

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,1 +1,1 @@
-Rails.application.config.session_store :disabled
+Rails.application.config.session_store :cookie_store, key: '_pension_guidance'


### PR DESCRIPTION
After upgrading to Rails 5.0.1 CSRF protection attempts to clear the
flash upon failure, unfortunately a bug in Rails means it doesn't guard
against us not actually loading the session middleware thus causing the
app to crash where usually CSRF failures would be silent.

We now fail with exceptions for CSRF failures so we can catch them
early on. For the bookings, where we take sensitive data we absolutely
should ensure CSRF verification happens so I have enabled this. For the
other tools this isn't such an issue.

Given the nature of the pension type tool we cannot enable CSRF
verification so this is disabled entirely.