### PR TITLE
Fix visual bug with padding around date/time confirmation

### DIFF
--- a/app/assets/stylesheets/vendor/_slot-picker.scss
+++ b/app/assets/stylesheets/vendor/_slot-picker.scss
@@ -39,6 +39,9 @@
     color: $slot-picker-prompt;
   }
 
+  & + & {
+    padding-top: 10px;
+  }
 }
 
 


### PR DESCRIPTION
**Before**
<img width="364" alt="screen shot 2017-01-26 at 16 43 53" src="https://cloud.githubusercontent.com/assets/6049076/22340816/a30f14d6-e3e6-11e6-852b-62cdc6293530.png">
<img width="501" alt="screen shot 2017-01-26 at 16 43 40" src="https://cloud.githubusercontent.com/assets/6049076/22340817/a313a38e-e3e6-11e6-97bb-18ccbfadbf19.png">


**After**

<img width="535" alt="screen shot 2017-01-26 at 16 42 47" src="https://cloud.githubusercontent.com/assets/6049076/22340778/82e385fc-e3e6-11e6-9892-bde5699aa226.png">
<img width="410" alt="screen shot 2017-01-26 at 16 42 42" src="https://cloud.githubusercontent.com/assets/6049076/22340779/82e4421c-e3e6-11e6-9ffc-7841edbbb3b3.png">
