### PR TITLE
Show error message when customer does not enter a postcode

### DIFF
--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -8,7 +8,8 @@ class LocationsController < ApplicationController
   layout 'full_width_with_breadcrumbs', only: %i(show index)
 
   def index
-    return render :search unless @postcode.present?
+    return render :search if @postcode.nil?
+    return render :empty_postcode if @postcode.empty?
 
     @locations = begin
       Locations.nearest_to_postcode(@postcode, limit: NEAREST_LIMIT).map do |location|

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -11,15 +11,7 @@ class LocationsController < ApplicationController
     return render :search if @postcode.nil?
     return render :empty_postcode if @postcode.empty?
 
-    @locations = begin
-      Locations.nearest_to_postcode(@postcode, limit: NEAREST_LIMIT).map do |location|
-        LocationSearchResultDecorator.new(location)
-      end
-    rescue Geocoder::InvalidPostcode
-      render :invalid_postcode
-    rescue Geocoder::FailedLookup
-      render :failed_lookup
-    end
+    retrieve_locations
   end
 
   def show
@@ -36,6 +28,18 @@ class LocationsController < ApplicationController
   end
 
   private
+
+  def retrieve_locations
+    @locations = begin
+      Locations.nearest_to_postcode(@postcode, limit: NEAREST_LIMIT).map do |location|
+        LocationSearchResultDecorator.new(location)
+      end
+    rescue Geocoder::InvalidPostcode
+      render :invalid_postcode
+    rescue Geocoder::FailedLookup
+      render :failed_lookup
+    end
+  end
 
   def set_breadcrumbs
     breadcrumb Breadcrumb.book_an_appointment

--- a/app/views/components/_error_postcode.html.erb
+++ b/app/views/components/_error_postcode.html.erb
@@ -1,0 +1,27 @@
+<% content_for(:page_title, t('service.title', page_title: 'Find an appointment location near you')) %>
+
+<% content_for(:data_layer) do %>
+  <script>
+    dataLayer = [{
+      'postcodeValid': false
+    }];
+  </script>
+<% end %>
+
+<div class="l-grid-row">
+  <div class="l-column-two-thirds">
+    <article role="article" class="text">
+      <h1>Find an appointment location near you</h1>
+
+      <p>Search for your nearest appointment locations.</p>
+
+      <%= render 'components/locations_search', has_error: true do %>
+        <% yield %>
+      <% end %>
+
+      <div class="application-notice info-notice">
+        <p>You can also <a href="/book-phone">book a phone appointment</a>.</p>
+      </div>
+    </article>
+  </div>
+</div>

--- a/app/views/components/_locations_search.html.erb
+++ b/app/views/components/_locations_search.html.erb
@@ -5,9 +5,7 @@
       Postcode
       <span class="form-hint">For example, 'SW1A 1AA'</span>
       <% if has_error %>
-        <span class="t-invalid-postcode error-message">
-          <strong><%= @postcode.squish %></strong> is not a valid postcode
-        </span>
+        <%= yield %>
       <% end %>
     </label>
     <input type="text" class="form-control" name="postcode" id="location" value="<%= @postcode&.squish %>">

--- a/app/views/components/_locations_search.html.erb
+++ b/app/views/components/_locations_search.html.erb
@@ -8,7 +8,7 @@
         <%= yield %>
       <% end %>
     </label>
-    <input type="text" class="form-control" name="postcode" id="location" value="<%= @postcode&.squish %>">
+    <input type="text" class="form-control" name="postcode" id="location" value="<%= @postcode&.squish %>" required="true">
     <input type="submit" class="button" value="Search">
   </div>
 </form>

--- a/app/views/locations/empty_postcode.html.erb
+++ b/app/views/locations/empty_postcode.html.erb
@@ -1,0 +1,5 @@
+<%= render 'components/error_postcode' do %>
+  <span class="t-empty-postcode error-message">Please enter a valid postcode</span>
+<% end %>
+
+

--- a/app/views/locations/empty_postcode.html.erb
+++ b/app/views/locations/empty_postcode.html.erb
@@ -1,5 +1,3 @@
 <%= render 'components/error_postcode' do %>
   <span class="t-empty-postcode error-message">Please enter a valid postcode</span>
 <% end %>
-
-

--- a/app/views/locations/invalid_postcode.html.erb
+++ b/app/views/locations/invalid_postcode.html.erb
@@ -1,25 +1,7 @@
-<% content_for(:page_title, t('service.title', page_title: 'Find an appointment location near you')) %>
-
-<% content_for(:data_layer) do %>
-  <script>
-    dataLayer = [{
-      'postcodeValid': false
-    }];
-  </script>
+<%= render 'components/error_postcode' do %>
+  <span class="t-invalid-postcode error-message">
+    <strong><%= @postcode.squish %></strong> is not a valid postcode
+  </span>
 <% end %>
 
-<div class="l-grid-row">
-  <div class="l-column-two-thirds">
-    <article role="article" class="text">
-      <h1>Find an appointment location near you</h1>
 
-      <p>Search for your nearest appointment locations.</p>
-
-      <%= render 'components/locations_search', has_error: true %>
-
-      <div class="application-notice info-notice">
-        <p>You can also <a href="/book-phone">book a phone appointment</a>.</p>
-      </div>
-    </article>
-  </div>
-</div>

--- a/content/book_face_to_face.md
+++ b/content/book_face_to_face.md
@@ -15,7 +15,7 @@ Search for your nearest appointment locations.
       Postcode
       <span class="form-hint">For example, 'SW1A 1AA'</span>
     </label>
-    <input type="text" class="form-control" id="postcode" name="postcode" value="">
+    <input type="text" class="form-control" id="postcode" name="postcode" value="" required="true">
     <input type="submit" class="button" id="btn-search" value="Search">
   </div>
 </form>

--- a/features/find_nearest_face-to-face_appointment_locations.feature
+++ b/features/find_nearest_face-to-face_appointment_locations.feature
@@ -12,6 +12,10 @@ Scenario: Search using an invalid postcode (i.e. one that we can't find)
   When I search for appointment locations near to an invalid postcode
   Then I should be informed that Pension Wise cannot find that postcode
 
+Scenario: Search without entering a postcode
+  When I search for appointment locations without entering a postcode
+  Then I should be informed that I need to enter a postcode
+
 Scenario: Bookmark search results
   Given I have searched for appointment locations near to a valid postcode
   And I have bookmarked the page

--- a/features/find_nearest_face-to-face_appointment_locations.feature
+++ b/features/find_nearest_face-to-face_appointment_locations.feature
@@ -14,7 +14,7 @@ Scenario: Search using an invalid postcode (i.e. one that we can't find)
 
 Scenario: Search without entering a postcode
   When I search for appointment locations without entering a postcode
-  Then I should be informed that I need to enter a postcode
+  Then I am told to enter a valid postcode
 
 Scenario: Bookmark search results
   Given I have searched for appointment locations near to a valid postcode

--- a/features/pages/locations_page.rb
+++ b/features/pages/locations_page.rb
@@ -5,6 +5,7 @@ module Pages
     set_url '/locations{?postcode}'
 
     element :invalid_postcode, '.t-invalid-postcode'
+    element :empty_postcode_error, '.t-empty-postcode'
 
     sections :locations, '.t-location' do
       element :name, '.t-name'

--- a/features/step_definitions/location_steps.rb
+++ b/features/step_definitions/location_steps.rb
@@ -35,6 +35,10 @@ When(/^I search for appointment locations near to an invalid postcode$/) do
   Pages::Locations.new.load(postcode: postcode)
 end
 
+When(/^I search for appointment locations without entering a postcode$/) do
+  Pages::Locations.new.load(postcode: '')
+end
+
 When(/^I view the details of an appointment location that doesn't handle its own booking$/) do
   Pages::Location.new.load(id: 'paris')
 end
@@ -60,6 +64,10 @@ end
 
 Then(/^I should be informed that Pension Wise cannot find that postcode$/) do
   expect(Pages::Locations.new).to have_invalid_postcode
+end
+
+Then(/^I should be informed that I need to enter a postcode$/) do
+  expect(Pages::Locations.new).to have_empty_postcode_error
 end
 
 Then(/^I should see the details of that appointment location$/) do

--- a/features/step_definitions/location_steps.rb
+++ b/features/step_definitions/location_steps.rb
@@ -66,7 +66,7 @@ Then(/^I should be informed that Pension Wise cannot find that postcode$/) do
   expect(Pages::Locations.new).to have_invalid_postcode
 end
 
-Then(/^I should be informed that I need to enter a postcode$/) do
+Then(/^I am told to enter a valid postcode$/) do
   expect(Pages::Locations.new).to have_empty_postcode_error
 end
 

--- a/spec/controllers/locations_controller_spec.rb
+++ b/spec/controllers/locations_controller_spec.rb
@@ -11,9 +11,9 @@ RSpec.describe LocationsController, type: :controller do
     end
 
     specify 'with an empty postcode' do
-      get :index, params: { postcode: ' ' }
+      get :index, params: { postcode: '' }
 
-      expect(response).to render_template(:search)
+      expect(response).to render_template(:empty_postcode)
     end
 
     specify 'with an invalid postcode' do


### PR DESCRIPTION
<img width="600" alt="screen shot 2017-02-07 at 12 18 09" src="https://cloud.githubusercontent.com/assets/6049076/22690843/82a62750-ed2f-11e6-9d00-42c50ca88f5f.png">

If a user does not enter a postcode on face to face location
search then we show the location search again but include
a suitable error message to inform the user what they need
to do