### PR TITLE
Precompile assets in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ cache:
   - node_modules
   - tmp/cache/assets/test
   - vendor/assets/bower_components
+  - tmp/cache/assets/sprockets
 env:
   global:
   - PATH=$PWD/bin:$PATH
@@ -21,6 +22,7 @@ before_script:
 - "(cd .downloads; [ -d prince-9.0r5-linux-amd64-static ] || curl -s http://www.princexml.com/download/prince-9.0r5-linux-amd64-static.tar.gz | tar xzf -)"
 - echo $PWD | ./.downloads/prince-9.0r5-linux-amd64-static/install.sh
 - npm install
+- bundle exec rails assets:precompile RAILS_ENV=test
 notifications:
   slack:
     secure: AAOOmT8WC2VhlOAyxthZdbJlnpShzgo6HAOH+jyivKdgS5Na+GuNtEY45g5GCjBv7rlf8q+ZyG4tOwgnQ3ylB9f85B1HcGol+qnhs/0T787XjRVTOgPj6k2iFLUlwOBHhPE4oxpjXz6vp+gaqL5BlU4nYqG185tOp/SK/V3SWW8=

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -45,4 +45,7 @@ Rails.application.configure do
 
   # Disable caching. All cache reads and writes result in a cache miss.
   config.cache_store = :null_store
+
+  # Precompile in travis to resolve poltergeist timeouts
+  config.assets.compile = ENV['TRAVIS'] ? false : true
 end


### PR DESCRIPTION
This should mitigate those issues where poltergeist times out on the
first 'JS' request due to JIT asset compilation.