### PR TITLE
Expose an API for clearing booking locations

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,7 +82,7 @@ GEM
     babel-transpiler (0.7.0)
       babel-source (>= 4.0, < 6)
       execjs (~> 2.0)
-    booking_locations (0.9.1)
+    booking_locations (0.12.0)
       activesupport (>= 4, < 5.1)
       globalid
     bugsnag (5.2.0)

--- a/app/controllers/locations_cache_controller.rb
+++ b/app/controllers/locations_cache_controller.rb
@@ -1,0 +1,24 @@
+class LocationsCacheController < ActionController::Base
+  before_action :token_authenticate
+
+  def destroy
+    BookingLocations.clear_cache
+
+    head :no_content
+  end
+
+  private
+
+  def token_authenticate
+    authenticate_or_request_with_http_token do |token|
+      ActiveSupport::SecurityUtils.secure_compare(
+        ::Digest::SHA256.hexdigest(token),
+        ::Digest::SHA256.hexdigest(locations_cache_token)
+      )
+    end
+  end
+
+  def locations_cache_token
+    ENV.fetch('LOCATIONS_CACHE_TOKEN')
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,8 @@ Rails.application.routes.draw do
   root 'home#show'
 
   constraints format: 'html' do
+    delete '/locations_cache', to: 'locations_cache#destroy'
+
     resources :categories, only: 'show', path: 'browse'
 
     get '/book', to: redirect('/appointments', status: 302)

--- a/spec/requests/locations_cache_sweeper_api_spec.rb
+++ b/spec/requests/locations_cache_sweeper_api_spec.rb
@@ -1,0 +1,71 @@
+require 'securerandom'
+require 'booking_locations/stub_api'
+
+RSpec.describe 'DELETE /cache', type: :request do
+  scenario 'unauthorised access' do
+    when_the_client_makes_an_unauthorised_request
+    then_the_service_responds_with_a_401
+  end
+
+  scenario 'expiring the locations cache entries' do
+    with_stubbed_booking_locations do
+      given_various_cache_entries_exist
+      when_the_client_makes_the_request
+      then_only_the_cached_locations_are_expired
+      and_the_service_responds_with_a_204
+    end
+  end
+
+  def when_the_client_makes_an_unauthorised_request
+    ENV['LOCATIONS_CACHE_TOKEN'] = 'welp'
+    token = ActionController::HttpAuthentication::Token.encode_credentials('deadbeef')
+
+    delete locations_cache_path, headers: { 'HTTP_AUTHORIZATION' => token }
+  end
+
+  def then_the_service_responds_with_a_401
+    expect(response).to be_unauthorized
+  end
+
+  def given_various_cache_entries_exist
+    @location_cache_key = 'ac7112c3-e3cf-45cd-a8ff-9ba827b8e7ef'
+    # this will cause a cache miss / write
+    BookingLocations.find(@location_cache_key)
+
+    @other_cache_keys = %w(boop snoot).each do |cache_key|
+      Rails.cache.write(cache_key, '...')
+    end
+  end
+
+  def when_the_client_makes_the_request
+    ENV['LOCATIONS_CACHE_TOKEN'] = 'deadbeef'
+    token = ActionController::HttpAuthentication::Token.encode_credentials('deadbeef')
+
+    delete locations_cache_path, headers: { 'HTTP_AUTHORIZATION' => token }
+  end
+
+  def then_only_the_cached_locations_are_expired
+    expect(Rails.cache.fetch(@location_cache_key)).to be_nil
+
+    @other_cache_keys.each do |cache_key|
+      expect(Rails.cache.fetch(cache_key)).to be_present
+    end
+  end
+
+  def and_the_service_responds_with_a_204
+    expect(response).to be_no_content
+  end
+
+  def with_stubbed_booking_locations
+    cache = Rails.cache
+    api   = BookingLocations.api
+
+    BookingLocations.api = BookingLocations::StubApi.new
+    Rails.cache = ActiveSupport::Cache::MemoryStore.new
+
+    yield
+  ensure
+    BookingLocations.api = api
+    Rails.cache = cache
+  end
+end


### PR DESCRIPTION
We need a way of remotely triggering a cache flush when booking
locations change structurely. This change adds an API endpoint, with
simple token based authentication. We are not using SSO here since this
application is not backed by a persistent store - a requirement for
GDS-SSO and signon integration.

A request issued to `DELETE /locations_cache` with the correct
authorisation token will sweep the cached locations and leave
non-prefixed (anything other than our locations) entries as-is.