### PR TITLE
Make error messages on the site consistent with booking journey errors

### DIFF
--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -1,4 +1,4 @@
-# rubocop:disable Metrics/AbcSize, Lint/AssignmentInCondition
+# rubocop:disable Lint/AssignmentInCondition
 class QuestionsController < ApplicationController
   skip_before_action :verify_authenticity_token
 
@@ -8,7 +8,7 @@ class QuestionsController < ApplicationController
     if answer = question.metadata.answers[params[:response]]
       redirect_to answer
     else
-      redirect_to "/#{params[:question_id]}", alert: I18n.t('pension_type_tool.error')
+      redirect_to "/#{params[:question_id]}", alert: true
     end
   end
 end

--- a/app/forms/feedback_form.rb
+++ b/app/forms/feedback_form.rb
@@ -4,7 +4,7 @@ class FeedbackForm
   attr_accessor :name, :email, :message, :feedback_type
 
   validates :name, presence: true
-  validates :email, presence: true, format: { with: /.+@.+\..+/ }
+  validates :email, format: { with: /.+@.+\..+/ }
   validates :message, presence: true
   validates :feedback_type, inclusion: { in: %w(online_booking pension_type_tool) }
 

--- a/app/views/appointment_summaries/new.html.erb
+++ b/app/views/appointment_summaries/new.html.erb
@@ -8,13 +8,15 @@
 
   <% if @appointment_summary.errors.any? %>
     <div class="error-summary" role="group" aria-labelledby="error-summary-heading" tabindex="-1">
-      <h1 class="heading-medium error-summary-heading" id="error-summary-heading">
-        There was a problem with your details
-      </h1>
+      <h2 class="heading-medium error-summary-heading" id="error-summary-heading">
+        Unable to submit the form
+      </h2>
+
+      <p>Check the following:</p>
 
       <ul class="error-summary-list">
         <% @appointment_summary.errors.each do |attribute, attribute_message| %>
-          <li><a href="#<%= attribute %>"><%= sanitize(attribute_message, :tags => []) %></a></li>
+          <li><%= link_to "#{AppointmentSummary.human_attribute_name attribute} – #{sanitize(attribute_message, :tags => [])}", "##{attribute}" %></li>
         <% end %>
       </ul>
     </div>
@@ -22,9 +24,13 @@
 
   <h2 id="age">Your age</h2>
 
-  <div class="form-group">
+  <div class="form-group <%= 'form-group-error' if @appointment_summary.errors.include?(:appointment_type) %>" id="appointment_type" tabindex="-1">
     <fieldset class="inline">
       <legend class="visuallyhidden">Your age</legend>
+
+      <% if @appointment_summary.errors.include?(:appointment_type) %>
+        <span class="error-message"><%= @appointment_summary.errors[:appointment_type].to_sentence.capitalize %></span>
+      <% end %>
 
       <div class="multiple-choice">
         <%= f.radio_button :appointment_type, '50_54', checked: false %>

--- a/app/views/components/_error_postcode.html.erb
+++ b/app/views/components/_error_postcode.html.erb
@@ -13,6 +13,18 @@
     <article role="article" class="text">
       <h1>Find an appointment location near you</h1>
 
+      <div class="error-summary" role="group" aria-labelledby="error-summary-heading-1" tabindex="-1">
+        <h2 class="heading-medium error-summary-heading" id="error-summary-heading-1">
+          Unable to submit the form
+        </h2>
+
+        <p>Check the following:</p>
+
+        <ul class="error-summary-list">
+          <li><%= link_to "Postcode - enter a valid postcode", "#location" %></li>
+        </ul>
+      </div>
+
       <p>Search for your nearest appointment locations.</p>
 
       <%= render 'components/locations_search', has_error: true do %>

--- a/app/views/components/_locations_search.html.erb
+++ b/app/views/components/_locations_search.html.erb
@@ -8,7 +8,7 @@
         <%= yield %>
       <% end %>
     </label>
-    <input type="text" class="form-control" name="postcode" id="location" value="<%= @postcode&.squish %>" required="true">
+    <input type="text" class="form-control<%= ' form-control-error' if has_error %>" name="postcode" id="location" value="<%= @postcode&.squish %>" required="true">
     <input type="submit" class="button" value="Search">
   </div>
 </form>

--- a/app/views/feedbacks/_form.html.erb
+++ b/app/views/feedbacks/_form.html.erb
@@ -1,9 +1,25 @@
+<% if @feedback.errors.any? %>
+  <div class="error-summary t-errors" role="group" aria-labelledby="error-summary-heading-example-1" tabindex="-1">
+    <h2 class="heading-medium error-summary-heading" id="error-summary-heading-example-1">
+      Unable to submit the form
+    </h2>
+
+    <p>Check the following:</p>
+
+    <ul class="error-summary-list">
+      <% @feedback.errors.each do |key, message| %>
+        <li><%= link_to "#{FeedbackForm.human_attribute_name key} – #{message}", "#feedback_#{key}" %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>
+
 <%= form_for @feedback, url: feedback_path, as: :feedback, html: { class: 'js-feedback-form' } do |f| %>
   <%= f.hidden_field :feedback_type %>
   <div class="form-group <%= 'form-group-error' if @feedback.errors.include?(:name) %>">
     <%= f.label :name, class: 'form-label' %>
     <% if @feedback.errors.include?(:name) %>
-      <span class="error-message"><%= @feedback.errors[:name].to_sentence %></span>
+      <span class="error-message"><%= @feedback.errors[:name].to_sentence.capitalize %></span>
     <% end %>
     <%= f.text_field :name, class: "t-feedback-name form-control #{'form-control-error' if @feedback.errors.include?(:name)}" %>
   </div>
@@ -11,7 +27,7 @@
   <div class="form-group <%= 'form-group-error' if @feedback.errors.include?(:email) %>">
     <%= f.label :email, class: 'form-label' %>
     <% if @feedback.errors.include?(:email) %>
-      <span class="error-message"><%= @feedback.errors[:email].to_sentence %></span>
+      <span class="error-message"><%= @feedback.errors[:email].to_sentence.capitalize %></span>
     <% end %>
     <%= f.text_field :email, class: "t-feedback-email form-control #{'form-control-error' if @feedback.errors.include?(:email)}" %>
   </div>
@@ -19,7 +35,7 @@
   <div class="form-group <%= 'form-group-error' if @feedback.errors.include?(:message) %>">
     <%= f.label :message, class: 'form-label' %>
     <% if @feedback.errors.include?(:message) %>
-      <span class="error-message"><%= @feedback.errors[:message].to_sentence %></span>
+      <span class="error-message"><%= @feedback.errors[:message].to_sentence.capitalize %></span>
     <% end %>
     <%= f.text_area :message, class: "t-feedback-message form-control #{'form-control-error' if @feedback.errors.include?(:message)}" %>
   </div>

--- a/app/views/layouts/guides.html.erb
+++ b/app/views/layouts/guides.html.erb
@@ -2,7 +2,7 @@
   <article role="article" class="text">
     <% if flash[:alert] %>
       <div class="error-summary alert-alert" aria-labelledby="error-summary-heading" role="group">
-        <h1 class="heading-medium error-summary-heading" id="error-summary-heading"><%= t('pension_type_tool.error') %></h1>
+        <h2 class="heading-medium error-summary-heading" id="error-summary-heading"><%= t('pension_type_tool.error_title') %></h2>
         <ul>
           <li><%= link_to t('pension_type_tool.error'), '#question' %></li>
         </ul>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,6 +1,7 @@
 en:
   pension_type_tool:
-    error: 'Please answer the question to proceed'
+    error_title: 'Unable to submit the form'
+    error: 'Select an answer'
 
   service:
     title: '%{page_title} - Pension Wise'
@@ -41,6 +42,8 @@ en:
         dc_pot: Defined contribution pension
         opt_in: Terms and conditions
         telephone_number: Phone number
+      appointment_summary:
+        appointment_type: Your age
     errors:
       models:
         annuity_registration_form:
@@ -52,7 +55,7 @@ en:
         appointment_summary:
           attributes:
             appointment_type:
-              inclusion: Please select the age range you are in
+              inclusion: select a range
         booking_request_form:
           attributes:
             first_name:
@@ -91,3 +94,11 @@ en:
               inclusion: select an option
             accept_terms_and_conditions:
               inclusion: please accept
+        feedback_form:
+          attributes:
+            name:
+              blank: enter a name
+            email:
+              invalid: enter a valid email address
+            message:
+              blank: enter a message


### PR DESCRIPTION
This makes the feedback form, the pension type tool, appointment summary
and location search forms consistent with the wording that has been
introduced on the booking journey forms

<img width="664" alt="screen shot 2017-04-13 at 11 56 22" src="https://cloud.githubusercontent.com/assets/6049076/25002057/3c42d7ec-2040-11e7-83e5-a60546e42bcd.png">
