### PR TITLE
Ensure locations are cached correctly

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,7 +82,7 @@ GEM
     babel-transpiler (0.7.0)
       babel-source (>= 4.0, < 6)
       execjs (~> 2.0)
-    booking_locations (0.12.0)
+    booking_locations (0.13.0)
       activesupport (>= 4, < 5.1)
       globalid
     bugsnag (5.2.0)


### PR DESCRIPTION
This addresses the bug with prefixing in `booking_locations`.