### PR TITLE
Adding per page titles for each step of the telephone booking process

### DIFF
--- a/app/views/telephone_appointments/_step_1.html.erb
+++ b/app/views/telephone_appointments/_step_1.html.erb
@@ -1,3 +1,5 @@
+<% content_for(:page_title, t('service.title', page_title: 'Book a phone appointment')) %>
+
 <div class="l-column-full">
   <%= f.hidden_field :start_at, id: 'hidden_telephone_appointment_start_at_step_1' %>
   <%= render 'hidden_fields', f: f, id_prefix: 'step_1' %>

--- a/app/views/telephone_appointments/_step_2.html.erb
+++ b/app/views/telephone_appointments/_step_2.html.erb
@@ -1,4 +1,6 @@
-  <div class="l-column-half l-column-half--right">
-    <%= render 'hidden_fields', f: f, id_prefix: 'step_2' %>
-    <%= render 'times', times: @times %>
-  </div>
+<% content_for(:page_title, t('service.title', page_title: 'Choose a Time - Book a phone appointment')) %>
+
+<div class="l-column-half l-column-half--right">
+  <%= render 'hidden_fields', f: f, id_prefix: 'step_2' %>
+  <%= render 'times', times: @times %>
+</div>

--- a/app/views/telephone_appointments/_step_3.html.erb
+++ b/app/views/telephone_appointments/_step_3.html.erb
@@ -1,195 +1,197 @@
-  <div class="l-column-two-thirds">
-    <%= f.hidden_field :start_at, id: 'hidden_telephone_appointment_start_at_step_3' %>
+<% content_for(:page_title, t('service.title', page_title: 'Customer Details - Book a phone appointment')) %>
 
-    <h2 class="slot-picker-header">Your details</h2>
+<div class="l-column-two-thirds">
+  <%= f.hidden_field :start_at, id: 'hidden_telephone_appointment_start_at_step_3' %>
 
-    <div class="form-group <%= 'error' if @telephone_appointment.errors.include?(:first_name) %>">
-      <%= f.label :first_name, class: 'form-label' %>
-      <% if @telephone_appointment.errors.include?(:first_name) %>
-        <span class="error-message"><%= @telephone_appointment.errors[:first_name].to_sentence %></span>
-      <% end %>
-      <%= f.text_field :first_name, class: 't-first-name form-control' %>
-    </div>
+  <h2 class="slot-picker-header">Your details</h2>
 
-    <div class="form-group <%= 'error' if @telephone_appointment.errors.include?(:last_name) %>">
-      <%= f.label :last_name, class: 'form-label' %>
-      <% if @telephone_appointment.errors.include?(:last_name) %>
-        <span class="error-message"><%= @telephone_appointment.errors[:last_name].to_sentence %></span>
-      <% end %>
-      <%= f.text_field :last_name, class: 't-last-name form-control' %>
-    </div>
+  <div class="form-group <%= 'error' if @telephone_appointment.errors.include?(:first_name) %>">
+    <%= f.label :first_name, class: 'form-label' %>
+    <% if @telephone_appointment.errors.include?(:first_name) %>
+      <span class="error-message"><%= @telephone_appointment.errors[:first_name].to_sentence %></span>
+    <% end %>
+    <%= f.text_field :first_name, class: 't-first-name form-control' %>
+  </div>
 
-    <div class="form-group <%= 'error' if @telephone_appointment.errors.include?(:email) %>">
-      <%= f.label :email, class: 'form-label' do %>
-        Email
-        <span class="form-hint">We’ll send an email confirming your appointment date</span>
-      <% end %>
+  <div class="form-group <%= 'error' if @telephone_appointment.errors.include?(:last_name) %>">
+    <%= f.label :last_name, class: 'form-label' %>
+    <% if @telephone_appointment.errors.include?(:last_name) %>
+      <span class="error-message"><%= @telephone_appointment.errors[:last_name].to_sentence %></span>
+    <% end %>
+    <%= f.text_field :last_name, class: 't-last-name form-control' %>
+  </div>
 
-      <% if @telephone_appointment.errors.include?(:email) %>
-        <span class="error-message"><%= @telephone_appointment.errors[:email].to_sentence %></span>
-      <% end %>
+  <div class="form-group <%= 'error' if @telephone_appointment.errors.include?(:email) %>">
+    <%= f.label :email, class: 'form-label' do %>
+      Email
+      <span class="form-hint">We’ll send an email confirming your appointment date</span>
+    <% end %>
 
-      <%= f.email_field :email, class: 't-email form-control' %>
-    </div>
+    <% if @telephone_appointment.errors.include?(:email) %>
+      <span class="error-message"><%= @telephone_appointment.errors[:email].to_sentence %></span>
+    <% end %>
 
-    <div class="form-group <%= 'error' if @telephone_appointment.errors.include?(:phone) %>">
-      <%= f.label :phone, class: 'form-label' do %>
-        Phone number
-        <span class="form-hint">The number you’d like us to call you on</span>
-      <% end %>
+    <%= f.email_field :email, class: 't-email form-control' %>
+  </div>
 
-      <% if @telephone_appointment.errors.include?(:phone) %>
-        <span class="error-message"><%= @telephone_appointment.errors[:phone].to_sentence %></span>
-      <% end %>
+  <div class="form-group <%= 'error' if @telephone_appointment.errors.include?(:phone) %>">
+    <%= f.label :phone, class: 'form-label' do %>
+      Phone number
+      <span class="form-hint">The number you’d like us to call you on</span>
+    <% end %>
 
-      <%= f.text_field :phone, class: 't-phone form-control' %>
-    </div>
+    <% if @telephone_appointment.errors.include?(:phone) %>
+      <span class="error-message"><%= @telephone_appointment.errors[:phone].to_sentence %></span>
+    <% end %>
 
-    <div class="form-group <%= 'error' if @telephone_appointment.errors.include?(:memorable_word) %>">
-      <%= f.label :memorable_word, class: 'form-label' do %>
-        Your memorable word
-        <span class="form-hint">Our guidance specialist will repeat this word when they call so you know it’s us</span>
-      <% end %>
-      <% if @telephone_appointment.errors.include?(:memorable_word) %>
-        <span class="error-message"><%= @telephone_appointment.errors[:memorable_word].to_sentence %></span>
-      <% end %>
-      <%= f.text_field :memorable_word, class: 't-memorable-word form-control' %>
-    </div>
+    <%= f.text_field :phone, class: 't-phone form-control' %>
+  </div>
 
-    <div class="form-group <%= 'error' if @telephone_appointment.errors.include?(:date_of_birth) %>">
-      <fieldset>
-        <legend>
-          <span class="form-label-bold">
-            Date of birth
-          </span>
-          <span class="form-hint" id="dob-hint">You must be aged 50 or over to book an appointment, eg 31 3 1950</span>
-        </legend>
-        <div class="form-date">
-          <div class="form-group form-group-day">
-            <label class="form-label" for="<%= f.object_name %>_date_of_birth_day">Day</label>
-            <%=
-              f.number_field(
-                'date_of_birth_day',
-                id: "#{f.object_name}_date_of_birth_day",
-                use_label: false,
-                value: f.object.date_of_birth.try(:day),
-                placeholder: 'DD',
-                class: 'f-dob__input form-control js-dob-day t-date-of-birth-day',
-                pattern: '[0-9]*',
-                min: 1,
-                max: 31,
-                'aria-describedby': 'dob-hint'
-              )
-            %>
-          </div>
-          <div class="form-group form-group-month">
-            <label class="form-label" for="<%= f.object_name %>_date_of_birth_month">Month</label>
-            <%=
-              f.number_field(
-                'date_of_birth_month',
-                id: "#{f.object_name}_date_of_birth_month",
-                use_label: false,
-                value: f.object.date_of_birth.try(:month),
-                placeholder: 'MM',
-                class: 'form-dob__input form-control js-dob-month t-date-of-birth-month',
-                pattern: '[0-9]*',
-                min: 1,
-                max: 12
-              )
-            %>
-          </div>
-          <div class="form-group form-group-year">
-            <label class="form-label" for="<%= f.object_name %>_date_of_birth_year">Year</label>
-            <%=
-              f.number_field(
-                'date_of_birth_year',
-                id: "#{f.object_name}_date_of_birth_year",
-                use_label: false,
-                value: f.object.date_of_birth.try(:year),
-                placeholder: 'YYYY',
-                class: 'form-dob__input form-control form-dob__input--year js-dob-year t-date-of-birth-year',
-                pattern: '[0-9]*',
-                min: 120.years.ago.year,
-                max: Date.today.year
-              )
-            %>
-          </div>
+  <div class="form-group <%= 'error' if @telephone_appointment.errors.include?(:memorable_word) %>">
+    <%= f.label :memorable_word, class: 'form-label' do %>
+      Your memorable word
+      <span class="form-hint">Our guidance specialist will repeat this word when they call so you know it’s us</span>
+    <% end %>
+    <% if @telephone_appointment.errors.include?(:memorable_word) %>
+      <span class="error-message"><%= @telephone_appointment.errors[:memorable_word].to_sentence %></span>
+    <% end %>
+    <%= f.text_field :memorable_word, class: 't-memorable-word form-control' %>
+  </div>
+
+  <div class="form-group <%= 'error' if @telephone_appointment.errors.include?(:date_of_birth) %>">
+    <fieldset>
+      <legend>
+        <span class="form-label-bold">
+          Date of birth
+        </span>
+        <span class="form-hint" id="dob-hint">You must be aged 50 or over to book an appointment, eg 31 3 1950</span>
+      </legend>
+      <div class="form-date">
+        <div class="form-group form-group-day">
+          <label class="form-label" for="<%= f.object_name %>_date_of_birth_day">Day</label>
+          <%=
+            f.number_field(
+              'date_of_birth_day',
+              id: "#{f.object_name}_date_of_birth_day",
+              use_label: false,
+              value: f.object.date_of_birth.try(:day),
+              placeholder: 'DD',
+              class: 'f-dob__input form-control js-dob-day t-date-of-birth-day',
+              pattern: '[0-9]*',
+              min: 1,
+              max: 31,
+              'aria-describedby': 'dob-hint'
+            )
+          %>
         </div>
-        <% if @telephone_appointment.errors.include?(:date_of_birth) %>
-          <span class="error-message"><%= @telephone_appointment.errors[:date_of_birth].to_sentence %></span>
-        <% end %>
-      </fieldset>
-    </div>
-
-    <div class="form-group t-dc-pot-confirmed <%= 'error' if @telephone_appointment.errors.include?(:dc_pot_confirmed) %>">
-      <fieldset class="inline">
-        <legend>I have a defined contribution pension pot (<b>not</b> a final salary or career average pension)</legend>
-
-        <% if @telephone_appointment.errors.include?(:dc_pot_confirmed) %>
-          <span class="error-message"><%= @telephone_appointment.errors[:dc_pot_confirmed].to_sentence %></span>
-        <% end %>
-
-        <%= f.label :dc_pot_confirmed, value: 'yes', class: 'block-label' do %>
-            <%= f.radio_button :dc_pot_confirmed, 'yes' %>
-            Yes
-        <% end %>
-
-        <%= f.label :dc_pot_confirmed, value: 'no', class: 'block-label' do %>
-            <%= f.radio_button :dc_pot_confirmed, 'no', class: 't-dc-pot-confirmed-no' %>
-            No
-        <% end %>
-
-        <%= f.label :dc_pot_confirmed, value: 'not-sure', class: 'block-label' do %>
-          <%= f.radio_button :dc_pot_confirmed, 'not-sure' %>
-          Not sure
-        <% end %>
-      </fieldset>
-    </div>
-
-    <div class="form-group <%= 'error' if @telephone_appointment.errors.include?(:opt_out_of_market_research) %>">
-      <fieldset>
-        <legend>
-          <% if @telephone_appointment.errors.include?(:opt_in) %>
-            <span class="error-message"><%= @telephone_appointment.errors[:opt_out_of_market_research].to_sentence %></span>
-          <% end %>
-        </legend>
-        <%= f.label :opt_out_of_market_research, class: 'block-label selection-button-checkbox t-opt-in' do %>
-          <%= f.check_box :opt_out_of_market_research, class: 't-opt-out-of-market-research' %> Opt out of market research
-          <span class="form-hint">If you don't want us to contact you about your experience of our service</span>
-        <% end %>
-      </fieldset>
-    </div>
-
-    <div class="form-group <%= 'error' if @telephone_appointment.errors.include?(:accept_terms_and_conditions) %>">
-      <fieldset>
-        <legend>
-          Terms and conditions
-          <% if @telephone_appointment.errors.include?(:opt_in) %>
-            <span class="error-message"><%= @telephone_appointment.errors[:opt_in].to_sentence %></span>
-          <% end %>
-        </legend>
-        <%= f.label :accept_terms_and_conditions, class: 'block-label selection-button-checkbox t-opt-in' do %>
-          <%= f.check_box :accept_terms_and_conditions, class: 't-accept-terms-and-conditions' %> I accept the <a href="/privacy" target="_blank">terms and conditions</a>
-        <% end %>
-      </fieldset>
-    </div>
-
-    <div class="form-group">
-      <%= f.submit 'Confirm appointment', class: 'button t-submit', data: { disable_with: 'Please wait...' } %>
-    </div>
+        <div class="form-group form-group-month">
+          <label class="form-label" for="<%= f.object_name %>_date_of_birth_month">Month</label>
+          <%=
+            f.number_field(
+              'date_of_birth_month',
+              id: "#{f.object_name}_date_of_birth_month",
+              use_label: false,
+              value: f.object.date_of_birth.try(:month),
+              placeholder: 'MM',
+              class: 'form-dob__input form-control js-dob-month t-date-of-birth-month',
+              pattern: '[0-9]*',
+              min: 1,
+              max: 12
+            )
+          %>
+        </div>
+        <div class="form-group form-group-year">
+          <label class="form-label" for="<%= f.object_name %>_date_of_birth_year">Year</label>
+          <%=
+            f.number_field(
+              'date_of_birth_year',
+              id: "#{f.object_name}_date_of_birth_year",
+              use_label: false,
+              value: f.object.date_of_birth.try(:year),
+              placeholder: 'YYYY',
+              class: 'form-dob__input form-control form-dob__input--year js-dob-year t-date-of-birth-year',
+              pattern: '[0-9]*',
+              min: 120.years.ago.year,
+              max: Date.today.year
+            )
+          %>
+        </div>
+      </div>
+      <% if @telephone_appointment.errors.include?(:date_of_birth) %>
+        <span class="error-message"><%= @telephone_appointment.errors[:date_of_birth].to_sentence %></span>
+      <% end %>
+    </fieldset>
   </div>
-  <div class="l-column-third">
-    <h2 class="slot-picker-header">Your appointment</h2>
-    <p>You requested this date for your appointment</p>
-    <div class="slot-picker-confirmed-date">
-      <p class="slot-picker-confirmed-date__text"><b><%= l(@telephone_appointment.start_at, format: :govuk_date) %></b></p>
-      <p class="slot-picker-confirmed-date__text"><%= l(@telephone_appointment.start_at, format: :govuk_time) %>, 45 to 60 minutes</p>
-    </div>
 
-    <p><%= link_to('Change date/time', new_telephone_appointment_path) %></p>
+  <div class="form-group t-dc-pot-confirmed <%= 'error' if @telephone_appointment.errors.include?(:dc_pot_confirmed) %>">
+    <fieldset class="inline">
+      <legend>I have a defined contribution pension pot (<b>not</b> a final salary or career average pension)</legend>
 
-    <h2 class="slot-picker-header slot-picker-header--need-help">Need help?</h2>
+      <% if @telephone_appointment.errors.include?(:dc_pot_confirmed) %>
+        <span class="error-message"><%= @telephone_appointment.errors[:dc_pot_confirmed].to_sentence %></span>
+      <% end %>
 
-    <p>Phone <b>0800 138 3944</b> to speak to someone who can help book your free appointment.</p>
-    <p>Call between 8am to 10pm, every day</p>
+      <%= f.label :dc_pot_confirmed, value: 'yes', class: 'block-label' do %>
+          <%= f.radio_button :dc_pot_confirmed, 'yes' %>
+          Yes
+      <% end %>
+
+      <%= f.label :dc_pot_confirmed, value: 'no', class: 'block-label' do %>
+          <%= f.radio_button :dc_pot_confirmed, 'no', class: 't-dc-pot-confirmed-no' %>
+          No
+      <% end %>
+
+      <%= f.label :dc_pot_confirmed, value: 'not-sure', class: 'block-label' do %>
+        <%= f.radio_button :dc_pot_confirmed, 'not-sure' %>
+        Not sure
+      <% end %>
+    </fieldset>
   </div>
+
+  <div class="form-group <%= 'error' if @telephone_appointment.errors.include?(:opt_out_of_market_research) %>">
+    <fieldset>
+      <legend>
+        <% if @telephone_appointment.errors.include?(:opt_in) %>
+          <span class="error-message"><%= @telephone_appointment.errors[:opt_out_of_market_research].to_sentence %></span>
+        <% end %>
+      </legend>
+      <%= f.label :opt_out_of_market_research, class: 'block-label selection-button-checkbox t-opt-in' do %>
+        <%= f.check_box :opt_out_of_market_research, class: 't-opt-out-of-market-research' %> Opt out of market research
+        <span class="form-hint">If you don't want us to contact you about your experience of our service</span>
+      <% end %>
+    </fieldset>
+  </div>
+
+  <div class="form-group <%= 'error' if @telephone_appointment.errors.include?(:accept_terms_and_conditions) %>">
+    <fieldset>
+      <legend>
+        Terms and conditions
+        <% if @telephone_appointment.errors.include?(:opt_in) %>
+          <span class="error-message"><%= @telephone_appointment.errors[:opt_in].to_sentence %></span>
+        <% end %>
+      </legend>
+      <%= f.label :accept_terms_and_conditions, class: 'block-label selection-button-checkbox t-opt-in' do %>
+        <%= f.check_box :accept_terms_and_conditions, class: 't-accept-terms-and-conditions' %> I accept the <a href="/privacy" target="_blank">terms and conditions</a>
+      <% end %>
+    </fieldset>
+  </div>
+
+  <div class="form-group">
+    <%= f.submit 'Confirm appointment', class: 'button t-submit', data: { disable_with: 'Please wait...' } %>
+  </div>
+</div>
+<div class="l-column-third">
+  <h2 class="slot-picker-header">Your appointment</h2>
+  <p>You requested this date for your appointment</p>
+  <div class="slot-picker-confirmed-date">
+    <p class="slot-picker-confirmed-date__text"><b><%= l(@telephone_appointment.start_at, format: :govuk_date) %></b></p>
+    <p class="slot-picker-confirmed-date__text"><%= l(@telephone_appointment.start_at, format: :govuk_time) %>, 45 to 60 minutes</p>
+  </div>
+
+  <p><%= link_to('Change date/time', new_telephone_appointment_path) %></p>
+
+  <h2 class="slot-picker-header slot-picker-header--need-help">Need help?</h2>
+
+  <p>Phone <b>0800 138 3944</b> to speak to someone who can help book your free appointment.</p>
+  <p>Call between 8am to 10pm, every day</p>
+</div>

--- a/app/views/telephone_appointments/confirmation.html.erb
+++ b/app/views/telephone_appointments/confirmation.html.erb
@@ -1,3 +1,5 @@
+<% content_for(:page_title, t('service.title', page_title: 'Confirmation - Book a phone appointment')) %>
+
 <div class="l-grid-row">
   <div class="l-column-two-thirds">
     <h1>We’ve booked your appointment</h1>

--- a/app/views/telephone_appointments/ineligible.html.erb
+++ b/app/views/telephone_appointments/ineligible.html.erb
@@ -1,2 +1,4 @@
+<% content_for(:page_title, t('service.title', page_title: 'Ineligible - Book a phone appointment')) %>
+
 <%= render partial: 'ineligible' %>
 

--- a/app/views/telephone_appointments/new.html.erb
+++ b/app/views/telephone_appointments/new.html.erb
@@ -1,4 +1,3 @@
-<% content_for(:page_title, t('service.title', page_title: 'Book a phone appointment')) %>
 <div class="l-grid-row">
   <div class="l-column-full">
     <h1>Book a phone appointment</h1>


### PR DESCRIPTION
This will help the analytics team work out which page is being
served, for the purpose of seeing how far customers are getting in the
booking process.

At present both the time selection (non-js) and customer details form
are both being served at the URL '/telephone_appointments'.

Changing the page title helps the analytics team separate out
those different page view types.