### PR TITLE
Promotion of Pension Tool / Moving Book appointment links

### DIFF
--- a/content/adjustable_income.md
+++ b/content/adjustable_income.md
@@ -19,6 +19,8 @@ This option is also known as ‘flexi-access drawdown’.
 
 You’ll probably need to be involved in choosing and managing your investments. The value of your pot can go up or down.
 
+^Find out [if you can book](/pension-type-tool) a free Pension Wise appointment.^
+
 Not all pension providers offer this option. If your current provider doesn’t offer it, you can transfer your pot to another provider but you might have to pay a fee.
 
 {::calculator id="adjustable-income" /}
@@ -40,6 +42,8 @@ If you take the 25% tax-free lump sum, you must get an adjustable income with th
 You can move your pot gradually – you don’t have to move it all at once. Each time you move a sum, 25% is tax free.
 
 If you choose this option, you can leave your money to someone when you die but they may have to pay tax on it.
+
+^Book a [free Pension Wise appointment](/appointments?icn=book-appointment&amp;ici=bottom-adjustable-income) to find out more about what you can do with your pot.^
 
 ## How adjustable income works
 
@@ -77,7 +81,5 @@ Beware of pension scams contacting you unexpectedly about an investment or busin
 - [Shop around](/shop-around) – ask providers what products they offer to suit your circumstances.
 - Get some estimates from other providers on how much your pot could grow and what the fees are – usually you just have to fill in a short form on their website.
 - Make sure you know [how much tax](/tax) you’ll pay on any money you’re planning to take out.
-
-**Book a [free Pension Wise appointment](/appointments?icn=book-appointment&amp;ici=bottom-adjustable-income) to find out more about what you can do with your pot.**
 
 </div>

--- a/content/guaranteed_income.md
+++ b/content/guaranteed_income.md
@@ -15,7 +15,9 @@ You can use your pension pot to buy an insurance policy that gives you a guarant
 - You can take 25% of your pot as tax-free cash and buy an annuity with the other 75%.
 - You pay tax on your annuity income.
 
-^If you’re currently receiving a pension income it’s likely that you’ve already bought an annuity or are taking an income from a final salary or career average (defined benefit) pension.^
+If you’re currently receiving a pension income it’s likely that you’ve already bought an annuity or are taking an income from a final salary or career average (defined benefit) pension.
+
+^Find out [if you can book](/pension-type-tool) a free Pension Wise appointment.^
 
 {::calculator id="guaranteed-income" /}
 
@@ -61,7 +63,9 @@ You could then buy an annuity with the other 75%.
 
 You [pay tax on income from an annuity](/tax), just like you do on your salary. This is because when you’re paying into your pension you get tax relief on your contributions.
 
-^If you take the 25% tax-free lump sum you must buy an annuity with the rest or use one of the [other pension options](/pension-pot-options).^
+If you take the 25% tax-free lump sum you must buy an annuity with the rest or use one of the [other pension options](/pension-pot-options).
+
+^Book a [free Pension Wise appointment](/appointments?icn=book-appointment&amp;ici=bottom-guaranteed-income) to find out more about what you can do with your pot.^
 
 ## Scams
 Beware of pension scams contacting you unexpectedly about an investment or business opportunity that you’ve not spoken to them about before. You could lose all your money and face tax of up to 55% and extra fees.
@@ -75,7 +79,5 @@ Beware of pension scams contacting you unexpectedly about an investment or busin
 - Ask your provider about the types of annuity they offer, eg if you’re in poor health you could get a better rate.
 - You can [shop around and compare providers](/shop-around) to get the best deal.
 - Understand [how much tax you’ll pay](/tax) on your annuity income.
-
-**Book a [free Pension Wise appointment](/appointments?icn=book-appointment&amp;ici=bottom-guaranteed-income) to find out more about what you can do with your pot.**
 
 </div>

--- a/content/leave_pot_untouched.md
+++ b/content/leave_pot_untouched.md
@@ -20,6 +20,8 @@ You don’t pay tax while the money stays in your pot.
 
 Money you leave in your pot can be [passed on](/when-you-die) tax free if you die before the age of 75.
 
+^Find out [if you can book](/pension-type-tool) a free Pension Wise appointment.^
+
 ## Fees and investment risk
 
 You may be charged extra fees if you don't start taking your money when you reach your selected retirement age. Check with your provider.
@@ -33,6 +35,8 @@ You (and your employer) can continue to pay into your pot but there may be restr
 You usually pay tax if savings in your pension pots go above the [annual allowance](https://www.gov.uk/tax-on-your-private-pension/annual-allowance). This is currently £40,000 a year.
 
 {::calculator id="leave-pot-untouched" /}
+
+^Book a [free Pension Wise appointment](/appointments?icn=book-appointment&amp;ici=bottom-leave-pot-untouched) to find out more about what you can do with your pot.^
 
 ## Scams
 
@@ -52,7 +56,5 @@ Ask your pension provider the following questions:
 - How much can I still pay in?
 - Does my pot have any special features that could mean I get a better deal, eg a guaranteed annuity rate?
 - Do you have up-to-date details of the person I want to leave my pot to (my ‘beneficiary’)?
-
-**Book a [free Pension Wise appointment](/appointments?icn=book-appointment&amp;ici=bottom-leave-pot-untouched) to find out more about what you can do with your pot.**
 
 </div>

--- a/content/mix_options.md
+++ b/content/mix_options.md
@@ -15,6 +15,8 @@ You can mix the ways you take your pension pot.
 - Not all pension providers offer all the options.
 - If you have multiple pots, you can use different options for each pot, eg leave one pot untouched and take cash in chunks from another.
 
+^Find out [if you can book](/pension-type-tool) a free Pension Wise appointment.^
+
 {: .info-notice--mix-options}
 $E
 **Example**
@@ -30,6 +32,8 @@ $E
 
 Mixing your options can be complicated. If you’re interested in this you might want to talk to a [financial adviser](/financial-advice) first.
 
+^Book a [free Pension Wise appointment](/appointments?icn=book-appointment&amp;ici=bottom-mix-options) to find out more about what you can do with your pot.^
+
 {::options parse_block_html="true" /}
 <div class="next-steps next-steps--mix-options">
 
@@ -39,7 +43,5 @@ If you’re interested in mixing your options:
 
 - Look at all the options to see which ones are right for you
 - [Shop around](/shop-around) – you don’t have to get an adjustable income or buy an annuity from your current provider
-
-**Book a [free Pension Wise appointment](/appointments?icn=book-appointment&amp;ici=bottom-mix-options) to find out more about what you can do with your pot.**
 
 </div>

--- a/content/pension_statements.md
+++ b/content/pension_statements.md
@@ -6,30 +6,33 @@ description: Your pension statement shows your pension type, how much is in your
 
 You normally get one pension statement a year – your provider may call this your annual or yearly statement.
 
-Your statement shows how much is in your pot and usually an estimate of how much you might get when you start taking money from it.
+Your statement shows:
 
-^Knowing what’s in your pension statement will help when you come to [book a free appointment](/appointments) with a Pension Wise guidance specialist.^
+ - how much is in your pot
+ - an estimate of how much you might get when you start taking your money
+ - if your pension has any special features, eg guaranteed annuity rate
+ - your ‘selected retirement age’ (the age you agreed with your provider to retire)
+ - the ‘transfer value’ of your pot – the amount you would get if you moved provider or cashed in your whole pot
+ 
+ ## Your pension type
+ 
+Your statement should tell you if you have a defined contribution or a defined benefit pension – or you can [check which type of pension you have](/pension-type-tool).
 
-Your statement should tell you your [pension type](/pension-types) – defined contribution or defined benefit. It may also show if your pension has any special features like a guaranteed annuity rate.
-It should also include your ‘selected retirement age’ (the age you agreed with your provider to retire).
+If your statement shows a ‘total plan’ or ‘fund value’, it’s likely you have a defined contribution pension.
+
+^You can [book a free Pension Wise appointment](/appointments) if you have a defined contribution pension.^
+
+If it shows a pension value at retirement which is linked to your salary and length of service with an employer, it’s likely you have a defined benefit (final salary or career average) pension.
+
+^You can get help with final salary and career average pensions (defined benefit) at [The Pensions Advisory Service](http://www.pensionsadvisoryservice.org.uk)^
+
+Your statement may use the words ‘scheme’, ‘plan’ or ‘policy’ – this is your provider’s way of describing your pension.
 
 ## The State Pension
 
 You get a [State Pension](https://www.gov.uk/state-pension-statement) statement from the government.
 
 Read more about what’s in your [State Pension statement](https://www.gov.uk/government/publications/your-state-pension-statement-explained-dwp040) on GOV.UK.
-
-## What’s in your pot and your pension type
-
-If your statement shows a ‘total plan’ or ‘fund value’, it’s likely you have a defined contribution pension. This means you can book a Pension Wise appointment and get personal guidance on what you can do with your pot. If it shows a pension value at retirement which is linked to your salary and length of service with an employer, your pension type is likely to be final salary or career average (defined benefit).
-
-^You can get help with final salary and career average pensions (defined benefit) at [The Pensions Advisory Service](http://www.pensionsadvisoryservice.org.uk)^
-
-Your statement may use the words ‘scheme’, ‘plan’ or ‘policy’ – this is your provider’s way of describing your pension.
-
-### Transfer value
-
-Your statement will also normally show the ‘transfer value’ of your pot. This is the amount you would get if you moved provider or cashed in your whole pot.
 
 ## Special features
 

--- a/content/take_cash_in_chunks.md
+++ b/content/take_cash_in_chunks.md
@@ -18,9 +18,11 @@ Some pension providers charge a fee to take cash out.
 
 Not all providers offer this option. If your current provider doesn’t offer it, you can transfer your pot to another provider but you might have to pay a fee.
 
-%Taking a large sum of cash from your pot can mean you pay a higher amount of tax.%
+^Find out [if you can book](/pension-type-tool) a free Pension Wise appointment.^
 
 {::calculator id="take-cash-in-chunks" /}
+
+%Taking a large sum of cash from your pot can mean you pay a higher amount of tax.%
 
 ## Tax
 
@@ -42,6 +44,8 @@ You may pay emergency tax when you take money from your pot which you can claim 
 
 If your provider doesn’t pay your emergency tax back automatically, you can claim it back from
 HM Revenue and Customs.
+
+^Book a [free Pension Wise appointment](/appointments?icn=book-appointment&amp;ici=bottom-take-cash-in-chunks) to find out more about what you can do with your pot.^
 
 ## Continuing to pay in
 
@@ -66,7 +70,5 @@ Beware of [pension scams](/scams) contacting you unexpectedly about an investmen
 - If they don’t offer it, you can transfer your pot but you might be charged a fee.
 - Check if your pot has any special features that could mean you get a better deal, eg a guaranteed annuity rate.
 - Understand [how much tax](/tax) you’ll pay on any money you’re planning to take out.
-
-**Book a [free Pension Wise appointment](/appointments?icn=book-appointment&amp;ici=bottom-take-cash-in-chunks) to find out more about what you can do with your pot.**
 
 </div>

--- a/content/take_whole_pot.md
+++ b/content/take_whole_pot.md
@@ -16,9 +16,11 @@ You can take your whole pension pot as cash.
 
 You pay tax when you take money from your pot. This is because when you’re paying into your pension you get tax relief on your contributions.
 
-%Taking a large sum of cash from your pot can mean you pay a higher amount of tax.%
+^Find out [if you can book](/pension-type-tool) a free Pension Wise appointment.^
 
 {::calculator id="take-whole-pot" /}
+
+%Taking a large sum of cash from your pot can mean you pay a higher amount of tax.%
 
 ## Paying tax
 
@@ -30,6 +32,8 @@ You may pay emergency tax when you take money from your pot which you can claim 
 
 If your provider doesn’t pay your emergency tax back automatically, you can claim it back from
 HM Revenue and Customs.
+
+^Book a [free Pension Wise appointment](/appointments?icn=book-appointment&amp;ici=bottom-take-whole-pot) to find out more about what you can do with your pot.^
 
 ## Benefits
 
@@ -46,7 +50,5 @@ Beware of [pension scams](/scams) contacting you unexpectedly about an investmen
 
 - Ask your provider if you can take 25% tax free.
 - If you want to reinvest the money, talk to a registered [financial adviser](/financial-advice) first.
-
-**Book a [free Pension Wise appointment](/appointments?icn=book-appointment&amp;ici=bottom-take-whole-pot) to find out more about what you can do with your pot.**
 
 </div>


### PR DESCRIPTION
Added link to the pension type tool to all options pages and pension statements page to potentially increase click-through rate and conversion. Moved book appointment link from under next steps section of options pages to within body copy of pages to provide greater visibility.