### PR TITLE
Pass 'not sure' through to bookings API

### DIFF
--- a/app/lib/booking_requests/api_mapper.rb
+++ b/app/lib/booking_requests/api_mapper.rb
@@ -13,7 +13,7 @@ module BookingRequests
           date_of_birth: booking_request.date_of_birth.iso8601,
           accessibility_requirements: booking_request.accessibility_requirements,
           marketing_opt_in: booking_request.opt_in,
-          defined_contribution_pot: dc_pot_as_boolean(booking_request.dc_pot),
+          defined_contribution_pot_confirmed: dc_pot_as_boolean(booking_request.dc_pot),
           slots: [
             slot(1, booking_request.primary_slot),
             slot(2, booking_request.secondary_slot),
@@ -35,7 +35,7 @@ module BookingRequests
     end
 
     def self.dc_pot_as_boolean(dc_pot)
-      %w(yes not-sure).any? { |type| dc_pot.include?(type) }
+      dc_pot == 'yes'
     end
   end
 end

--- a/spec/lib/booking_requests/api_mapper_spec.rb
+++ b/spec/lib/booking_requests/api_mapper_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe BookingRequests::ApiMapper do
           date_of_birth: '1950-01-01',
           accessibility_requirements: false,
           marketing_opt_in: false,
-          defined_contribution_pot: true,
+          defined_contribution_pot_confirmed: true,
           slots: [
             { priority: 1, date: '2016-01-01', from: '0900', to: '1300' },
             { priority: 2, date: '2016-01-01', from: '1300', to: '1700' },
@@ -54,12 +54,8 @@ RSpec.describe BookingRequests::ApiMapper do
       expect(described_class.dc_pot_as_boolean('yes')).to be true
     end
 
-    it 'coerces `not-sure` to true' do
-      expect(described_class.dc_pot_as_boolean('not-sure')).to be true
-    end
-
-    it 'coerces `no` to false' do
-      expect(described_class.dc_pot_as_boolean('no')).to be false
+    it 'coerces `not-sure` to false' do
+      expect(described_class.dc_pot_as_boolean('not-sure')).to be false
     end
   end
 end


### PR DESCRIPTION
To facilitate displaying when the customer specified they were unsure
whether their pension was DC, we now pass their selection through to
the bookings API per the requirements for displaying in planner.