### PR TITLE
Add GuideRespository.slugs method

### DIFF
--- a/app/repositories/guide_repository.rb
+++ b/app/repositories/guide_repository.rb
@@ -7,6 +7,10 @@ class GuideRepository
   attr_accessor :dir
   private :dir, :dir=
 
+  def self.slugs
+    @slugs ||= new.slugs
+  end
+
   def initialize(dir = Rails.root.join('content'))
     self.dir = dir
   end
@@ -29,6 +33,13 @@ class GuideRepository
       id = path.match(%r{^#{dir}/(?<id>[^\.]*)\.(?<ext>.*)$})[:id]
       read_guide(id, path)
     end
+  end
+
+  def slugs
+    glob_dir('*').map do |path|
+      id = path.match(%r{^#{dir}/(?<id>[^\.]+)\.(?:(?<locale>[^\.]+)\.)?(?<ext>.*)$})[:id]
+      id.tr('_', '-')
+    end.uniq
   end
 
   private

--- a/config/application.rb
+++ b/config/application.rb
@@ -30,7 +30,7 @@ module PensionGuidance
     config.middleware.insert_before(
       ActionDispatch::Cookies,
       Middleware::StripSessionCookie,
-      paths: GuideRepository.new.all.map(&:slug)
+      paths: GuideRepository.slugs
     )
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,11 +7,11 @@ Rails.application.routes.draw do
 
     get '/book', to: redirect('/appointments', status: 302)
 
-    GuideRepository.new.all.each do |guide|
-      get guide.slug,
+    GuideRepository.slugs.each do |slug|
+      get slug,
           controller: 'guides',
           action: 'show',
-          id: guide.slug
+          id: slug
     end
 
     get 'guaranteed-income/estimate', to: 'calculators/guaranteed_income#show'

--- a/spec/repositories/guide_repository_spec.rb
+++ b/spec/repositories/guide_repository_spec.rb
@@ -66,4 +66,14 @@ RSpec.describe GuideRepository do
       )
     end
   end
+
+  describe '#slugs' do
+    it 'returns an array of slugs' do
+      expect(guide_repository.slugs).to include(
+        'the-test-html-guide',
+        'the-test-govspeak-guide',
+        'nested/nested-guide'
+      )
+    end
+  end
 end


### PR DESCRIPTION
This generates the lists of slugs from the file name
taking into account language specific files.

Previously the `all` method required the files to be 
read in.

In addition the result of slugs has been cached on
GuideRespository object.