### PR TITLE
Allow feedback to be left on the pension type tool

### DIFF
--- a/app/controllers/feedbacks_controller.rb
+++ b/app/controllers/feedbacks_controller.rb
@@ -1,4 +1,5 @@
 class FeedbacksController < ApplicationController
+  skip_before_action :verify_authenticity_token
   layout 'full_width'
 
   def new

--- a/spec/features/feedback_spec.rb
+++ b/spec/features/feedback_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+RSpec.feature 'Customer feedback', js: true do
+  scenario 'can be left on the pension type tool' do
+    begin
+      allow_forgery_protection = FeedbacksController.allow_forgery_protection
+      FeedbacksController.allow_forgery_protection = true
+
+      visit '/pension-type-tool'
+
+      click_on 'Is there anything wrong with this page?'
+
+      fill_in 'Name', with: 'Jim Bob'
+      fill_in 'Email', with: 'jim@bob.com'
+      fill_in 'Message', with: 'Some feedback'
+
+      click_on 'Send feedback'
+
+      expect(page).to have_content('Thank you for your help')
+    ensure
+      FeedbacksController.allow_forgery_protection = allow_forgery_protection
+    end
+  end
+end


### PR DESCRIPTION
This was failing to work as the cookies are striped
from the page to enable caching. This change requires
CSRF protection from the feedback submission form.