### PR TITLE
Alter the Calendar for F2F to have a max-height instead of height

### DIFF
--- a/app/assets/stylesheets/vendor/_slot-picker.scss
+++ b/app/assets/stylesheets/vendor/_slot-picker.scss
@@ -78,4 +78,9 @@
 .SlotPicker-timeSlots {
   margin-bottom: -5px;
 }
+
+.BookingCalendar-mask {
+  height: auto;
+  max-height: 279px;
+}
 // scss-lint:enable SelectorFormat


### PR DESCRIPTION
In order to deal with the fact that some locations are closing,
the calendar is starting to show less than a month's worth of
days, which has caused a visual issue with the calendar design.

This change introduces a max-height instead of a fixed height
so the calendar can get smaller

**Before**
<img width="523" alt="screen shot 2017-03-08 at 16 33 03" src="https://cloud.githubusercontent.com/assets/6049076/23713181/ffd1f7f0-041c-11e7-8704-9347c44881cb.png">

**After**
<img width="512" alt="screen shot 2017-03-08 at 16 33 16" src="https://cloud.githubusercontent.com/assets/6049076/23713192/05a15b8a-041d-11e7-893b-5c21320a8131.png">
