### PR TITLE
Cache booking locations with redis store

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,4 +73,5 @@ end
 
 group :staging, :production do
   gem 'rails_12factor'
+  gem 'redis-rails', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -268,6 +268,22 @@ GEM
     rainbow (2.2.1)
     rake (12.0.0)
     redis (3.3.3)
+    redis-actionpack (5.0.1)
+      actionpack (>= 4.0, < 6)
+      redis-rack (>= 1, < 3)
+      redis-store (>= 1.1.0, < 1.4.0)
+    redis-activesupport (5.0.1)
+      activesupport (>= 3, < 6)
+      redis-store (~> 1.2.0)
+    redis-rack (2.0.0)
+      rack (~> 2.0)
+      redis-store (~> 1.2.0)
+    redis-rails (5.0.1)
+      redis-actionpack (~> 5.0.0)
+      redis-activesupport (~> 5.0.0)
+      redis-store (~> 1.2.0)
+    redis-store (1.2.0)
+      redis (>= 2.2)
     rgeo (0.5.3)
     rgeo-geojson (0.4.3)
       rgeo (~> 0.5)
@@ -424,6 +440,7 @@ DEPENDENCIES
   rails-controller-testing
   rails_12factor
   redis
+  redis-rails
   rgeo
   rgeo-geojson
   rspec-rails

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,3 +1,5 @@
+require 'redis-rails'
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
@@ -58,7 +60,7 @@ Rails.application.configure do
   # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
 
   # Use a different cache store in production.
-  config.cache_store = :memory_store
+  config.cache_store = :redis_store
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   config.action_controller.asset_host = ENV['ASSET_HOST']


### PR DESCRIPTION
Using the redis store instead of the memory store means the cache
survives app restarts and is shared across however many web processes
we are using. This is favourable to each web process maintaining its
own in-memory cache.