### PR TITLE
Disallow spidering of /telephone-appointments/ URLs

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -10,3 +10,4 @@ Disallow: /home-alternative
 Disallow: /pension-type-tool/
 Disallow: /facebook-landing
 Disallow: /landing
+Disallow: /telephone-appointments/


### PR DESCRIPTION
As we are rolling out booking a telephone appointment online
as a private beta, we don't want the form to be searchable
just yet.