### PR TITLE
Improve wording on face to face search results page

### DIFF
--- a/app/views/locations/index.html.erb
+++ b/app/views/locations/index.html.erb
@@ -2,7 +2,7 @@
 
 <h1>Appointment locations near <%= @postcode.squish.upcase %></h1>
 
-<p>These are the <%= @locations.length %> locations nearest to <%= @postcode.squish.upcase %>.</p>
+<p>There are <%= @locations.length %> locations near to <%= @postcode.squish.upcase %>.</p>
 
 <ol class="location-list">
   <% @locations.each do |location| %>


### PR DESCRIPTION
Feedback from DWP content team suggested the wording could
be improved.

<img width="931" alt="screen shot 2017-04-06 at 14 49 58" src="https://cloud.githubusercontent.com/assets/6049076/24757893/77cd570a-1ad8-11e7-95ea-602a818f94a9.png">
