### PR TITLE
Updated allowance figures

### DIFF
--- a/content/adjustable_income.md
+++ b/content/adjustable_income.md
@@ -57,7 +57,9 @@ If your provider goes bust you’ll be covered by the [Financial Services Compen
 
 ## Continue to pay in
 
-If you have more than one pension pot, you can take an adjustable income from one and continue to pay into others. The maximum you can pay in is £10,000 a year. This includes your tax relief of 20%. For example, to get a contribution of £10,000 you would only have to pay in £8,000.
+If you have more than one pension pot, you can take an adjustable income from one and continue to pay into others. The maximum you can pay in is £10,000 a year (changing to £4,000 a year from 6 April 2017).
+
+This includes your tax relief of 20%. For example, to get a contribution of £10,000 you would only have to pay in £8,000.
 
 You may still be able to pay into the pot you take your adjustable income from but you won’t get tax relief on these payments.
 

--- a/content/take_cash_in_chunks.md
+++ b/content/take_cash_in_chunks.md
@@ -49,7 +49,9 @@ HM Revenue and Customs.
 
 ## Continuing to pay in
 
-If you have more than one pension pot, you can take chunks of cash from one and continue to pay into others. The maximum you can pay in is £10,000 a year. This includes your tax relief of 20%. For example, to get a contribution of £10,000 you would only have to pay in £8,000.
+If you have more than one pension pot, you can take chunks of cash from one and continue to pay into others. The maximum you can pay in is £10,000 a year (changing to £4,000 a year from 6 April 2017). 
+
+This includes your tax relief of 20%. For example, to get a contribution of £10,000 you would only have to pay in £8,000.
 
 Your provider may also let you continue to pay into the pot you take cash from.
 

--- a/content/work_out_income.md
+++ b/content/work_out_income.md
@@ -108,7 +108,9 @@ There’s a limit to how much you can pay into your pot and still get tax relief
 
 If you have more than one pot, you can continue to pay into a pot after you start to take money from another.
 
-The amount you can pay in drops to a maximum of £10,000 a year once you start taking money from a pot. This includes your [tax relief](https://www.gov.uk/tax-on-your-private-pension/pension-tax-relief) of 20%. For example, to get a contribution of £10,000 you would only have to pay in £8,000.
+The amount you can pay in drops to a maximum of £10,000 a year once you start taking money from a pot (changing to £4,000 a year from 6 April 2017).
+
+This includes your [tax relief](https://www.gov.uk/tax-on-your-private-pension/pension-tax-relief) of 20%. For example, to get a contribution of £10,000 you would only have to pay in £8,000.
 
 You may still be able to pay into the pot you take money from but you won’t get tax relief on these payments.
 


### PR DESCRIPTION
Changes to the money purchase annual allowance figure. New figure of £4,000 replacing £10,000 from 6 April. Policy have requested we inform users about this in advance.
