### PR TITLE
Call centre opening time changed

### DIFF
--- a/app/views/telephone_appointments/_step_3.html.erb
+++ b/app/views/telephone_appointments/_step_3.html.erb
@@ -199,5 +199,5 @@
   <h2 class="slot-picker-header slot-picker-header--need-help">Need help?</h2>
 
   <p>Phone <b>0800 138 3944</b> to speak to someone who can help book your free appointment.</p>
-  <p>Call between 8am to 10pm, every day</p>
+  <p>Call between 8am to 8pm, Monday to Friday</p>
 </div>

--- a/content/book_face_to_face.md
+++ b/content/book_face_to_face.md
@@ -1,5 +1,5 @@
 ---
-description: Call 0300 330 1001 between 8am to 10pm, every day.
+description: Find an appointment location near you.
 tags:
   - appointments
   - booking

--- a/content/book_phone.md
+++ b/content/book_phone.md
@@ -1,5 +1,5 @@
 ---
-description: Call 0800 138 3944 between 8am to 10pm, every day.
+description: Call 0800 138 3944 between 8am to 8pm, Monday to Friday.
 tags:
   - appointments
   - booking
@@ -12,7 +12,7 @@ or call **0800 138 3944**.
 
 If you’re outside the UK, call +44 20 3733 3495.
 
-- Call between 8am to 10pm, every day
+- Call between 8am to 8pm, Monday to Friday
 - We’ll send you an email to confirm your booking
 
 [Find out about call charges](https://www.gov.uk/call-charges)


### PR DESCRIPTION
As part of the new agreement the opening times for the call centre to
book Pension Wise appointment is now 8am - 8pm Monday to Friday.

The new times will need to be reflected on the website where shown.