### PR TITLE
Add unique URLs for book appointment links on home/guide pages

### DIFF
--- a/app/decorators/guide_decorator.rb
+++ b/app/decorators/guide_decorator.rb
@@ -5,6 +5,10 @@ class GuideDecorator < SimpleDelegator
     "/#{slug}"
   end
 
+  def ga_origin
+    "top-#{slug.split('/').last}"
+  end
+
   def title
     @title ||= headers.values.first
   end

--- a/app/views/home/show.html.erb
+++ b/app/views/home/show.html.erb
@@ -5,7 +5,7 @@
 <% content_for(:canonical_path, '/') %>
 
 <div class="home-intro l-page-container">
-  <p class="home-intro__text">Phone <b>0800 138 3944</b> to <a href="/appointments" id="book-appointment-home-link">book a free appointment</a></p>
+  <p class="home-intro__text">Phone <b>0800 138 3944</b> to <a href="/appointments?icn=book-appointment&amp;ici=top-homepage">book a free appointment</a></p>
 </div>
 
 <div class="l-grid-row l-home-row l-home-row--accent">
@@ -95,7 +95,7 @@
       <p>Our pension specialists are impartial – they don’t recommend products or companies and won’t tell you how to invest your money.</p>
 
       <p>Have your appointment over the phone or in person somewhere local to you.</p>
-      <p><a href="/appointments" class="button">Book a free appointment</a></p>
+      <p><a href="/appointments?icn=book-appointment&amp;ici=bottom-homepage" class="button">Book a free appointment</a></p>
       <p><a href="/pension-type-tool">Find out if you can book</a></p>
     </div>
   </div>

--- a/app/views/layouts/_two_column.erb
+++ b/app/views/layouts/_two_column.erb
@@ -15,7 +15,7 @@
       </div>
       <div class="l-column-third l-column-third--sidebar">
         <% if book_an_appointment_link? %>
-          <a href="/appointments" class="book-appointment" id="book-appointment-link">Book a free appointment</a>
+          <a href="/appointments<%= defined?(@guide) ? "?icn=book-appointment&ici=#{@guide.ga_origin}" : '' %>" class="book-appointment">Book a free appointment</a>
         <% end %>
 
         <%= yield :sidebar %>

--- a/content/adjustable_income.md
+++ b/content/adjustable_income.md
@@ -78,6 +78,6 @@ Beware of pension scams contacting you unexpectedly about an investment or busin
 - Get some estimates from other providers on how much your pot could grow and what the fees are – usually you just have to fill in a short form on their website.
 - Make sure you know [how much tax](/tax) you’ll pay on any money you’re planning to take out.
 
-**Book a [free Pension Wise appointment](/appointments) to find out more about what you can do with your pot.**
+**Book a [free Pension Wise appointment](/appointments?icn=book-appointment&amp;ici=bottom-adjustable-income) to find out more about what you can do with your pot.**
 
 </div>

--- a/content/guaranteed_income.md
+++ b/content/guaranteed_income.md
@@ -76,6 +76,6 @@ Beware of pension scams contacting you unexpectedly about an investment or busin
 - You can [shop around and compare providers](/shop-around) to get the best deal.
 - Understand [how much tax you’ll pay](/tax) on your annuity income.
 
-**Book a [free Pension Wise appointment](/appointments) to find out more about what you can do with your pot.**
+**Book a [free Pension Wise appointment](/appointments?icn=book-appointment&amp;ici=bottom-guaranteed-income) to find out more about what you can do with your pot.**
 
 </div>

--- a/content/leave_pot_untouched.md
+++ b/content/leave_pot_untouched.md
@@ -28,7 +28,7 @@ As with every investment the value of your pot could go up or down.
 
 ## Continuing to pay in
 
-You (and your employer) can continue to pay into your pot but there may be restrictions. 
+You (and your employer) can continue to pay into your pot but there may be restrictions.
 
 You usually pay tax if savings in your pension pots go above the [annual allowance](https://www.gov.uk/tax-on-your-private-pension/annual-allowance). This is currently £40,000 a year.
 
@@ -53,6 +53,6 @@ Ask your pension provider the following questions:
 - Does my pot have any special features that could mean I get a better deal, eg a guaranteed annuity rate?
 - Do you have up-to-date details of the person I want to leave my pot to (my ‘beneficiary’)?
 
-**Book a [free Pension Wise appointment](/appointments) to find out more about what you can do with your pot.**
+**Book a [free Pension Wise appointment](/appointments?icn=book-appointment&amp;ici=bottom-leave-pot-untouched) to find out more about what you can do with your pot.**
 
 </div>

--- a/content/mix_options.md
+++ b/content/mix_options.md
@@ -40,6 +40,6 @@ If you’re interested in mixing your options:
 - Look at all the options to see which ones are right for you
 - [Shop around](/shop-around) – you don’t have to get an adjustable income or buy an annuity from your current provider
 
-**Book a [free Pension Wise appointment](/appointments) to find out more about what you can do with your pot.**
+**Book a [free Pension Wise appointment](/appointments?icn=book-appointment&amp;ici=bottom-mix-options) to find out more about what you can do with your pot.**
 
 </div>

--- a/content/take_cash_in_chunks.md
+++ b/content/take_cash_in_chunks.md
@@ -67,6 +67,6 @@ Beware of [pension scams](/scams) contacting you unexpectedly about an investmen
 - Check if your pot has any special features that could mean you get a better deal, eg a guaranteed annuity rate.
 - Understand [how much tax](/tax) you’ll pay on any money you’re planning to take out.
 
-**Book a [free Pension Wise appointment](/appointments) to find out more about what you can do with your pot.**
+**Book a [free Pension Wise appointment](/appointments?icn=book-appointment&amp;ici=bottom-take-cash-in-chunks) to find out more about what you can do with your pot.**
 
 </div>

--- a/content/take_whole_pot.md
+++ b/content/take_whole_pot.md
@@ -47,6 +47,6 @@ Beware of [pension scams](/scams) contacting you unexpectedly about an investmen
 - Ask your provider if you can take 25% tax free.
 - If you want to reinvest the money, talk to a registered [financial adviser](/financial-advice) first.
 
-**Book a [free Pension Wise appointment](/appointments) to find out more about what you can do with your pot.**
+**Book a [free Pension Wise appointment](/appointments?icn=book-appointment&amp;ici=bottom-take-whole-pot) to find out more about what you can do with your pot.**
 
 </div>


### PR DESCRIPTION
Analytics team have requested we remove the ids previously added
to book appointment links and add unique tracking URLs which
will help them work out which book appointment link has been
clicked on a page.