### PR TITLE
Add book online button to phone page

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,8 +45,6 @@ Rails.application.routes.draw do
       end
     end
 
-    get '/telephone_appointments/new', to: redirect('/telephone-appointments/new', status: 301)
-
     resource :feedback, only: [:create, :new] do
       get :thanks
     end

--- a/content/book_phone.md
+++ b/content/book_phone.md
@@ -4,12 +4,13 @@ tags:
   - appointments
   - booking
 ---
-
 # How to book a phone appointment
 
-Phone **0800 138 3944**.
+[Book online](/telephone-appointments/new){: .button #phone-button style="font-size: 0.9em; padding-left: 2em; padding-right: 2em;"}
 
-If you’re outside the UK phone +44 20 3733 3495.
+or call **0800 138 3944**.
+
+If you’re outside the UK, call +44 20 3733 3495.
 
 - Call between 8am to 10pm, every day
 - We’ll send you an email to confirm your booking


### PR DESCRIPTION
After a successful trial of adding the online booking button to the `book-phone` page, this will add the button permanently to the page - thus officially launching online telephone booking 🎉 

<img width="600" alt="screen shot 2017-03-27 at 09 39 26" src="https://cloud.githubusercontent.com/assets/6049076/24347748/4c9745a0-12d1-11e7-9814-2986065a6a58.png">
