### PR TITLE
Correct steps line-height to match height of circle

### DIFF
--- a/app/assets/stylesheets/components/govspeak/_steps.scss
+++ b/app/assets/stylesheets/components/govspeak/_steps.scss
@@ -32,7 +32,7 @@
       font-weight: 600;
       height: 24px;
       left: 0;
-      line-height: 25px;
+      line-height: 24px;
       position: absolute;
       text-align: center;
       top: .75em;


### PR DESCRIPTION
This ensures the text is vertical centered correctly