### PR TITLE
Fix a timing issue in the booking feature

### DIFF
--- a/features/step_definitions/customer_booking_request_steps.rb
+++ b/features/step_definitions/customer_booking_request_steps.rb
@@ -43,6 +43,8 @@ Then(/^I see the location name "(.*?)"$/) do |name|
 end
 
 Then(/^I see slots up to the day of closure$/) do
+  @step_one.wait_for_available_days
+
   expect(@step_one).to have_available_days(count: 1)
 end
 


### PR DESCRIPTION
We need to explicitly wait for the slots to be bound here before
asserting on their presence.