### PR TITLE
Dasherise the TAP journey URLs

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,7 +35,7 @@ Rails.application.routes.draw do
       end
     end
 
-    resources :telephone_appointments do
+    resources :telephone_appointments, only: %i(new create), path: 'telephone-appointments' do
       collection do
         get :ineligible
         get :confirmation

--- a/features/pages/ineligible_for_appointment.rb
+++ b/features/pages/ineligible_for_appointment.rb
@@ -1,5 +1,5 @@
 module Pages
   class IneligibleForAppointment < SitePrism::Page
-    set_url '/telephone_appointments/ineligible'
+    set_url '/telephone-appointments/ineligible'
   end
 end

--- a/features/pages/new_telephone_appointment.rb
+++ b/features/pages/new_telephone_appointment.rb
@@ -1,6 +1,6 @@
 module Pages
   class NewTelephoneAppointment < SitePrism::Page
-    set_url '/telephone_appointments/new'
+    set_url '/telephone-appointments/new'
 
     element :first_name, '.t-first-name'
     element :last_name, '.t-last-name'


### PR DESCRIPTION
We favour dashes over underscores for customer-facing URIs.