### PR TITLE
Adding a continue button to the telephone appointment form

### DIFF
--- a/app/assets/stylesheets/components/slot-picker/_slot-picker-times.scss
+++ b/app/assets/stylesheets/components/slot-picker/_slot-picker-times.scss
@@ -10,6 +10,7 @@
   float: left;
   list-style: none;
   margin: 0;
+  position: relative;
   text-align: left;
   width: 50%;
 
@@ -24,21 +25,34 @@
   }
 }
 
-.slot-picker-times__action {
-  background: none;
+.slot-picker-times__selection {
+  position: absolute;
+  top: 8px;
+  left: 10px;
+
+  &:checked {
+    + .slot-picker-times__time-text {
+      background: $calendar-selection;
+    }
+  }
+}
+
+.slot-picker-times__time-text {
   border: 1px solid $color-black;
+  box-sizing: border-box;
   cursor: pointer;
+  display: block;
   font-size: 1em;
   margin: 0 0 16px;
   padding: 8px;
+  text-align: center;
   width: 98%;
 
   @include media(tablet) {
     width: 75%;
   }
 
-  &:hover,
-  &:focus {
+  &:hover {
     background: $calendar-selection;
   }
 }

--- a/app/controllers/telephone_appointments_controller.rb
+++ b/app/controllers/telephone_appointments_controller.rb
@@ -8,6 +8,8 @@ class TelephoneAppointmentsController < ApplicationController
     retrieve_slots
   end
 
+  helper_method :slot_selected?
+
   def new
   end
 
@@ -33,8 +35,10 @@ class TelephoneAppointmentsController < ApplicationController
   def create_step_2
     if request.xhr?
       render partial: 'times', locals: { times: @times }
-    else
+    elsif slot_selected?
       telephone_appointment.advance! { render :new }
+    else
+      render :new
     end
   end
 
@@ -107,5 +111,9 @@ class TelephoneAppointmentsController < ApplicationController
   def set_breadcrumbs
     breadcrumb Breadcrumb.book_an_appointment
     breadcrumb Breadcrumb.book_a_telephone_appointment
+  end
+
+  def slot_selected?
+    telephone_appointment.start_at
   end
 end

--- a/app/views/telephone_appointments/_hidden_fields.html.erb
+++ b/app/views/telephone_appointments/_hidden_fields.html.erb
@@ -9,3 +9,4 @@
 <%= f.hidden_field :dc_pot_confirmed, id: "#{id_prefix}_dc_pot_confirmed" %>
 <%= f.hidden_field :opt_out_of_market_research, id: "#{id_prefix}_opt_out_of_market_research" %>
 <%= f.hidden_field :accept_terms_and_conditions, id: "#{id_prefix}_accept_terms_and_conditions" %>
+<%= f.hidden_field :selected_date, id: "#{id_prefix}_selected_date" %>

--- a/app/views/telephone_appointments/_step_2.html.erb
+++ b/app/views/telephone_appointments/_step_2.html.erb
@@ -1,6 +1,7 @@
 <% content_for(:page_title, t('service.title', page_title: 'Choose a Time')) %>
 
-<div class="l-column-half l-column-half--right">
+<div class="l-column-half l-column-half--right" data-slot-picker-single-time>
   <%= render 'hidden_fields', f: f, id_prefix: 'step_2' %>
   <%= render 'times', times: @times %>
+  <%= render 'times_js' %>
 </div>

--- a/app/views/telephone_appointments/_times.html.erb
+++ b/app/views/telephone_appointments/_times.html.erb
@@ -1,14 +1,24 @@
-<h2 class="slot-picker-header js-slot-picker-header">Choose a time on <%= l(@telephone_appointment.selected_date, format: :govuk_date) %></h2>
-<% if times.present? %>
-<ol class="slot-picker-times js-slot-picker-times">
-  <% times.each do |time| %>
-    <li class="slot-picker-times__time">
-      <button class="slot-picker-times__action" value="<%= time %>" name="telephone_appointment[start_at]">
-        <%= l(time, format: :govuk_time) %>
-      </button>
-    </li>
+<h2 class="slot-picker-header js-slot-picker-header">
+  <% if times.present? %>
+    Choose a time on <%= l(@telephone_appointment.selected_date, format: :govuk_date) %>
+  <% else %>
+    No times available on <%= l(@telephone_appointment.selected_date, format: :govuk_date) %>
   <% end %>
-</ol>
+</h2>
+<% if times.present? %>
+  <ol class="slot-picker-times js-slot-picker-times" tabindex="-1" id="telephone_appointment_times">
+    <% times.each do |time| %>
+      <li class="slot-picker-times__time">
+        <input class="slot-picker-times__selection" type="radio" value="<%= time %>" id="time-<%= time %>" name="telephone_appointment[start_at]" />
+        <label class="slot-picker-times__time-text" for="time-<%= time %>">
+           <%= l(time, format: :govuk_time) %>
+        </label>
+      </li>
+    <% end %>
+  </ol>
+
+  <input type="submit" value="Continue" class="button t-continue" name="continue" />
 <% else %>
-<p class="t-choose-other-time-message">Sorry there are no times available on this day. Please choose another day.</p>
+  <p class="t-choose-other-time-message">Sorry there are no times available on this day. Please choose another day.</p>
 <% end %>
+<input type="hidden" name="telephone_appointment[selected_date]" value="<%= @telephone_appointment.selected_date %>" />

--- a/app/views/telephone_appointments/_times_js.html.erb
+++ b/app/views/telephone_appointments/_times_js.html.erb
@@ -1,0 +1,11 @@
+<script type="text/html" id="slot-picker-ajax-loader">
+  <div class="ajax-loader slot-picker-ajax-loader">
+    <span class="visually-hidden">Loading times</span>
+  </div>
+</script>
+<script type="text/html" id="slot-picker-error">
+  <div class="error-summary slot-picker-error" role="group" aria-labelledby="error-times-heading">
+    <h2 class="heading-medium slot-picker-header js-slot-picker-error-header" id="error-times-heading" tabindex="-1">An error has occured</h2>
+    <p>There was a problem retrieving the appointment times. Please try again.</p>
+  </div>
+</script>

--- a/app/views/telephone_appointments/new.html.erb
+++ b/app/views/telephone_appointments/new.html.erb
@@ -1,17 +1,21 @@
 <div class="l-grid-row">
-  <div class="l-column-two-thirds">
+  <div class="l-column-full">
     <h1>Book a phone appointment</h1>
 
-    <% if @telephone_appointment.errors.any? %>
+    <% if @telephone_appointment.errors.any? || (params[:continue] && !slot_selected?) %>
       <div class="error-summary t-errors" role="group" aria-labelledby="error-summary-heading-example-1" tabindex="-1">
         <h2 class="heading-medium error-summary-heading" id="error-summary-heading-example-1">
           Unable to submit the form
         </h2>
+
         <p>Check the following:</p>
 
         <ul class="error-summary-list">
           <% @telephone_appointment.errors.each do |key, message| %>
             <li><%= link_to "#{TelephoneAppointment.human_attribute_name key} – #{message}", "#telephone_appointment_#{key}" %></li>
+          <% end %>
+          <% unless slot_selected? %>
+            <li><%= link_to 'Select a time', "#telephone_appointment_times" %></li>
           <% end %>
         </ul>
       </div>
@@ -24,17 +28,7 @@
 
     <% if @telephone_appointment.step == 1 %>
       <div class="l-column-half l-column-half--right" data-slot-picker-single-time>
-        <script type="text/html" id="slot-picker-ajax-loader">
-          <div class="ajax-loader slot-picker-ajax-loader">
-            <span class="visually-hidden">Loading times</span>
-          </div>
-        </script>
-        <script type="text/html" id="slot-picker-error">
-          <div class="error-summary slot-picker-error" role="group" aria-labelledby="error-times-heading">
-            <h2 class="heading-medium slot-picker-header js-slot-picker-error-header" id="error-times-heading" tabindex="-1">An error has occured</h2>
-            <p>There was a problem retrieving the appointment times. Please try again.</p>
-          </div>
-        </script>
+        <%= render 'times_js' %>
       </div>
     <% end %>
   <% end %>

--- a/features/pages/new_telephone_appointment.rb
+++ b/features/pages/new_telephone_appointment.rb
@@ -18,6 +18,8 @@ module Pages
 
     element :submit, '.t-submit'
 
+    element :continue, '.t-continue'
+
     def choose_date(date)
       page.choose(date)
     end

--- a/features/step_definitions/telephone_booking_request_steps.rb
+++ b/features/step_definitions/telephone_booking_request_steps.rb
@@ -33,7 +33,8 @@ end
 
 def choose_date_and_time
   @page.find('button[value="2017-01-17"]').click
-  @page.click_on('12:20pm')
+  @page.find('label', text: '12:20pm').click
+  @page.continue.click
 end
 
 Given(/^they do not have a DC pot$/) do


### PR DESCRIPTION
After a user selected a time we were moving them on automatically
to the customer form page.

Feedback from DWP content team suggested that the standard
gov.uk way is to let a user make a choice and then decide to
continue to the next step by clicking a 'continue' button

<img width="499" alt="screen shot 2017-04-12 at 13 00 06" src="https://cloud.githubusercontent.com/assets/6049076/24956542/f9ec0690-1f7f-11e7-8533-1be7a4dc57b5.png">
