### PR TITLE
Accommodate per-location slots for face-to-face

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,7 +74,7 @@ GEM
     babel-transpiler (0.7.0)
       babel-source (>= 4.0, < 6)
       execjs (~> 2.0)
-    booking_locations (0.8.0)
+    booking_locations (0.9.0)
       activesupport (>= 4, < 5.1)
       globalid
     bugsnag (5.2.0)

--- a/app/forms/booking_request_form.rb
+++ b/app/forms/booking_request_form.rb
@@ -47,7 +47,7 @@ class BookingRequestForm
   end
 
   def slots_for_calendar
-    @slots_for_calendar ||= booking_location.slots.map(&:to_calendar)
+    @slots_for_calendar ||= booking_location.location_for(location_id).slots.map(&:to_calendar)
   end
 
   def booking_location

--- a/features/customer_booking_request.feature
+++ b/features/customer_booking_request.feature
@@ -5,19 +5,28 @@ Feature: Customer creates a Booking Request
 
 Scenario: Customer browses an online booking enabled location
   Given a location is enabled for online booking
-  When I browse for the location
+  When I browse for the location "Hackney"
   Then I can book online
 
 Scenario: Customer browses a regular location
   Given no locations are enabled for online booking
-  When I browse for the location
+  When I browse for the location "Hackney"
   Then I cannot book online
+
+@javascript @booking_locations @booking_requests @time_travel
+Scenario: Customer books a closing location
+  Given a location is enabled for online booking
+  And the date is "2016-06-17"
+  When I browse for the location "Dalston"
+  And I opt to book online
+  Then I see the location name "Dalston"
+  And I see slots up to the day of closure
 
 @javascript @booking_locations @booking_requests @time_travel
 Scenario: Customer makes an online Booking Request
   Given a location is enabled for online booking
   And the date is "2016-06-17"
-  When I browse for the location
+  When I browse for the location "Hackney"
   And I opt to book online
   Then I see the location name "Hackney"
   When I choose three available appointment slots
@@ -30,7 +39,7 @@ Scenario: Customer makes an online Booking Request
 Scenario: Customer navigates between Booking Request steps
   Given a location is enabled for online booking
   And the date is "2016-06-17"
-  When I browse for the location
+  When I browse for the location "Hackney"
   And I opt to book online
   Then I see the location name "Hackney"
   When I choose three available appointment slots
@@ -46,7 +55,7 @@ Scenario: Customer navigates between Booking Request steps
 Scenario: Customer attempts an invalid Booking Request
   Given a location is enabled for online booking
   And the date is "2016-06-17"
-  When I browse for the location
+  When I browse for the location "Hackney"
   And I opt to book online
   And I choose one available appointment slot
   Then I am told to choose further slots
@@ -60,7 +69,7 @@ Scenario: Customer attempts an invalid Booking Request
 Scenario: Customer is ineligible for guidance
   Given a location is enabled for online booking
   And the date is "2016-06-17"
-  When I browse for the location
+  When I browse for the location "Hackney"
   And I opt to book online
   And I choose three available appointment slots
   And I provide my personal details
@@ -71,7 +80,7 @@ Scenario: Customer is ineligible for guidance
 Scenario: Customer leaves inline feedback
   Given a location is enabled for online booking
   And the date is "2016-06-17"
-  When I browse for the location
+  When I browse for the location "Hackney"
   And I opt to book online
   When I complete the inline feedback
   Then I see my feedback was sent

--- a/features/fixtures/locations_with_online_booking.json
+++ b/features/fixtures/locations_with_online_booking.json
@@ -19,6 +19,25 @@
         "hours": "Monday to Friday, 9:30am to 5pm",
         "online_booking_enabled": true
       }
+    },
+    {
+      "type": "Feature",
+      "id": "183080c6-642b-4b8f-96fd-891f5cd9f9c7",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -0.0552525,
+          51.5461062
+        ]
+      },
+      "properties": {
+        "title": "Dalston",
+        "address": "Dalston High Street\nDALSTON\nLondon\nE8 1HE",
+        "booking_location_id": "ac7112c3-e3cf-45cd-a8ff-9ba827b8e7ef",
+        "phone": "+442085256360",
+        "hours": "Monday to Friday, 9:30am to 5pm",
+        "online_booking_enabled": true
+      }
     }
   ]
 }

--- a/features/step_definitions/customer_booking_request_steps.rb
+++ b/features/step_definitions/customer_booking_request_steps.rb
@@ -11,10 +11,15 @@ Given(/^the date is (.*)$/) do |date|
   Timecop.travel @date
 end
 
-When(/^I browse for the location$/) do
+When(/^I browse for the location "([^"]*)"$/) do |location|
+  locations = {
+    'Hackney' => 'ac7112c3-e3cf-45cd-a8ff-9ba827b8e7ef',
+    'Dalston' => '183080c6-642b-4b8f-96fd-891f5cd9f9c7'
+  }
+
   with_booking_locations do
     @page = Pages::Location.new
-    @page.load(id: 'ac7112c3-e3cf-45cd-a8ff-9ba827b8e7ef')
+    @page.load(id: locations[location])
   end
 end
 
@@ -37,9 +42,13 @@ Then(/^I see the location name "(.*?)"$/) do |name|
   expect(@step_one.location_name.text).to include(name)
 end
 
+Then(/^I see slots up to the day of closure$/) do
+  expect(@step_one).to have_available_days(count: 1)
+end
+
 When(/^I view the face to face booking form$/) do
   step('a location is enabled for online booking')
-  step('I browse for the location')
+  step('I browse for the location "Hackney"')
   step('I opt to book online')
 end
 


### PR DESCRIPTION
We need to display per-location slots for face-to-face bookings due to
the upcoming location closures. These changes ensure the calendar is
bound to the chosen location's slots, not its booking location as
before.