### PR TITLE
Update copy on telephone booking confirmation page

### DIFF
--- a/app/views/telephone_appointments/confirmation.html.erb
+++ b/app/views/telephone_appointments/confirmation.html.erb
@@ -1,17 +1,19 @@
-<h1>Your booking is confirmed</h1>
+<div class="l-grid-row">
+  <div class="l-column-two-thirds">
+    <h1>We’ve booked your appointment</h1>
 
-<p>Thank you for booking a guidance appointment with Pension Wise.</p>
+    <p>Thank you for booking a Pension Wise guidance appointment.</p>
 
-<p>Your reference number is <span class="t-booking-reference"><strong><%= @booking_reference %></strong></span> and one of our guidance specialists will call you on
-  <span class="t-start">
-    <strong>
-      <%= l(@booking_date, format: :govuk_date) %>
-    </strong>
-    at
-    <strong>
-      <%= l(@booking_date, format: :govuk_time) %>
-    </strong>
-  </span>
-</p>
+    <p><strong>Your reference number</strong><br>
+    <span class="t-booking-reference"><%= @booking_reference %></span></p>
 
-<p>You'll receive an email confirming these details and how to prepare for your appointment.</p>
+    <div class="t-start">
+      <p><strong>Date</strong><br><%= l(@booking_date, format: :govuk_date) %></p>
+      <p><strong>Time</strong><br><%= l(@booking_date, format: :govuk_time) %></p>
+    </div>
+
+    <p>We’ll email you to confirm these details. You’ll also receive information to help you prepare for your appointment.</p>
+
+    <p><a href="https://research.pensionwise.gov.uk/s/bookingfeedback/">Give us your feedback</a></p>
+  </div>
+</div>

--- a/features/step_definitions/telephone_booking_request_steps.rb
+++ b/features/step_definitions/telephone_booking_request_steps.rb
@@ -107,7 +107,8 @@ end
 Then(/^they see a confirmation of their appointment$/) do
   @page = Pages::TelephoneAppointmentConfirmation.new
   expect(@page.booking_reference).to have_text '123456'
-  expect(@page.start).to have_text '17 January 2017 at 12:20pm'
+  expect(@page.start).to have_text '17 January 2017'
+  expect(@page.start).to have_text '12:20pm'
 end
 
 When(/^the slot becomes unavailable while they are filling in their details$/) do


### PR DESCRIPTION
User research found that users were finding the page
ambiguous in terms of what they would receive in the
confirmation email and they would like to know the
details of their appointment in case the email
didn't reach them.

Switched to two thirds layout which is the same as
face to face booking request confirmation page

<img width="1066" alt="screen shot 2017-02-13 at 09 33 53" src="https://cloud.githubusercontent.com/assets/6049076/22878331/4ab06b66-f1d1-11e6-84d5-09a919f133d4.png">
