### PR TITLE
Adding in aXe accessibility testing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,7 @@ group :development do
 end
 
 group :test do
+  gem 'axe-matchers'
   gem 'cucumber-rails', require: false
   gem 'fakeredis'
   gem 'launchy'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,6 +63,13 @@ GEM
     ast (2.3.0)
     autoprefixer-rails (6.5.4)
       execjs
+    axe-matchers (1.3.2)
+      dumb_delegator (~> 0.8)
+      virtus (~> 1.0)
+    axiom-types (0.1.1)
+      descendants_tracker (~> 0.0.4)
+      ice_nine (~> 0.11.0)
+      thread_safe (~> 0.3, >= 0.3.1)
     babel-source (5.8.35)
     babel-transpiler (0.7.0)
       babel-source (>= 4.0, < 6)
@@ -84,6 +91,8 @@ GEM
       xpath (~> 2.0)
     cliver (0.3.2)
     coderay (1.1.1)
+    coercible (1.0.0)
+      descendants_tracker (~> 0.0.1)
     concurrent-ruby (1.0.4)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
@@ -104,9 +113,13 @@ GEM
       nokogiri (~> 1.5)
       railties (>= 3, < 5.1)
     cucumber-wire (0.0.1)
+    descendants_tracker (0.0.4)
+      thread_safe (~> 0.3, >= 0.3.1)
     diff-lcs (1.2.5)
+    dumb_delegator (0.8.0)
     email_validation (1.2.1)
       localized_each_validator (>= 1.0.1)
+    equalizer (0.0.11)
     erubis (2.7.0)
     excon (0.54.0)
     execjs (2.7.0)
@@ -147,6 +160,7 @@ GEM
     htmlentities (4.3.4)
     humanize (1.2.3)
     i18n (0.7.0)
+    ice_nine (0.11.2)
     image_size (1.5.0)
     inflection (1.0.0)
     inline_svg (0.11.1)
@@ -339,6 +353,11 @@ GEM
     utf8-cleaner (0.2.5)
       activesupport
     vcr (3.0.3)
+    virtus (1.0.5)
+      axiom-types (~> 0.1)
+      coercible (~> 1.0)
+      descendants_tracker (~> 0.0, >= 0.0.3)
+      equalizer (~> 0.0, >= 0.0.9)
     webmock (2.3.1)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -369,6 +388,7 @@ PLATFORMS
 
 DEPENDENCIES
   autoprefixer-rails
+  axe-matchers
   booking_locations
   bugsnag
   canonical-rails
@@ -428,4 +448,4 @@ RUBY VERSION
    ruby 2.3.3p222
 
 BUNDLED WITH
-   1.13.6
+   1.13.7

--- a/app/views/appointment_summaries/new.html.erb
+++ b/app/views/appointment_summaries/new.html.erb
@@ -26,15 +26,13 @@
     <fieldset class="inline">
       <legend class="visuallyhidden">Your age</legend>
 
-      <%= f.label :appointment_type, value: '50_54', class: 'block-label' do %>
-          <%= f.radio_button :appointment_type, '50_54', checked: false,
-                             class: 't-appointment-type-50-54' %>
+      <%= f.label :appointment_type, value: '50_54', class: 'block-label t-appointment-type-50-54' do %>
+          <%= f.radio_button :appointment_type, '50_54', checked: false %>
           50 to 54
       <% end %>
 
-      <%= f.label :appointment_type, value: 'standard', class: 'block-label' do %>
-        <%= f.radio_button :appointment_type, 'standard', checked: false,
-                             class: 't-appointment-type-standard' %>
+      <%= f.label :appointment_type, value: 'standard', class: 'block-label t-appointment-type-standard' do %>
+        <%= f.radio_button :appointment_type, 'standard', checked: false %>
         55 or over
       <% end %>
     </fieldset>

--- a/features/accessibility.feature
+++ b/features/accessibility.feature
@@ -1,0 +1,33 @@
+@javascript
+Feature: Accessibility of pages
+  As a customer I want Pension Wise pages to be fully accessible
+  so I can navigate the website regardless of my access needs
+
+  Scenario: Homepage of the site is accessible
+    When I visit the homepage
+    Then the page should be accessible
+
+  Scenario Outline: Typical pages of the site are accessible
+    When I visit the page <Slug>
+    Then the page should be accessible
+
+    Examples:
+      | Slug                     |
+      | facebook-landing         |
+      | leave-pot-untouched      |
+      | tax                      |
+      | summary-document/new     |
+      | feedback/new             |
+
+  Scenario: Location page is accessible
+    When I visit a face to face booking location page
+    Then the page should be accessible
+
+  Scenario: Appointment summary page is accessible
+    When I visit the appointment summary page
+    Then the page should be accessible
+
+  @booking_locations
+  Scenario: Slot picker for face to face booking is not accessible while we develop our own slot picker
+    When I view the face to face booking form
+    Then the page should be accessible excluding ".SlotPicker"

--- a/features/cassettes/Accessibility_of_pages/Location_page_is_accessible.yml
+++ b/features/cassettes/Accessibility_of_pages/Location_page_is_accessible.yml
@@ -1,0 +1,79 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.postcodes.io/postcodes/BT73AP
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.54.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.11.5
+      Date:
+      - Mon, 30 Jan 2017 16:04:13 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '681'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      Etag:
+      - W/"2a9-HgDhl4N5wBUnx5tR2F28IA"
+      X-Gnu:
+      - Michael J Blanchard
+    body:
+      encoding: ASCII-8BIT
+      string: '{"status":200,"result":{"postcode":"BT7 3AP","quality":1,"eastings":334475,"northings":372070,"country":"Northern
+        Ireland","nhs_ha":"Health & Social Care Board","longitude":-5.92103307128071,"latitude":54.5790132673042,"parliamentary_constituency":"Belfast
+        South","european_electoral_region":"Northern Ireland","primary_care_trust":"Belfast","region":null,"lsoa":"Ballynafeigh
+        3","msoa":null,"incode":"3AP","outcode":"BT7","admin_district":"Belfast","parish":null,"admin_county":null,"admin_ward":"Ormeau","ccg":"Belfast","nuts":"Belfast","codes":{"admin_district":"N09000003","admin_county":"N99999999","admin_ward":"N08000342","parish":"N99999999","ccg":"ZC010","nuts":"UKN01"}}}'
+    http_version: 
+  recorded_at: Mon, 30 Jan 2017 16:04:12 GMT
+- request:
+    method: get
+    uri: https://api.postcodes.io/postcodes/BT73AP
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.54.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.11.5
+      Date:
+      - Mon, 30 Jan 2017 16:04:14 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '681'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      Etag:
+      - W/"2a9-HgDhl4N5wBUnx5tR2F28IA"
+      X-Gnu:
+      - Michael J Blanchard
+    body:
+      encoding: ASCII-8BIT
+      string: '{"status":200,"result":{"postcode":"BT7 3AP","quality":1,"eastings":334475,"northings":372070,"country":"Northern
+        Ireland","nhs_ha":"Health & Social Care Board","longitude":-5.92103307128071,"latitude":54.5790132673042,"parliamentary_constituency":"Belfast
+        South","european_electoral_region":"Northern Ireland","primary_care_trust":"Belfast","region":null,"lsoa":"Ballynafeigh
+        3","msoa":null,"incode":"3AP","outcode":"BT7","admin_district":"Belfast","parish":null,"admin_county":null,"admin_ward":"Ormeau","ccg":"Belfast","nuts":"Belfast","codes":{"admin_district":"N09000003","admin_county":"N99999999","admin_ward":"N08000342","parish":"N99999999","ccg":"ZC010","nuts":"UKN01"}}}'
+    http_version: 
+  recorded_at: Mon, 30 Jan 2017 16:04:13 GMT
+recorded_with: VCR 3.0.3

--- a/features/step_definitions/accessibility_steps.rb
+++ b/features/step_definitions/accessibility_steps.rb
@@ -1,0 +1,3 @@
+When(/^I visit the page (.*)$/) do |slug|
+  visit slug
+end

--- a/features/step_definitions/appointment_summary_steps.rb
+++ b/features/step_definitions/appointment_summary_steps.rb
@@ -7,8 +7,8 @@ When(/^I select (.*) as my age range$/) do |age|
   generator = @page.generator
 
   case age
-  when '55 or over' then generator.appointment_type_standard.set true
-  when '50 to 54' then generator.appointment_type_50_54.set true
+  when '55 or over' then generator.appointment_type_standard.click
+  when '50 to 54' then generator.appointment_type_50_54.click
   end
 end
 
@@ -19,12 +19,18 @@ When(/^I view the appointment summary$/) do
   @page = Pages::AppointmentSummary.new
 end
 
+When(/^I visit the appointment summary page$/) do
+  step('I visit the digital appointment summary generator')
+  step('I select 55 or over as my age range')
+  step('I view the appointment summary')
+end
+
 Given(/^I generate a valid appointment summary$/) do
   @page = Pages::AppointmentSummaryGenerator.new
   @page.load
 
   generator = @page.generator
-  generator.appointment_type_standard.set true
+  generator.appointment_type_standard.click
 
   generator.submit_button.click
 

--- a/features/step_definitions/customer_booking_request_steps.rb
+++ b/features/step_definitions/customer_booking_request_steps.rb
@@ -37,6 +37,12 @@ Then(/^I see the location name "(.*?)"$/) do |name|
   expect(@step_one.location_name.text).to include(name)
 end
 
+When(/^I view the face to face booking form$/) do
+  step('a location is enabled for online booking')
+  step('I browse for the location')
+  step('I opt to book online')
+end
+
 When(/^I choose three available appointment slots$/) do
   @step_one = Pages::BookingStepOne.new
   expect(@step_one).to be_displayed

--- a/features/step_definitions/location_steps.rb
+++ b/features/step_definitions/location_steps.rb
@@ -17,6 +17,10 @@ When(/^I drill down into a specific search result$/) do
   location.link_to.click
 end
 
+When(/^I visit a face to face booking location page$/) do
+  step('I view the details of an appointment location that handles its own booking')
+end
+
 When(/^I view the details of an appointment location that handles its own booking$/) do
   Pages::Location.new.load(id: 'london')
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,4 +1,5 @@
 require 'cucumber/rails'
 require 'cucumber/rspec/doubles'
+require 'axe/cucumber/step_definitions'
 
 ActionController::Base.allow_rescue = false


### PR DESCRIPTION
![axelogo](https://cloud.githubusercontent.com/assets/6049076/22472447/90674c78-e7cd-11e6-8818-d5c2ea33667d.png)

Using axe-matchers gem to integrate accessibility tests into a set of new cucumber features.

The tests which are run against the pages are listed here:
https://github.com/dequelabs/axe-core/blob/master/doc/rule-descriptions.md

Altered steps which select radio buttons on appointment summary form page to ensure they work with features with/without Javascript