### PR TITLE
Warn when a question is unanswered

### DIFF
--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -1,10 +1,14 @@
+# rubocop:disable Metrics/AbcSize, Lint/AssignmentInCondition
 class QuestionsController < ApplicationController
   skip_before_action :verify_authenticity_token
 
   def next
     question = GuideDecorator.cached_for(GuideRepository.new.find(params[:question_id]))
-    answer = question.metadata.answers[params[:response]]
 
-    redirect_to answer || "/#{params[:question_id]}"
+    if answer = question.metadata.answers[params[:response]]
+      redirect_to answer
+    else
+      redirect_to "/#{params[:question_id]}", alert: I18n.t('pension_type_tool.error')
+    end
   end
 end

--- a/app/repositories/guide_repository.rb
+++ b/app/repositories/guide_repository.rb
@@ -11,6 +11,10 @@ class GuideRepository
     @slugs ||= new.slugs
   end
 
+  def self.cacheable_slugs
+    slugs.reject { |s| /question-\d+\Z/ === s } # rubocop:disable Style/CaseEquality
+  end
+
   def initialize(dir = Rails.root.join('content'))
     self.dir = dir
   end

--- a/app/views/layouts/guides.html.erb
+++ b/app/views/layouts/guides.html.erb
@@ -1,5 +1,14 @@
 <%= render layout: 'layouts/two_column' do %>
   <article role="article" class="text">
+    <% if flash[:alert] %>
+      <div class="error-summary alert-alert" aria-labelledby="error-summary-heading" role="group">
+        <h1 class="heading-medium error-summary-heading" id="error-summary-heading"><%= t('pension_type_tool.error') %></h1>
+        <ul>
+          <li><%= link_to t('pension_type_tool.error'), '#question' %></li>
+        </ul>
+      </div>
+    <% end %>
+
     <%= yield %>
   </article>
 <% end %>

--- a/app/views/questions/_yes_no_dont_know_question.html.erb
+++ b/app/views/questions/_yes_no_dont_know_question.html.erb
@@ -1,7 +1,9 @@
 <form action="/questions" accept-charset="UTF-8" method="post">
   <input name="question_id" type="hidden" value="<%= id %>">
 
-  <%= header %>
+  <div id="question" tabindex="-1">
+    <%= header %>
+  </div>
 
   <div class="form-group">
     <label for="response_yes" class="block-label">

--- a/config/application.rb
+++ b/config/application.rb
@@ -30,7 +30,7 @@ module PensionGuidance
     config.middleware.insert_before(
       ActionDispatch::Cookies,
       Middleware::StripSessionCookie,
-      paths: GuideRepository.slugs
+      paths: GuideRepository.cacheable_slugs
     )
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,4 +1,6 @@
 en:
+  pension_type_tool:
+    error: 'Please answer the question to proceed'
 
   service:
     title: '%{page_title} - Pension Wise'

--- a/spec/features/questions_spec.rb
+++ b/spec/features/questions_spec.rb
@@ -14,6 +14,7 @@ RSpec.feature 'Questions', type: :feature do
       page.click_on 'Next step'
 
       expect(page.current_url).to match(guide.slug)
+      expect(page).to have_content(I18n.t('pension_type_tool.error'))
     end
   end
 


### PR DESCRIPTION
When the customer forgets to supply an answer on any of the pension type
tool questions we currently just redirect back, guarding them from
proceeding but without any explanatory text.

This change adds a flash warning message above the heading asking the
customer to complete and submit their answer correctly.

<img width="1098" alt="screen shot 2017-02-20 at 15 10 26" src="https://cloud.githubusercontent.com/assets/41963/23130540/ca8f7018-f77e-11e6-8f6a-d8e774e56953.png">
