### PR TITLE
Alternative landing page available at `/landing`

### DIFF
--- a/app/views/marketing/landing.html.erb
+++ b/app/views/marketing/landing.html.erb
@@ -1,0 +1,92 @@
+<% content_for(:page_title, t('service.homepage.title')) %>
+<% content_for(:meta_description, 'A free and impartial government service that helps you understand ' +
+  'the options for your pension pot.') %>
+<% content_for(:body_classes, 'marketing-page') %>
+
+<% content_for(:after_script) do %>
+  <%= javascript_include_tag 'video-player' %>
+<% end %>
+
+<div class="l-grid-row">
+  <div class="l-marketing-promo">
+    <div class="l-page-container l-marketing-promo__content">
+      <div class="l-column-third">
+        <a href="/"><%= render partial: 'components/logo_with_strapline_svg', locals: { image_class: 'marketing-logo' } %></a>
+      </div>
+    </div>
+  </div>
+</div>
+<div class="l-grid-row l-marketing-row--flip">
+  <div class="l-page-container">
+    <div class="marketing-promo">
+      <div class="l-column-full l-marketing-column">
+        <div class="marketing-book-content">
+          <h2 class="marketing-subheading">Book a free appointment</h2>
+          <p>Find out about how you can take your pension money, from getting a regular income to taking your whole pot as cash.</p>
+          <p>Speak to us over the phone or in person somewhere local to you.</p>
+          <p>Pension Wise is free and impartial – we don’t recommend products or companies and won’t tell you how to invest your money.</p>
+          <p class="marketing-book"><a href="/appointments" class="button">Book now</a></p>
+        </div>
+        <div class="youtube-video">
+          <div class="youtube-video__video">
+            <%= image_tag 'campaigns/appointment-holding.jpg', alt: 'Donna Reid (Pension Wise Guidance Specialist)', class: 'js-youtube-holding' %>
+            <button class="youtube-video-play js-youtube-play" data-youtube-id="b8Lsgk46Hgs"><svg xmlns="http://www.w3.org/2000/svg" width="75" height="52" viewBox="0 0 500 350"><title>Play video</title><path d="M500 74.767C500 33.472 466.55 0 425.278 0H74.722C33.45 0 0 33.472 0 74.767v200.466C0 316.528 33.45 350 74.722 350h350.556C466.55 350 500 316.528 500 275.233V74.767zm-300 184.81v-188.3l142.79 94.15L200 259.578z" fill-rule="evenodd" class="youtube-video-play__bg" /><path d="M199.928 71.057L200 259.593l142.982-94.18z" class="youtube-video-play__arrow" /></svg></button>
+          </div>
+          <p class="youtube-video-transcript-text">
+            <a href="#main-transcript" class="visually-hidden js-video-transcript-toggle" aria-controls="main-transcript">Show video transcript</a>
+          </p>
+        </div>
+        <div class="youtube-video-transcript js-video-transcript" id="main-transcript" tabindex="-1">
+          <noscript class="js-video-transcript-copy">
+            <h2 class="marketing-subheading">Donna Reid - Pension Wise Guidance Specialist</h2>
+
+            <p>&ldquo;Pension Wise is a government-backed service that provides free, impartial guidance to help you understand your options for your pensions savings.&rdquo;</p>
+
+            <p>Who is Pension Wise for?</p>
+
+            <p>&ldquo;You're eligible for a free Pension Wise appointment if you're 50 or over, and have defined contribution pension, which is where you build up a 'pot' of savings that you can access when you reach retirement. This would include many private and workplace pensions.&rdquo;</p>
+
+            <p>What does an appointment entail?</p>
+
+            <p>&ldquo;An appointment lasts approximately 45 minutes, and in that time, we'll explain the different options you have for accessing your pension pot, taking into account your particular circumstances. We'll also cover how to shop around for the best deal, how to avoid scams, as well as answer any questions you may have.&rdquo;</p>
+
+            <p>How to arrange an appointment</p>
+
+            <p>&ldquo;You can have your appointment either over the phone, or face-to-face in one of hundreds of locations across the UK.</p>
+
+            <p>&ldquo;Call for your free Pension Wise appointment, or for more information go to pensionwise.gov.uk&rdquo;</p>
+          </noscript>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div id="what-to-expect" class="l-grid-row l-marketing-row l-home-row--callout l-marketing-row--dog l-marketing-row--flat">
+  <div class="l-page-container l-home-row-callout__content">
+    <div class="l-column-third l-marketing-faux-column">
+      &nbsp;
+    </div>
+    <div class="l-column-two-thirds">
+      <h2 class="marketing-subheading">What to expect in an appointment</h2>
+      <%= image_tag 'campaigns/guider-image.jpg', alt: 'Guider and customer at an appointment', class: 'marketing-image' %>
+      <p>An appointment is a 45 to 60 minute conversation with a pensions specialist.</p>
+      <p>We’ll talk through your options for taking your personal or workplace pension money. We’ll also explain tax and give you next steps to take.</p>
+      <p>You’ll also get a written summary of your appointment.</p>
+      <div role="note" aria-label="Information" class="application-notice info-notice marketing-notice">
+        <p>For guidance on defined benefit pensions go to the <a href="http://www.pensionsadvisoryservice.org.uk">The Pensions Advisory Service</a> – for the State Pension go to the <a href="https://www.gov.uk/contact-pension-service">Pension Service</a>.
+      </div>
+    </div>
+  </div>
+</div>
+
+<div id="about-pensionwise" class="l-grid-row l-marketing-row l-marketing-row--flat l-marketing-row--flip l-home-row--callout">
+  <div class="l-page-container l-home-row-callout__content">
+    <div class="l-home-row-callout__column">
+      <h2 class="l-home-single-column-subheading">About Pension Wise</h2>
+      <p>Pension Wise is a free and impartial government service.</p>
+      <p>We were set up in 2015 after changes to pension rules gave people more choice over what they could do with their money.</p>
+      <p>We provide appointments through Citizens Advice and The Pensions Advisory Service over the phone and in person across the UK.</p>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,7 @@ Rails.application.routes.draw do
     post 'questions', to: 'questions#next'
 
     get 'facebook-landing', to: 'marketing#facebook-landing'
+    get 'landing', to: 'marketing#landing'
 
     resources :locations, only: [:index, :show] do
       member do

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -9,3 +9,4 @@ Disallow: /take-whole-pot/estimate
 Disallow: /home-alternative
 Disallow: /pension-type-tool/
 Disallow: /facebook-landing
+Disallow: /landing


### PR DESCRIPTION
The page is identical to the existing 'facebook landing' page,
except this one is to be used for various other digital marketing
and no phone number to promote online booking.