### PR TITLE
Enable multiple locales

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,7 @@ class ApplicationController < ActionController::Base
   include Breadcrumbs
 
   protect_from_forgery with: :exception
+  before_action :set_locale
 
   helper_method :footer?
 
@@ -11,5 +12,9 @@ class ApplicationController < ActionController::Base
 
   def footer?
     true
+  end
+
+  def set_locale
+    I18n.locale = params[:locale] || I18n.default_locale
   end
 end

--- a/app/models/guide.rb
+++ b/app/models/guide.rb
@@ -1,11 +1,12 @@
 class Guide
-  attr_reader :id, :content, :content_type, :metadata
+  attr_reader :id, :content, :content_type, :metadata, :available_locales
 
-  def initialize(id, content: '', content_type: nil, metadata: nil)
+  def initialize(id, content: '', content_type: nil, metadata: nil, available_locales: [])
     @id = id
     @content = content
     @content_type = content_type
     @metadata = OpenStruct.new(metadata)
+    @available_locales = [:en] | available_locales
   end
 
   def ==(other)

--- a/config/initializers/i18n.rb
+++ b/config/initializers/i18n.rb
@@ -1,0 +1,2 @@
+require 'i18n/backend/fallbacks'
+I18n::Backend::Simple.send(:include, I18n::Backend::Fallbacks)

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -1,0 +1,2 @@
+cy:
+  language: Cymraeg

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,4 +1,5 @@
 en:
+  language: English
 
   service:
     title: '%{page_title} - Pension Wise'

--- a/spec/fixtures/the_test_govspeak_guide.with-overrides.md
+++ b/spec/fixtures/the_test_govspeak_guide.with-overrides.md
@@ -1,0 +1,7 @@
+---
+label: Tested and overwritten
+description: The guide used for override testing
+tags:
+  - override
+---
+# This is the test guide with metadata overrides

--- a/spec/fixtures/the_test_govspeak_guide.without-overrides.md
+++ b/spec/fixtures/the_test_govspeak_guide.without-overrides.md
@@ -1,0 +1,1 @@
+# This is the test guide without metadata overrides

--- a/spec/repositories/guide_repository_spec.rb
+++ b/spec/repositories/guide_repository_spec.rb
@@ -32,16 +32,53 @@ RSpec.describe GuideRepository do
       specify 'with the correct content type' do
         expect(find.content_type).to eq(expected_content_type)
       end
+
+      specify 'with the correct tags' do
+        expect(find.metadata.tags).to eq(expect_tags)
+      end
     end
 
     context 'a govspeak guide' do
       let(:id) { 'the_test_govspeak_guide' }
+
+      it 'lists the available locales' do
+        expect(find.available_locales).to match_array(%i(en without-overrides with-overrides))
+      end
 
       include_examples 'existing guide' do
         let(:expected_content_type) { :govspeak }
         let(:expected_content) { "# This is the test guide\n" }
         let(:expected_label) { 'Tested' }
         let(:expected_description) { 'The guide used for testing' }
+        let(:expect_tags) { %w(testing tags govspeak) }
+      end
+
+      context 'language file without metadata overrides' do
+        before do
+          allow(I18n).to receive(:locale).and_return(:'without-overrides')
+        end
+
+        include_examples 'existing guide' do
+          let(:expected_content_type) { :govspeak }
+          let(:expected_content) { "# This is the test guide without metadata overrides\n" }
+          let(:expected_label) { 'Tested' }
+          let(:expected_description) { 'The guide used for testing' }
+          let(:expect_tags) { %w(testing tags govspeak) }
+        end
+      end
+
+      context 'language file with metadata overrides' do
+        before do
+          allow(I18n).to receive(:locale).and_return(:'with-overrides')
+        end
+
+        include_examples 'existing guide' do
+          let(:expected_content_type) { :govspeak }
+          let(:expected_content) { "# This is the test guide with metadata overrides\n" }
+          let(:expected_label) { 'Tested and overwritten' }
+          let(:expected_description) { 'The guide used for override testing' }
+          let(:expect_tags) { %w(override) }
+        end
       end
     end
 
@@ -53,6 +90,7 @@ RSpec.describe GuideRepository do
         let(:expected_content) { "<h1>This is the test guide</h1>\n" }
         let(:expected_label) { 'Tested' }
         let(:expected_description) { 'The guide used for testing' }
+        let(:expect_tags) { %w(testing tags html) }
       end
     end
   end


### PR DESCRIPTION
The locale needs to be set on a per request basis
passed in as one of the parameters.

Guides are now aware of `available_locales` that they
can be rendered in, and will be rendered in using the
current `I18n.locale` with a fallback to `:en`.

Each local needs a language translation in a
`config/locales/<locale>.yml` file.

Guides inherit metadata from base file.

Creating a new guide for for a location is as simple 
as creating a copy of the guide file with a `.<locale>.md`
extension.

No front-end implementation is included in this PR.

It is expect the front-end code will be similar to:

```erb
<% if @guide.available_locales.count > 1 %>
  <% @guide.available_locales.each do |locale| %>
    <% if locale == I8n.locale %>
      <span><%= I18n.t(:language, locale: locale) %></span>
    <% else %>
     <%= link_to I18n.t(:language, locale: locale || :en), public_send("#{@guide.id}_path", locale: locale) %>
    <% end %>
  <% end %>
<% end %>
```