### PR TITLE
Be more exact on which pages to disallow of the pension type tool

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -7,7 +7,14 @@ Disallow: /signposting/
 Disallow: /leave-pot-untouched/estimate
 Disallow: /take-whole-pot/estimate
 Disallow: /home-alternative
-Disallow: /pension-type-tool/
+Disallow: /pension-type-tool/question-2
+Disallow: /pension-type-tool/question-3
+Disallow: /pension-type-tool/question-4
+Disallow: /pension-type-tool/question-4
+Disallow: /pension-type-tool/defined-contribution
+Disallow: /pension-type-tool/might-defined-contribution
+Disallow: /pension-type-tool/most-cases-defined-benefit
+Disallow: /pension-type-tool/most-cases-defined-contribution
 Disallow: /facebook-landing
 Disallow: /landing
 Disallow: /telephone-appointments/


### PR DESCRIPTION
There is no reason why we shouldn't allow search engines to spider
the starting/introduction page of the pension type tool and the
page for the first question.

Anything further into the tool itself should be disallowed as it
requires the first question to be answered first.