### PR TITLE
Improvements to pension tool journey

### DIFF
--- a/content/appointments.md
+++ b/content/appointments.md
@@ -16,13 +16,13 @@ Your appointment will last around 45 to 60 minutes and we will:
 
 You can speak to us over the phone or face to face somewhere local to you.
 
-[Book a phone appointment](/book-phone){: .button #phone-button style="font-size: 0.9em; padding-left: 2em; padding-right: 2em;"}
-[Book a face-to-face appointment](/book-face-to-face){: .button #face-to-face-button style="font-size: 0.9em;"}
-
 ## Before you book
 
-You should be aged **50 or over** and have a **defined contribution** pension. This is a pension based on how much you and possibly your employer paid into your pot. It’s not a final salary pension.
+You should be aged **50 or over** and have a **defined contribution** pension (not a final salary or career average pension).
 
 [Not sure what pension type you have?](/pension-type-tool)
+
+[Book a phone appointment](/book-phone){: .button #phone-button style="font-size: 0.9em; padding-left: 2em; padding-right: 2em;"}
+[Book a face-to-face appointment](/book-face-to-face){: .button #face-to-face-button style="font-size: 0.9em;"}
 
 ^Our guidance is impartial – we won’t recommend any products or companies and won’t tell you how to invest your money.^

--- a/content/pension_type_tool/defined_contribution.md
+++ b/content/pension_type_tool/defined_contribution.md
@@ -10,7 +10,11 @@ tags:
 
 These are sometimes known as ‘money purchase’ pensions. The amount you get depends on how much was paid in and how well the investments have done.
 
-There are different ways you can take your defined contribution pension pot. You can book a free [Pension Wise appointment](/appointments) to find out more.
+You choose how to take money from your pension pot. 
+
+You can book a free Pension Wise appointment to talk about your options for taking your money.
+
+[Book a free appointment](/appointments){: .button}
 
 ^You can also [check another pension](/pension-type-tool).^
 

--- a/content/pension_type_tool/might_defined_contribution.md
+++ b/content/pension_type_tool/might_defined_contribution.md
@@ -10,7 +10,11 @@ tags:
 
 These are sometimes known as ‘money purchase’ pensions. The amount you get depends on how much was paid in and how well the investments have done.
 
-There are different ways you can take your defined contribution pension pot. You can book a free [Pension Wise appointment](/appointments) to find out more.
+You choose how to take money from your pension pot. 
+
+You can book a free Pension Wise appointment to talk about your options for taking your money.
+
+[Book a free appointment](/appointments){: .button}
 
 ^You can also [check another pension](/pension-type-tool).^
 

--- a/content/pension_type_tool/most_cases_defined_contribution.md
+++ b/content/pension_type_tool/most_cases_defined_contribution.md
@@ -10,7 +10,11 @@ tags:
 
 These are sometimes known as ‘money purchase’ pensions. The amount you get depends on how much was paid in and how well the investments have done.
 
-There are different ways you can take your defined contribution pension pot. You can book a free [Pension Wise appointment](/appointments) to find out more.
+You choose how to take money from your pension pot. 
+
+You can book a free Pension Wise appointment to talk about your options for taking your money.
+
+[Book a free appointment](/appointments){: .button}
 
 ^You can also [check another pension](/pension-type-tool).^
 


### PR DESCRIPTION
Given more prominence to pension tool on /appointments page to help users 'self-diagnose' before booking. Added green start buttons to pension tool answer pages to help make booking an appointment stand out more.