### PR TITLE
Cache page navigation elements

### DIFF
--- a/app/views/components/_page_nav.html.erb
+++ b/app/views/components/_page_nav.html.erb
@@ -1,3 +1,5 @@
-<div class="l-page-nav">
-  <%= render 'components/nav' %>
-</div>
+<% cache 'page_nav', expires_in: 2.hours do %>
+  <div class="l-page-nav">
+    <%= render 'components/nav' %>
+  </div>
+<% end %>


### PR DESCRIPTION
This navigation was aggressively cacheable and was taking on average
around 40% of the total time to render the page. Once rendered it is
completely static and changes very, very rarely.

This change caches the fragment for an arbitrary two hours.

From the results below (in development mode on my laptop) you can see
the response time drop from ~500ms to ~300ms.

Before:

```
Started GET "/" for ::1 at 2017-03-17 19:57:28 +0000
Processing by HomeController#show as HTML
  Rendering home/show.html.erb within layouts/home
  Rendered home/show.html.erb within layouts/home (1.6ms)
  Rendered components/_logo_link.html.erb (1.2ms)
  Rendered feedbacks/_form.html.erb (3.6ms)
  Rendered feedbacks/_feedback_form.html.erb (11.7ms)
  Rendered calculators/_form_input_currency.html.erb (1.3ms)
  Rendered calculators/_form_input_currency.html.erb (3.3ms)
  Rendered calculators/_form_input_currency.html.erb (0.5ms)
  Rendered calculators/_form_input_submit.html.erb (0.7ms)
  Rendered calculators/take_cash_in_chunks/_form.html.erb (37.2ms)
  Rendered components/_nav.html.erb (211.3ms)
  Rendered components/_page_nav.html.erb (212.8ms)
  Rendering /govuk_template-0.19.2/app/views/layouts/govuk_template.html.erb
  Rendered /govuk_template-0.19.2/app/views/layouts/govuk_template.html.erb (25.5ms)
  Rendered layouts/_base.html.erb (453.5ms)
Completed 200 OK in 462ms (Views: 459.2ms)
```

After:

```
Started GET "/" for ::1 at 2017-03-17 19:45:01 +0000
Processing by HomeController#show as HTML
  Rendering home/show.html.erb within layouts/home
  Rendered home/show.html.erb within layouts/home (1.0ms)
  Rendered components/_logo_link.html.erb (1.3ms)
Read fragment views/page_nav/e572a494d6b505a4da344fc885fa0971 (0.1ms)
  Rendered components/_page_nav.html.erb (3.0ms)
  Rendering /govuk_template-0.19.2/app/views/layouts/govuk_template.html.erb
  Rendered /govuk_template-0.19.2/app/views/layouts/govuk_template.html.erb (24.2ms)
  Rendered layouts/_base.html.erb (289.2ms)
Completed 200 OK in 295ms (Views: 293.6ms)
```