### PR TITLE
Temporarily redirect due to broken GTM link

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,6 +43,8 @@ Rails.application.routes.draw do
       end
     end
 
+    get '/telephone_appointments/new', to: redirect('/telephone-appointments/new', status: 301)
+
     resource :feedback, only: [:create, :new] do
       get :thanks
     end


### PR DESCRIPTION
We've accidentally used the wrong link in GTM so this redirect covers
that until we get it resolved over there.