### PR TITLE
Include TPAS phone number on online telephone booking confirmation page

### DIFF
--- a/app/views/telephone_appointments/confirmation.html.erb
+++ b/app/views/telephone_appointments/confirmation.html.erb
@@ -16,6 +16,8 @@
 
     <p>We’ll email you to confirm these details. You’ll also receive information to help you prepare for your appointment.</p>
 
+    <p>To cancel or change your appointment, or if any of the information above isn’t correct, call <strong>0800 138 3944</strong>.</p>
+
     <p><a href="https://research.pensionwise.gov.uk/s/bookingfeedback/">Give us your feedback</a></p>
   </div>
 </div>


### PR DESCRIPTION
After the latest round of the user research lab we found that we need
to place the call centre number on the online telephone booking
confirmation page in case the customer needs to get in touch regarding
the details of the appointment.