### PR TITLE
Correct call out copy

### DIFF
--- a/content/pension_type_tool/might_defined_contribution.md
+++ b/content/pension_type_tool/might_defined_contribution.md
@@ -12,6 +12,6 @@ These are sometimes known as ‘money purchase’ pensions. The amount you get d
 
 There are different ways you can take your defined contribution pension pot. You can book a free [Pension Wise appointment](/appointments) to find out more.
 
-^If you have more than one pension, you may also have a defined contribution pension – [check another pension](/pension-type-tool).^
+^You can also [check another pension](/pension-type-tool).^
 
 {::feedback_form /}


### PR DESCRIPTION
Corrected call out copy - didn't make sense in context of the answer.