### PR TITLE
Format single line output with lograge

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,6 +72,7 @@ group :test do
 end
 
 group :staging, :production do
+  gem 'lograge'
   gem 'rails_12factor'
   gem 'redis-rails', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -190,6 +190,10 @@ GEM
       activemodel (>= 3.0)
       activesupport (>= 3.0)
     log4r (1.1.10)
+    lograge (0.4.1)
+      actionpack (>= 4, < 5.1)
+      activesupport (>= 4, < 5.1)
+      railties (>= 4, < 5.1)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.4)
@@ -429,6 +433,7 @@ DEPENDENCIES
   jasmine-jquery-rails
   jasmine-rails
   launchy
+  lograge
   newrelic_rpm
   nokogiri
   output-templates (~> 4.4.5)!

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   include Breadcrumbs
+  include LogrageFilterer
 
   protect_from_forgery with: :exception
 

--- a/app/controllers/locations_cache_controller.rb
+++ b/app/controllers/locations_cache_controller.rb
@@ -1,4 +1,6 @@
 class LocationsCacheController < ActionController::Base
+  include LogrageFilterer
+
   before_action :token_authenticate
 
   def destroy

--- a/app/controllers/lograge_filterer.rb
+++ b/app/controllers/lograge_filterer.rb
@@ -1,0 +1,8 @@
+module LogrageFilterer
+  protected
+
+  def append_info_to_payload(payload)
+    super
+    payload[:params] = request.filtered_parameters
+  end
+end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,7 +1,17 @@
 require 'redis-rails'
 
+EXCEPTIONS = %w(controller action format id).freeze
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
+
+  # Use lograge in the single-line heroku router style
+  config.lograge.enabled = true
+  config.lograge.custom_options = lambda do |event|
+    {
+      params: event.payload[:params].except(*EXCEPTIONS)
+    }
+  end
 
   # Code is not reloaded between requests.
   config.cache_classes = true


### PR DESCRIPTION
Reduce logging into a single line format to avoid interleaving of
requests.