### PR TITLE
Alter headers in footer of site to H2s / Guider sidebar to <aside>

### DIFF
--- a/app/assets/stylesheets/components/_footer-categories.scss
+++ b/app/assets/stylesheets/components/_footer-categories.scss
@@ -12,6 +12,14 @@
       margin: 0 30px;
     }
   }
+
+  h2 {
+    @include bold-19;
+
+    @include media(tablet) {
+      margin: 0 15px;
+    }
+  }
 }
 
 .footer-categories {

--- a/app/views/appointment_summaries/create.html.erb
+++ b/app/views/appointment_summaries/create.html.erb
@@ -39,14 +39,14 @@
 </script>
 
 <% content_for :sticky_sidebar do %>
-  <div class="l-sticky-sidebar">
+  <aside class="l-sticky-sidebar">
     <div class="sticky-sidebar js-sticky-sidebar sticky-sidebar--appointment-summary">
       <div class="sidebar-hr"></div>
       <div class="sticky-sidebar__nav">
         <% headers.each do |id, text| %>
-          <h2 class="sticky-sidebar__heading">
+          <span class="sticky-sidebar__heading">
             <%= link_to text, "##{id}", class: 't-aside--heading' %>
-          </h2>
+          </span>
         <% end %>
 
         <ul class="sticky-sidebar__list nav">
@@ -63,7 +63,7 @@
         </ul>
       </div>
     </div>
-  </div>
+  </aside>
 <% end %>
 
 <% content_for :after_script do %>

--- a/app/views/components/_footer_categories.html.erb
+++ b/app/views/components/_footer_categories.html.erb
@@ -1,7 +1,7 @@
 <div class="footer-categories t-footer-categories">
   <% categories.each do |category| %>
     <div class="footer-categories__<%= category.items.size.humanize %>-column t-footer-category">
-      <h3 class="footer-categories__heading t-footer-category-header"><%= category.label %></h3>
+      <h2 class="footer-categories__heading t-footer-category-header"><%= category.label %></h2>
 
       <% category.items.each do |item| %>
 

--- a/app/views/guides/_option.html.erb
+++ b/app/views/guides/_option.html.erb
@@ -1,12 +1,12 @@
 <% content_for :sticky_sidebar do %>
-  <div class="l-sticky-sidebar">
+  <aside class="l-sticky-sidebar">
     <div class="sticky-sidebar js-sticky-sidebar sticky-sidebar--<%= @guide.slug %>">
       <div class="sidebar-hr"></div>
       <div class="sticky-sidebar__nav">
         <% @guide.headers.each do |id, text| %>
-          <h2 class="sticky-sidebar__heading">
+          <span class="sticky-sidebar__heading">
             <%= link_to text, "##{id}", class: 't-aside--heading' %>
-          </h2>
+          </span>
         <% end %>
 
         <ul class="sticky-sidebar__list nav">
@@ -24,7 +24,7 @@
         </ul>
       </div>
     </div>
-  </div>
+  </aside>
 <% end %>
 
 <% content_for :after_script do %>


### PR DESCRIPTION
The headers in the footer are better placed to be `H2`s as a descendant of the main header of the page (`H1`).

As `H3`s they ended up being a sub header of a random section of content which they were completely unrelated to.

Alter guide sidebar to be an `<aside>` element to aid screen readers.

Removes H2 header from the guider page right column as it is a repeat of the H1 of the page, and adds confusion.

**Example Document outline after change**
<img width="747" alt="screen shot 2017-03-09 at 13 53 59" src="https://cloud.githubusercontent.com/assets/6049076/23753044/e1b0ddb4-04cf-11e7-9930-d9be8b400d98.png">
