### PR TITLE
Check fields are valid before ineligible

### DIFF
--- a/app/controllers/telephone_appointments_controller.rb
+++ b/app/controllers/telephone_appointments_controller.rb
@@ -39,10 +39,10 @@ class TelephoneAppointmentsController < ApplicationController
   end
 
   def create_step_3
-    if telephone_appointment.ineligible?
-      redirect_to ineligible_telephone_appointments_path
-    elsif telephone_appointment.invalid?
+    if telephone_appointment.invalid?
       render :new
+    elsif telephone_appointment.ineligible?
+      redirect_to ineligible_telephone_appointments_path
     elsif telephone_appointment.save
       confirm_to_customer(telephone_appointment)
     else


### PR DESCRIPTION
Prior to this change we were overzealously checking eligibility
regardless whether the fields needed to determine these facts were
supplied by the customer.

This simple change just checks the values are valid before applying the
eligibility rules.