### PR TITLE
Specifying that text is in welsh where appropriate

### DIFF
--- a/app/models/guide.rb
+++ b/app/models/guide.rb
@@ -24,6 +24,10 @@ class Guide
     tagged_with?('option')
   end
 
+  def welsh?
+    tagged_with?('welsh')
+  end
+
   def related_to_appointments?
     tagged_with?('appointments')
   end

--- a/app/views/guides/show.html.erb
+++ b/app/views/guides/show.html.erb
@@ -3,6 +3,6 @@
 
 <%= render 'option' if @guide.option? %>
 
-<%= @guide.content %>
+<%= @guide.welsh? ? content_tag(:div, @guide.content, lang: 'cy') : @guide.content %>
 
 <%= render 'journey_links' if @guide.related_to_journey? %>

--- a/app/views/layouts/_base.html.erb
+++ b/app/views/layouts/_base.html.erb
@@ -53,7 +53,7 @@
       <li><a href="/cookies">Cookies</a></li>
       <li><a href="/privacy">Privacy policy</a></li>
       <li><a href="/contact">Contact</a></li>
-      <li><a href="/cymraeg">Cymraeg</a></li>
+      <li><a href="/cymraeg" lang="cy">Cymraeg</a></li>
       <li><a href="http://gov.uk/help/accessibility/" rel="external">Accessibility</a></li>
       <li><a href="/customer-promise">Customer promise</a></li>
       <li><a href="/after-your-appointment" class="t-appointment-summary-link">After your appointment</a></li>

--- a/content/cymraeg.md
+++ b/content/cymraeg.md
@@ -1,3 +1,8 @@
+---
+tags:
+  - welsh
+---
+
 # Cymraeg
 
 Mae gwefan Pensionwise yn y broses o gael ei chyfieithu i'r Gymraeg.

--- a/spec/models/guide_spec.rb
+++ b/spec/models/guide_spec.rb
@@ -48,6 +48,14 @@ RSpec.describe Guide, type: :model do
     end
   end
 
+  describe '#welsh?' do
+    context 'when tagged with "welsh"' do
+      let(:tags) { %w(welsh) }
+
+      it { is_expected.to be_welsh }
+    end
+  end
+
   describe '#related_to_appointments?' do
     context 'when tagged with "appointments"' do
       let(:tags) { %w(appointments) }


### PR DESCRIPTION
This aids speech synthesis tools to determine what pronunciations to use,
and translation tools to determine what rules to use.