### PR TITLE
Remove feedback link from pension type tool answer pages

### DIFF
--- a/content/pension_type_tool/defined_contribution.md
+++ b/content/pension_type_tool/defined_contribution.md
@@ -10,12 +10,10 @@ tags:
 
 These are sometimes known as ‘money purchase’ pensions. The amount you get depends on how much was paid in and how well the investments have done.
 
-You choose how to take money from your pension pot. 
+You choose how to take money from your pension pot.
 
 You can book a free Pension Wise appointment to talk about your options for taking your money.
 
 [Book a free appointment](/appointments){: .button}
 
 ^You can also [check another pension](/pension-type-tool).^
-
-{::feedback_form /}

--- a/content/pension_type_tool/might_defined_contribution.md
+++ b/content/pension_type_tool/might_defined_contribution.md
@@ -10,12 +10,10 @@ tags:
 
 These are sometimes known as ‘money purchase’ pensions. The amount you get depends on how much was paid in and how well the investments have done.
 
-You choose how to take money from your pension pot. 
+You choose how to take money from your pension pot.
 
 You can book a free Pension Wise appointment to talk about your options for taking your money.
 
 [Book a free appointment](/appointments){: .button}
 
 ^You can also [check another pension](/pension-type-tool).^
-
-{::feedback_form /}

--- a/content/pension_type_tool/most_cases_defined_benefit.md
+++ b/content/pension_type_tool/most_cases_defined_benefit.md
@@ -10,9 +10,7 @@ tags:
 
 Pension Wise only gives guidance on defined contribution pensions.
 
-For guidance on defined benefit pensions go to the [The Pensions Advisory Service](http://www.pensionsadvisoryservice.org.uk) 
+For guidance on defined benefit pensions go to the [The Pensions Advisory Service](http://www.pensionsadvisoryservice.org.uk)
 – for the State Pension go to the [Pension Service](https://www.gov.uk/contact-pension-service).
 
 ^If you have more than one pension, you may also have a defined contribution pension – [check another pension](/pension-type-tool).^
-
-{::feedback_form /}

--- a/content/pension_type_tool/most_cases_defined_contribution.md
+++ b/content/pension_type_tool/most_cases_defined_contribution.md
@@ -10,12 +10,10 @@ tags:
 
 These are sometimes known as ‘money purchase’ pensions. The amount you get depends on how much was paid in and how well the investments have done.
 
-You choose how to take money from your pension pot. 
+You choose how to take money from your pension pot.
 
 You can book a free Pension Wise appointment to talk about your options for taking your money.
 
 [Book a free appointment](/appointments){: .button}
 
 ^You can also [check another pension](/pension-type-tool).^
-
-{::feedback_form /}


### PR DESCRIPTION
In preparation of adding a smart survey to the answer pages
of the pension type tool, Product have asked us to remove
the feedback links as it will confuse users.

<img width="659" alt="screen shot 2017-04-03 at 10 33 15" src="https://cloud.githubusercontent.com/assets/6049076/24603507/f7cf29e2-1858-11e7-89fb-c2a8162e926b.png">
