### PR TITLE
Remove visually-hidden class override from project

### DIFF
--- a/app/assets/stylesheets/helpers/_visually-hidden.scss
+++ b/app/assets/stylesheets/helpers/_visually-hidden.scss
@@ -1,3 +1,0 @@
-.visually-hidden {
-  visibility: hidden;
-}


### PR DESCRIPTION
- visually-hidden is the standard class to use for
  govuk pages to hide text from visual users, but
  allow the text to be read by screen readers

- Adding visibility: hidden to visually-hidden class
  results in Jaws on Windows not reading the content