### PR TITLE
Content changes to ineligible page

### DIFF
--- a/app/views/application/_ineligible.html.erb
+++ b/app/views/application/_ineligible.html.erb
@@ -1,0 +1,16 @@
+<div class="l-grid-row">
+  <div class="l-column-two-thirds">
+    <h1>Sorry, you’re unable to have an appointment</h1>
+
+    <p>You must be aged <strong>50 or over</strong> with a
+    <strong>defined contribution</strong> pension to have a Pension Wise appointment.</p>
+
+    <div role="note" aria-label="Information" class="application-notice info-notice">
+      <p>Pension Wise only provides guidance on defined contribution pensions. For help with defined benefit (final salary or career average) pensions go to <a rel="external" href="https://www.pensionsadvisoryservice.org.uk/">The Pensions Advisory Service</a>.</p>
+    </div>
+
+    <p>You can also find out what <a href="/pension-type-tool">type of pension</a> you have.</p>
+
+    <p><a href="https://research.pensionwise.gov.uk/s/bookingfeedback/">Give us your feedback</a></p>
+  </div>
+</div>

--- a/app/views/booking_requests/ineligible.html.erb
+++ b/app/views/booking_requests/ineligible.html.erb
@@ -1,20 +1,4 @@
-<div class="l-grid-row">
-  <div class="l-column-two-thirds">
-    <h1>Sorry, you’re unable to have an appointment</h1>
-
-    <p>You must be aged <strong>50 or over</strong> and have a
-    <strong>defined contribution</strong> pension.</p>
-
-  <div role="note" aria-label="Information" class="application-notice info-notice">
-    <p>Pension Wise only provides guidance on what you can do with a defined contribution pension. For guidance on a defined benefit pension go to <a rel="external" href="http://www.pensionsadvisoryservice.org.uk/">The Pensions Advisory Service</a>.</p>
-  </div>
-
-    <p>Find out more if you’re not sure what <a
-      href="/pension-types">type of pension</a> you have.</p>
-
-    <p><a href="https://research.pensionwise.gov.uk/s/bookingfeedback/">Give us your feedback</a></p>
-  </div>
-</div>
+<%= render partial: 'ineligible' %>
 
 <script>
   window.dataLayer = window.dataLayer || [];

--- a/app/views/telephone_appointments/ineligible.html.erb
+++ b/app/views/telephone_appointments/ineligible.html.erb
@@ -1,16 +1,2 @@
-<div class="l-grid-row">
-  <div class="l-column-two-thirds">
-    <h1>Sorry, you’re unable to have an appointment</h1>
+<%= render partial: 'ineligible' %>
 
-    <p>You must be aged <strong>50 or over</strong> and have a
-    <strong>defined contribution</strong> pension.</p>
-
-    <div role="note" aria-label="Information" class="application-notice info-notice">
-      <p>Pension Wise only provides guidance on what you can do with a defined contribution pension. For guidance on a defined benefit pension go to <a rel="external" href="https://www.pensionsadvisoryservice.org.uk/">The Pensions Advisory Service</a>.</p>
-    </div>
-
-    <p>Find out more if you’re not sure what <a href="/pension-types">type of pension</a> you have.</p>
-
-    <p><a href="https://research.pensionwise.gov.uk/s/bookingfeedback/">Give us your feedback</a></p>
-  </div>
-</div>


### PR DESCRIPTION
Improves the language (eg use of 'pension' singular sounded a bit odd)
and to add links to the pension type tool to hopefully help users
understand their pension type and therefore the reason they're
ineligible.

![screen shot 2017-02-10 at 14 10 52](https://cloud.githubusercontent.com/assets/41963/22829587/36a0c46e-ef9b-11e6-9955-38761c7be4bb.png)
