### PR TITLE
Add unique id for book appointment link

### DIFF
--- a/app/views/home/show.html.erb
+++ b/app/views/home/show.html.erb
@@ -5,7 +5,7 @@
 <% content_for(:canonical_path, '/') %>
 
 <div class="home-intro l-page-container">
-  <p class="home-intro__text">Phone <b>0800 138 3944</b> to <a href="/appointments">book a free appointment</a></p>
+  <p class="home-intro__text">Phone <b>0800 138 3944</b> to <a href="/appointments" id="book-appointment-home-link">book a free appointment</a></p>
 </div>
 
 <div class="l-grid-row l-home-row l-home-row--accent">

--- a/app/views/layouts/_two_column.erb
+++ b/app/views/layouts/_two_column.erb
@@ -15,7 +15,7 @@
       </div>
       <div class="l-column-third l-column-third--sidebar">
         <% if book_an_appointment_link? %>
-          <a href="/appointments" class="book-appointment">Book a free appointment</a>
+          <a href="/appointments" class="book-appointment" id="book-appointment-link">Book a free appointment</a>
         <% end %>
 
         <%= yield :sidebar %>


### PR DESCRIPTION
Analytics team have requested an easier way to target the book
appointment link at the top of the site.

Added a different ID for the homepage link to distingish between
homepage and other pages of the site

<img width="966" alt="screen shot 2017-02-14 at 11 02 18" src="https://cloud.githubusercontent.com/assets/6049076/22926610/30ea3cb4-f2a5-11e6-870d-9836183b6c01.png">
