### PR TITLE
Survive refreshes using query string parameters

### DIFF
--- a/app/controllers/telephone_appointments_controller.rb
+++ b/app/controllers/telephone_appointments_controller.rb
@@ -16,8 +16,8 @@ class TelephoneAppointmentsController < ApplicationController
   end
 
   def confirmation
-    @booking_reference = flash[:booking_reference]
-    @booking_date      = Time.zone.parse(flash[:booking_date])
+    @booking_reference = params[:booking_reference]
+    @booking_date      = Time.zone.parse(params[:booking_date])
   end
 
   private
@@ -52,12 +52,9 @@ class TelephoneAppointmentsController < ApplicationController
   end
 
   def confirm_to_customer(telephone_appointment)
-    redirect_to(
-      confirmation_telephone_appointments_path,
-      flash: {
-        booking_reference: telephone_appointment.id,
-        booking_date: telephone_appointment.start_at
-      }
+    redirect_to confirmation_telephone_appointments_path(
+      booking_reference: telephone_appointment.id,
+      booking_date: telephone_appointment.start_at
     )
   end
 


### PR DESCRIPTION
The confirmation page was relying on flash parameters being set by the
referring action, when customers refreshed the page their session would
generally be expired and an error would occur.

Passing these values along with the query string works around the issue.