### PR TITLE
Make confirmation pages for both booking journeys consistent with govuk

### DIFF
--- a/app/assets/stylesheets/components/_govuk-box-highlight.scss
+++ b/app/assets/stylesheets/components/_govuk-box-highlight.scss
@@ -1,0 +1,6 @@
+.govuk-box-highlight__header {
+  @include media(tablet) {
+    margin-top: 0;
+    margin-bottom: 16px;
+  }
+}

--- a/app/views/booking_requests/completed.html.erb
+++ b/app/views/booking_requests/completed.html.erb
@@ -1,9 +1,11 @@
 <% content_for(:page_title, t('service.title', page_title: 'We’ve received your booking request')) %>
 <div class="l-grid-row">
   <div class="l-column-two-thirds">
-    <h1>We’ve received your booking request</h1>
+    <div class="govuk-box-highlight">
+      <h1 class="bold-large govuk-box-highlight__header">We’ve received<br>your booking request</h1>
+    </div>
 
-    <p>Thank you for requesting a guidance appointment with Pension Wise.</p>
+    <h2>What happens next?</h2>
 
     <p>We’ll call or email you within 2 working days to confirm the date and time of
     your appointment.</p>

--- a/app/views/telephone_appointments/confirmation.html.erb
+++ b/app/views/telephone_appointments/confirmation.html.erb
@@ -2,17 +2,20 @@
 
 <div class="l-grid-row">
   <div class="l-column-two-thirds">
-    <h1>We’ve booked your appointment</h1>
-
-    <p>Thank you for booking a Pension Wise guidance appointment.</p>
-
-    <p><strong>Your reference number</strong><br>
-    <span class="t-booking-reference"><%= @booking_reference %></span></p>
+    <div class="govuk-box-highlight">
+      <h1 class="bold-large govuk-box-highlight__header">We’ve booked your appointment</h1>
+      <p>
+        Your reference number is <br>
+        <strong class="heading-medium t-booking-reference"><%= @booking_reference %></strong>
+      </p>
+    </div>
 
     <div class="t-start">
       <p><strong>Date</strong><br><%= l(@booking_date, format: :govuk_date) %></p>
       <p><strong>Time</strong><br><%= l(@booking_date, format: :govuk_time) %></p>
     </div>
+
+    <h2>What happens next?</h2>
 
     <p>We’ll email you to confirm these details. You’ll also receive information to help you prepare for your appointment.</p>
 


### PR DESCRIPTION
DWP feedback recommended that we changed our confirmation pages
to be inline with govuk standards here:
https://www.gov.uk/service-manual/design/confirmation-pages

## Telephone booking confirmation

<img width="678" alt="screen shot 2017-04-07 at 11 37 19" src="https://cloud.githubusercontent.com/assets/6049076/24796819/96faefda-1b86-11e7-88fa-0c788f93bc4a.png">

## Face to face booking confirmation

<img width="659" alt="screen shot 2017-04-07 at 11 36 38" src="https://cloud.githubusercontent.com/assets/6049076/24796821/97137f8c-1b86-11e7-8e5c-d4e21da328d2.png">
