### PR TITLE
Whitelist local assets only during JS tests

### DIFF
--- a/features/support/poltergeist.rb
+++ b/features/support/poltergeist.rb
@@ -1,4 +1,8 @@
 require 'capybara/poltergeist'
 
+Capybara.register_driver :poltergeist do |app|
+  Capybara::Poltergeist::Driver.new(app, url_whitelist: %w(127.0.0.1))
+end
+
 Capybara.javascript_driver = :poltergeist
 Capybara.default_max_wait_time = 20


### PR DESCRIPTION
This stops our tests loading remote assets, speeding up the tests
generally but also silencing the stupid console output from smart
survey's scripts.