### PR TITLE
Check F2F fields are valid before ineligible

### DIFF
--- a/app/controllers/booking_requests_controller.rb
+++ b/app/controllers/booking_requests_controller.rb
@@ -17,13 +17,13 @@ class BookingRequestsController < ApplicationController
   def complete
     @feedback = FeedbackForm.for_online_booking
 
-    if @booking_request.step_two_valid?
+    if @booking_request.step_two_invalid?
+      render :step_two
+    elsif @booking_request.ineligible?
+      redirect_to booking_request_ineligible_location_path(id: location_id)
+    else
       BookingRequests.create(@booking_request)
       redirect_to booking_request_completed_location_path(id: location_id)
-    else
-      return redirect_to booking_request_ineligible_location_path(id: location_id) unless @booking_request.eligible?
-
-      render :step_two
     end
   end
 

--- a/app/forms/booking_request_form.rb
+++ b/app/forms/booking_request_form.rb
@@ -3,7 +3,7 @@ class BookingRequestForm
 
   attr_accessor :location_id, :primary_slot, :secondary_slot, :tertiary_slot,
                 :first_name, :last_name, :email, :telephone_number,
-                :memorable_word, :appointment_type, :accessibility_requirements,
+                :memorable_word, :accessibility_requirements,
                 :date_of_birth, :opt_in, :dc_pot
 
   with_options if: :step_one? do |step_one|
@@ -18,10 +18,9 @@ class BookingRequestForm
     step_two.validates :email, presence: true, email: true
     step_two.validates :telephone_number, presence: true
     step_two.validates :memorable_word, presence: true
-    step_two.validates :appointment_type, inclusion: { in: %w(50-54 55-plus) }, if: :date_of_birth
     step_two.validates :accessibility_requirements, inclusion: { in: %w(0 1) }
     step_two.validates :opt_in, acceptance: { accept: '1' }
-    step_two.validates :dc_pot, inclusion: { in: %w(yes not-sure) }
+    step_two.validates :dc_pot, inclusion: { in: %w(yes no not-sure) }
     step_two.validates :date_of_birth, presence: true
   end
 
@@ -70,10 +69,18 @@ class BookingRequestForm
     valid?
   end
 
-  def eligible?
-    return true if step_two_valid?
+  def step_two_invalid?
+    !step_two_valid?
+  end
 
-    (errors.keys & %i(appointment_type dc_pot)).empty?
+  def eligible?
+    return unless step_two_valid?
+
+    age >= 50 && dc_pot != 'no'
+  end
+
+  def ineligible?
+    !eligible?
   end
 
   def step_one?

--- a/features/customer_booking_request.feature
+++ b/features/customer_booking_request.feature
@@ -73,6 +73,7 @@ Scenario: Customer is ineligible for guidance
   And I opt to book online
   And I choose three available appointment slots
   And I provide my personal details
+  And I provide ineligible details
   When I submit my completed Booking Request
   Then I am told I am ineligible for guidance
 

--- a/features/step_definitions/customer_booking_request_steps.rb
+++ b/features/step_definitions/customer_booking_request_steps.rb
@@ -99,6 +99,13 @@ When(/^I pass the basic eligibility requirements$/) do
   @step_two.check_hidden_radio(@step_two.dc_pot_yes)
 end
 
+When(/^I provide ineligible details$/) do
+  @step_two.date_of_birth_day.set '01'
+  @step_two.date_of_birth_month.set '01'
+  @step_two.date_of_birth_year.set '2010'
+  @step_two.check_hidden_radio(@step_two.dc_pot_yes)
+end
+
 When(/^I submit my completed Booking Request$/) do
   @step_two.submit.click
 end

--- a/spec/forms/booking_request_form_spec.rb
+++ b/spec/forms/booking_request_form_spec.rb
@@ -61,7 +61,6 @@ RSpec.describe BookingRequestForm do
         subject.date_of_birth = '2010-01-01'
 
         expect(subject.appointment_type).to eq('under-50')
-        expect(subject).not_to be_step_two_valid
         expect(subject).not_to be_eligible
       end
 

--- a/spec/lib/booking_requests/api_mapper_spec.rb
+++ b/spec/lib/booking_requests/api_mapper_spec.rb
@@ -14,8 +14,7 @@ RSpec.describe BookingRequests::ApiMapper do
       email: 'lucius@example.com',
       telephone_number: '0208 244 3987',
       memorable_word: 'meseeks',
-      appointment_type: '55-plus',
-      date_of_birth: '1950-01-01',
+      date_of_birth: '1951-01-01',
       accessibility_requirements: false,
       opt_in: false,
       dc_pot: 'yes'
@@ -35,7 +34,7 @@ RSpec.describe BookingRequests::ApiMapper do
           phone: '0208 244 3987',
           memorable_word: 'meseeks',
           age_range: '55-plus',
-          date_of_birth: '1950-01-01',
+          date_of_birth: '1951-01-01',
           accessibility_requirements: false,
           marketing_opt_in: false,
           defined_contribution_pot_confirmed: true,


### PR DESCRIPTION
Prior to this change we were overzealously checking eligibility
regardless whether the fields needed to determine these facts were
supplied by the customer.

This simple change just checks the values are valid before applying the
eligibility rules.