### PR TITLE
Improve face-to-face appointment availability copy

### DIFF
--- a/app/views/booking_requests/completed.html.erb
+++ b/app/views/booking_requests/completed.html.erb
@@ -8,7 +8,7 @@
     your appointment.</p>
 
     <div class="application-notice info-notice">
-      <p>This is a new service. Appointment availability is limited depending on location.</p>
+      <p>Appointment availability depends on location. You may not get your requested dates. We may need to call you to arrange an alternative date.</p>
     </div>
 
     <p><a href="https://research.pensionwise.gov.uk/s/bookingfeedback/">Give us your feedback</a></p>

--- a/app/views/booking_requests/step_one.html.erb
+++ b/app/views/booking_requests/step_one.html.erb
@@ -49,11 +49,9 @@
         <%= f.select(:primary_slot, @booking_request.slots_for_calendar, { include_blank: "" }, { class: 'SlotPicker-input hide-only-with-js' }) %>
         <%= f.select(:secondary_slot, @booking_request.slots_for_calendar, { include_blank: "" }, { class: 'SlotPicker-input hide-only-with-js' }) %>
         <%= f.select(:tertiary_slot, @booking_request.slots_for_calendar, { include_blank: "" }, { class: 'SlotPicker-input hide-only-with-js' }) %>
-        <p>
-          <%= f.button('Continue', type: 'submit', class: 'button t-continue') %>
-        </p>
+        <p>Appointment availability depends on location. You may not get your requested dates. We may need to call you to arrange an alternative date.</p>
+        <p><%= f.button('Continue', type: 'submit', class: 'button t-continue') %></p>
       <% end %>
-      <p>This is a new service. Appointment availability is limited depending on location. We'll call or email to confirm an appointment date with you.</p>
     </div>
 
     <div class="l-column-half">


### PR DESCRIPTION
**Step One**
<img width="1038" alt="screen shot 2017-02-07 at 15 16 00" src="https://cloud.githubusercontent.com/assets/6049076/22697113/61b66910-ed48-11e6-80a7-a2dd2b84e660.png">

**Confirmation**
<img width="781" alt="screen shot 2017-02-07 at 15 16 47" src="https://cloud.githubusercontent.com/assets/6049076/22697137/77fabfbe-ed48-11e6-8a11-646827c4e0f2.png">

Customers have been complaining about not getting their
chosen date/times, this improves the copy and makes it
more prominent