### PR TITLE
Ensure content is cached with a TTL

### DIFF
--- a/app/decorators/cached_guide_decorator.rb
+++ b/app/decorators/cached_guide_decorator.rb
@@ -1,15 +1,16 @@
 class CachedGuideDecorator < SimpleDelegator
-  attr_accessor :cache
+  attr_accessor :cache, :expires_in
 
-  def initialize(decorator, cache)
+  def initialize(decorator, cache, expires_in = Rails.application.config.cache_max_age)
     __setobj__(decorator)
     self.cache = cache
+    self.expires_in = expires_in
   end
 
   %i(title content).each do |method|
     define_method(method) do
       cache_key = "#{__getobj__.id}-#{method}"
-      cache.fetch(cache_key) { super() }
+      cache.fetch(cache_key, expires_in: expires_in) { super() }
     end
   end
 end

--- a/spec/decorators/cached_guide_decorator_spec.rb
+++ b/spec/decorators/cached_guide_decorator_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe CachedGuideDecorator do
   subject(:cached_decorator) { described_class.new(decorator, cache) }
 
   describe '#title' do
-    it 'uses the correct cache key' do
-      expect(cache).to receive(:fetch).with("#{id}-#{title}")
+    it 'uses the correct cache key and expiration' do
+      expect(cache).to receive(:fetch).with("#{id}-#{title}", expires_in: 10)
       cached_decorator.title
     end
 
@@ -48,8 +48,8 @@ RSpec.describe CachedGuideDecorator do
   end
 
   describe '#content' do
-    it 'uses the correct cache key' do
-      expect(cache).to receive(:fetch).with("#{id}-#{content}")
+    it 'uses the correct cache key and expiration' do
+      expect(cache).to receive(:fetch).with("#{id}-#{content}", expires_in: 10)
       cached_decorator.content
     end
 


### PR DESCRIPTION
Up to now content items were being cached indefinitely. This was not a
problem when we were configured to use the memory store that wouldn't
survive application restarts but is now we use an out-of-process cache
store via Redis. This change ensures we respect the TTL on content
items.