### PR TITLE
Strip cookies for guide paths

### DIFF
--- a/app/middleware/strip_session_cookie.rb
+++ b/app/middleware/strip_session_cookie.rb
@@ -1,0 +1,31 @@
+module Middleware
+  class StripSessionCookie
+    def initialize(app, paths:)
+      @app   = app
+      @paths = paths
+    end
+
+    def call(env)
+      if strip?(env)
+        cookieless_call(env)
+      else
+        @app.call(env)
+      end
+    end
+
+    private
+
+    def cookieless_call(env)
+      env.delete('HTTP_COOKIE')
+
+      @app.call(env).tap do |_, headers, _|
+        headers.delete('Set-Cookie')
+      end
+    end
+
+    def strip?(env)
+      path = Rack::Request.new(env).path
+      @paths.include?(path.sub('/', ''))
+    end
+  end
+end

--- a/app/repositories/guide_repository.rb
+++ b/app/repositories/guide_repository.rb
@@ -1,3 +1,6 @@
+require_relative '../models/guide'
+require_relative '../lib/front_matter_parser'
+
 class GuideRepository
   GuideNotFound = Class.new(StandardError)
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -6,6 +6,9 @@ require 'action_view/railtie'
 require 'sprockets/railtie'
 require 'sprockets/es6'
 
+require_relative '../app/repositories/guide_repository'
+require_relative '../app/middleware/strip_session_cookie'
+
 Bundler.require(*Rails.groups)
 
 module PensionGuidance
@@ -23,5 +26,11 @@ module PensionGuidance
     config.action_view.field_error_proc = proc { |html_tag, _|
       html_tag
     }
+
+    config.middleware.insert_before(
+      ActionDispatch::Cookies,
+      Middleware::StripSessionCookie,
+      paths: GuideRepository.new.all.map(&:slug)
+    )
   end
 end

--- a/spec/middleware/strip_session_cookie_spec.rb
+++ b/spec/middleware/strip_session_cookie_spec.rb
@@ -1,0 +1,30 @@
+RSpec.describe Middleware::StripSessionCookie, '#call' do
+  let(:app) { double }
+  let(:response) { [200, { 'Set-Cookie' => 'obai' }, 'body'] }
+
+  subject { described_class.new(app, paths: %w(tax)) }
+
+  context 'with a matching path' do
+    it 'strips cookies from the request and response' do
+      env = { 'HTTP_COOKIE' => 'ohai', 'PATH_INFO' => '/tax' }
+
+      expect(app).to receive(:call).with('PATH_INFO' => '/tax').and_return(response)
+
+      subject.call(env).tap do |_, headers, _|
+        expect(headers).to be_empty
+      end
+    end
+  end
+
+  context 'with no matching path' do
+    it 'does not strip cookies from the request and response' do
+      env = { 'HTTP_COOKIE' => 'ohai', 'PATH_INFO' => '/nope' }
+
+      expect(app).to receive(:call).with(env).and_return(response)
+
+      subject.call(env).tap do |_, headers, _|
+        expect(headers).to include('Set-Cookie')
+      end
+    end
+  end
+end


### PR DESCRIPTION
The guides were cacheable prior to 8bfd9f1 that added CSRF protection,
requiring cookies to be enabled. After 8bfd9f1 I noticed a great deal
more traffic at the origin. This will no doubt affect us over the next
few weeks as more traffic arrives due to marketing attempts.

Cloudflare will not cache content returned from the origin when the
`Set-Cookie` response header is present. To restore public caching for
the guide pages we can simply strip away cookies from the request /
response - leaving the other pages to process cookies as normal.

The middleware is loaded early on during the boot process (before Rails
has autoloaded) thus the need to explicitly require the
`GuideRepository` and its dependents.