### PR TITLE
Standardise page titles across booking journeys

### DIFF
--- a/app/views/booking_requests/completed.html.erb
+++ b/app/views/booking_requests/completed.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:page_title, t('service.title', page_title: 'We’ve received your booking request')) %>
 <div class="l-grid-row">
   <div class="l-column-two-thirds">
     <h1>We’ve received your booking request</h1>

--- a/app/views/booking_requests/ineligible.html.erb
+++ b/app/views/booking_requests/ineligible.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:page_title, t('service.title', page_title: 'Sorry, you’re unable to have an appointment')) %>
 <%= render partial: 'ineligible', locals: { telephone: false } %>
 
 <script>

--- a/app/views/telephone_appointments/_step_2.html.erb
+++ b/app/views/telephone_appointments/_step_2.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title, t('service.title', page_title: 'Choose a Time - Book a phone appointment')) %>
+<% content_for(:page_title, t('service.title', page_title: 'Choose a Time')) %>
 
 <div class="l-column-half l-column-half--right">
   <%= render 'hidden_fields', f: f, id_prefix: 'step_2' %>

--- a/app/views/telephone_appointments/_step_3.html.erb
+++ b/app/views/telephone_appointments/_step_3.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title, t('service.title', page_title: 'Customer Details - Book a phone appointment')) %>
+<% content_for(:page_title, t('service.title', page_title: 'Your details')) %>
 
 <div class="l-column-two-thirds">
   <%= f.hidden_field :start_at, id: 'hidden_telephone_appointment_start_at_step_3' %>

--- a/app/views/telephone_appointments/confirmation.html.erb
+++ b/app/views/telephone_appointments/confirmation.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title, t('service.title', page_title: 'Confirmation - Book a phone appointment')) %>
+<% content_for(:page_title, t('service.title', page_title: 'Confirmation')) %>
 
 <div class="l-grid-row">
   <div class="l-column-two-thirds">

--- a/app/views/telephone_appointments/ineligible.html.erb
+++ b/app/views/telephone_appointments/ineligible.html.erb
@@ -1,3 +1,3 @@
-<% content_for(:page_title, t('service.title', page_title: 'Ineligible - Book a phone appointment')) %>
+<% content_for(:page_title, t('service.title', page_title: 'Sorry, you’re unable to have an appointment')) %>
 
 <%= render partial: 'ineligible', locals: { telephone: true } %>


### PR DESCRIPTION
Some titles were missing on pages on the booking journey.
They were also inconsistent between telephone and face to face
so this addresses that too.