### PR TITLE
Updating calculator error msgs to be inline with other error msgs

### DIFF
--- a/app/views/calculators/_error_summary.html.erb
+++ b/app/views/calculators/_error_summary.html.erb
@@ -1,14 +1,14 @@
 <div class="error-summary" role="group" aria-labelledby="error-summary-heading" tabindex="-1">
 
-  <h1 class="heading-medium error-summary-heading" id="error-summary-heading">
+  <h2 class="heading-medium error-summary-heading" id="error-summary-heading">
     <%= t('.heading') %>
-  </h1>
+  </h2>
 
   <ul class="error-summary-list">
-    <% messages.each do |attribute, attribute_messages| %>
-      <% attribute_messages.each do |attribute_message| %>
-        <li><a href="#<%= attribute %>"><%= sanitize(attribute_message, :tags => []) %></a></li>
-      <% end %>
+    <% errors.each do |attribute, message| %>
+      <li>
+        <%= link_to "#{form.human_attribute_name attribute} – #{sanitize(message, :tags => [])}", "##{attribute}" %>
+      </li>
     <% end %>
   </ul>
 

--- a/app/views/calculators/_form_input_currency.html.erb
+++ b/app/views/calculators/_form_input_currency.html.erb
@@ -10,7 +10,7 @@
     <%= label %>
     <%= content_tag :span, hint, class: 'form-hint' unless hint.blank? %>
   </label>
-  <%= simple_format error_messages.join("\n"), { class: 'error-message' }, wrapper_tag: 'span' %>
+  <%= simple_format error_messages.map(&:upcase_first).join("\n"), { class: 'error-message' }, wrapper_tag: 'span' %>
   <%= content_tag :span, '£', id: labelled_by_symbol %>
   <%= text_field_tag field, number_to_currency(value, unit: ''), 'aria-labelledby' => "#{labelled_by_label} #{labelled_by_symbol}",
                      class: %w(form-control calculator__field) << "t-calculator-#{field} #{'form-control-error' unless error_messages.empty?}" %>

--- a/app/views/calculators/_form_input_number.html.erb
+++ b/app/views/calculators/_form_input_number.html.erb
@@ -10,7 +10,7 @@
     <%= label %>
     <%= content_tag :span, hint, class: 'form-hint' unless hint.blank? %>
   </label>
-  <%= simple_format error_messages.join("\n"), { class: 'error-message' }, wrapper_tag: 'span' %>
+  <%= simple_format error_messages.map(&:upcase_first).join("\n"), { class: 'error-message' }, wrapper_tag: 'span' %>
   <%= text_field_tag field, number_to_currency(value, unit: ''),
                      class: %w(form-control calculator__field) << "t-calculator-#{field} #{'form-control-error' unless error_messages.empty?}" %>
 </div>

--- a/app/views/calculators/adjustable_income/_form.html.erb
+++ b/app/views/calculators/adjustable_income/_form.html.erb
@@ -1,18 +1,19 @@
 <%
   form = local_assigns[:form]
-  messages = form&.errors&.messages
   errors = form&.errors || {}
 %>
 
 <h2 id="calculator"><%= t('.heading') %></h2>
 
-<%= render 'calculators/error_summary', messages: messages if form&.invalid? %>
+<%= render 'calculators/error_summary',
+  form: Calculators::AdjustableIncomeForm,
+  errors: errors if form&.invalid? %>
 
 <form action="/adjustable-income/estimate#form" method="get">
   <%= render 'calculators/form_input_currency',
              field: :pot,
              value: form&.pot,
-             label: t('.pot_value_label'),
+             label: Calculators::AdjustableIncomeForm.human_attribute_name(:pot),
              error_messages: errors[:pot] %>
 
   <%= render 'calculators/form_input_hidden',
@@ -23,7 +24,7 @@
              field: :age,
              css_classes: 'js-scroll-target',
              value: form&.age,
-             label: t('.age_label'),
+             label: Calculators::AdjustableIncomeForm.human_attribute_name(:age),
              error_messages: errors[:age] %>
 
   <%= render 'calculators/form_input_submit' %>

--- a/app/views/calculators/guaranteed_income/_form.html.erb
+++ b/app/views/calculators/guaranteed_income/_form.html.erb
@@ -1,25 +1,26 @@
 <%
   form = local_assigns[:form]
-  messages = form&.errors&.messages
   errors = form&.errors || {}
 %>
 
 <h2 id="calculator"><%= t('.heading') %></h2>
 
-<%= render 'calculators/error_summary', messages: messages if form&.invalid? %>
+<%= render 'calculators/error_summary',
+  form: Calculators::GuaranteedIncomeForm,
+  errors: errors if form&.invalid? %>
 
 <form action="/guaranteed-income/estimate#form" method="get">
   <%= render 'calculators/form_input_currency',
              field: :pot,
              value: form&.pot,
-             label: t('.pot_value_label'),
+             label: Calculators::GuaranteedIncomeForm.human_attribute_name(:pot),
              error_messages: errors[:pot] %>
 
   <%= render 'calculators/form_input_number',
              field: :age,
              css_classes: 'js-scroll-target',
              value: form&.age,
-             label: t('.age_label'),
+             label: Calculators::GuaranteedIncomeForm.human_attribute_name(:age),
              error_messages: errors[:age] %>
 
   <%= render 'calculators/form_input_submit' %>

--- a/app/views/calculators/leave_pot_untouched/_form.html.erb
+++ b/app/views/calculators/leave_pot_untouched/_form.html.erb
@@ -1,24 +1,25 @@
 <%
   form = local_assigns[:form]
-  messages = form&.errors&.messages
   errors = form&.errors || {}
 %>
 
-<h2 id="calculator">Estimate how much your pot could grow</h2>
+<h2 id="calculator"><%= t('.heading') %></h2>
 
-<%= render 'calculators/error_summary', messages: messages if form&.invalid? %>
+<%= render 'calculators/error_summary',
+  form: Calculators::LeavePotUntouchedForm,
+  errors: errors if form&.invalid? %>
 
 <form action="/leave-pot-untouched/estimate#form" method="get">
   <%= render 'calculators/form_input_currency',
              field: :pot,
              value: form&.pot,
-             label: t('.pot_value_label'),
+             label: Calculators::LeavePotUntouchedForm.human_attribute_name(:pot),
              error_messages: errors[:pot] %>
 
   <%= render 'calculators/form_input_currency',
              field: :contribution,
              value: form&.contribution,
-             label: t('.contribution_label'),
+             label: Calculators::LeavePotUntouchedForm.human_attribute_name(:contribution),
              error_messages: errors[:contribution] %>
 
   <%= render 'calculators/form_input_submit' %>

--- a/app/views/calculators/take_cash_in_chunks/_form.html.erb
+++ b/app/views/calculators/take_cash_in_chunks/_form.html.erb
@@ -1,31 +1,32 @@
 <%
   form = local_assigns[:form]
-  messages = form&.errors&.messages
   errors = form&.errors || {}
 %>
 
 <h2 id="calculator"><%= t('.heading') %></h2>
 
-<%= render 'calculators/error_summary', messages: messages if form&.invalid? %>
+<%= render 'calculators/error_summary',
+  form: Calculators::TakeCashInChunksForm,
+  errors: errors if form&.invalid? %>
 
 <form action="/take-cash-in-chunks/estimate#form" method="get">
   <%= render 'calculators/form_input_currency',
              field: :income,
              value: form&.income,
-             label: t('.income_label'),
+             label: Calculators::TakeCashInChunksForm.human_attribute_name(:income),
              hint: t('.income_hint'),
              error_messages: errors[:income] %>
 
   <%= render 'calculators/form_input_currency',
              field: :pot,
              value: form&.pot,
-             label: t('.pot_value_label'),
+             label: Calculators::TakeCashInChunksForm.human_attribute_name(:pot),
              error_messages: errors[:pot] %>
 
   <%= render 'calculators/form_input_currency',
              field: :chunk,
              value: form&.chunk,
-             label: t('.chunk_label'),
+             label: Calculators::TakeCashInChunksForm.human_attribute_name(:chunk),
              error_messages: errors[:chunk] %>
 
   <%= render 'calculators/form_input_submit' %>

--- a/app/views/calculators/take_whole_pot/_form.html.erb
+++ b/app/views/calculators/take_whole_pot/_form.html.erb
@@ -1,25 +1,26 @@
 <%
   form = local_assigns[:form]
-  messages = form&.errors&.messages
   errors = form&.errors || {}
 %>
 
 <h2 id="calculator"><%= t('.heading') %></h2>
 
-<%= render 'calculators/error_summary', messages: messages if form&.invalid? %>
+<%= render 'calculators/error_summary',
+  form: Calculators::TakeWholePotForm,
+  errors: errors if form&.invalid? %>
 
 <form action="/take-whole-pot/estimate#calculator" method="get">
   <%= render 'calculators/form_input_currency',
              field: :income,
              value: form&.income,
-             label: t('.income_label'),
+             label: Calculators::TakeWholePotForm.human_attribute_name(:income),
              hint: t('.income_hint'),
              error_messages: errors[:income] %>
 
   <%= render 'calculators/form_input_currency',
              field: :pot,
              value: form&.pot,
-             label: t('.pot_value_label'),
+             label: Calculators::TakeWholePotForm.human_attribute_name(:pot),
              error_messages: errors[:pot] %>
 
   <%= render 'calculators/form_input_submit' %>

--- a/config/locales/calculators.en.yml
+++ b/config/locales/calculators.en.yml
@@ -1,6 +1,6 @@
 en:
   calculators:
     error_summary:
-      heading: There was a problem with your details
+      heading: Unable to submit the form
     form_input_submit:
       submit_tag: Calculate

--- a/config/locales/calculators/adjustable_income.en.yml
+++ b/config/locales/calculators/adjustable_income.en.yml
@@ -1,24 +1,28 @@
 en:
   activemodel:
+    attributes:
+      calculators/adjustable_income_form:
+        pot: 'How much is in your pot?'
+        age: 'What age do you want to take your money?'
     errors:
       models:
         calculators/adjustable_income_form:
           attributes:
             pot:
-              blank: Please enter the amount in your pot
-              not_a_number: Using numbers, please enter the amount in your pot
-              greater_than: The amount in your pot must be at least £1
-              less_than: The amount in your pot must be less than £5,000,000
+              blank: enter a figure
+              not_a_number: use numbers only
+              greater_than: amount must be at least £1
+              less_than: amount must be less than £5,000,000
             desired_monthly_income:
-              blank: Please enter the amount you would like to take per month
-              not_a_number: Using numbers, please enter the amount you would like to take per month
-              greater_than_or_equal_to: Your desired income for the month must be £0 or more
-              less_than: Your monthly income must be less than your pension pot value
-              greater_than: Your desired monthly income must be more than zero
+              blank: enter a figure
+              not_a_number: use numbers only
+              greater_than_or_equal_to: amount must be £0 or more
+              less_than: amount must be less than your pension pot value
+              greater_than: amount must be more than zero
             age:
-              blank: Please enter the age you plan to retire at
-              not_a_number: Using numbers, please enter the age you want to retire
-              greater_than_or_equal_to: We can only provide an estimate for those over 55
+              blank: enter a figure
+              not_a_number: use numbers only
+              greater_than_or_equal_to: enter an age over 55
 
   calculators:
     adjustable_income:
@@ -53,8 +57,5 @@ en:
 
       form:
         heading: Estimate how much you could get
-        pot_value_label: How much is in your pot?
-        age_label: What age do you want to take your money?
-
       show:
         back: Back to description

--- a/config/locales/calculators/guaranteed_income.en.yml
+++ b/config/locales/calculators/guaranteed_income.en.yml
@@ -1,16 +1,20 @@
 en:
   activemodel:
+    attributes:
+      calculators/guaranteed_income_form:
+        pot: 'How much is in your pot?'
+        age: 'What age do you want to take your money?'
     errors:
       models:
         calculators/guaranteed_income_form:
           attributes:
             pot:
-              blank: Please enter the amount in your pot
-              not_a_number: Using numbers, please enter the amount in your pot
-              greater_than: The amount in your pot must be at least £1
+              blank: enter a figure
+              not_a_number: use numbers only
+              greater_than: amount must be at least £1
             age:
-              blank: Please enter the age you plan to retire at
-              not_a_number: Using numbers, please enter how much you can pay in each month
+              blank: enter a figure
+              not_a_number: use numbers only
               greater_than_or_equal_to: We can only provide an estimate for people aged 55 to 75. If you’re over 75 you can compare annuities on the <a href="https://www.moneyadviceservice.org.uk/en/tools/annuities">Money Advice Service website</a>.
               less_than_or_equal_to: We can only provide an estimate for people aged 55 to 75. If you’re over 75 you can compare annuities on the <a href="https://www.moneyadviceservice.org.uk/en/tools/annuities">Money Advice Service website</a>.
 
@@ -39,8 +43,5 @@ en:
 
       form:
         heading: Estimate how much your guaranteed income could be
-        pot_value_label: How much is in your pot?
-        age_label: What age do you want to take your money?
-
       show:
         back: Back to description

--- a/config/locales/calculators/leave_pot_untouched.en.yml
+++ b/config/locales/calculators/leave_pot_untouched.en.yml
@@ -1,16 +1,20 @@
 en:
   activemodel:
+    attributes:
+      calculators/leave_pot_untouched_form:
+        pot: 'How much is in your pot?'
+        contribution: 'How much can you pay in each month?'
     errors:
       models:
         calculators/leave_pot_untouched_form:
           attributes:
             pot:
-              blank: Please enter the amount in your pot
-              not_a_number: Using numbers, please enter the amount in your pot
-              greater_than: The amount in your pot must be at least £1
+              blank: enter a figure
+              not_a_number: use numbers only
+              greater_than: amount must be at least £1
             contribution:
-              not_a_number: Using numbers, please enter how much you can pay in each month
-              greater_than_or_equal_to: How much you can pay in each month must be £0 or more
+              not_a_number: use numbers only
+              greater_than_or_equal_to: amount must be £0 or more
 
   calculators:
     leave_pot_untouched:
@@ -43,10 +47,7 @@ en:
             <li>
               You must leave your whole pot — you can't take just the 25% tax-free lump sum and leave the rest.
             </li>
-
       form:
-        pot_value_label: How much is in your pot?
-        contribution_label: How much can you pay in each month?
-
+        heading: Estimate how much your pot could grow
       show:
         back: Back to description

--- a/config/locales/calculators/take_cash_in_chunks.en.yml
+++ b/config/locales/calculators/take_cash_in_chunks.en.yml
@@ -1,22 +1,27 @@
 en:
   activemodel:
+    attributes:
+      calculators/take_cash_in_chunks_form:
+        pot: How much is in your pot?
+        income: What is your yearly income?
+        chunk: How much do you want to take as your first cash chunk?
     errors:
       models:
         calculators/take_cash_in_chunks_form:
           attributes:
             pot:
-              blank: Please enter the amount in your pot
-              not_a_number: Using numbers, please enter the amount in your pot
-              greater_than: The amount in your pot must be at least £1
+              blank: enter a figure
+              not_a_number: use numbers only
+              greater_than: amount must be at least £1
             income:
-              blank: Please enter your income for the year
-              not_a_number: Using numbers, please enter your income for the year
-              greater_than_or_equal_to: Your income for the year must be £0 or more
+              blank: enter a figure
+              not_a_number: use numbers only
+              greater_than_or_equal_to: amount must be £0 or more
             chunk:
-              blank: Please enter how much you want to take in your first year
-              not_a_number: Using numbers, please enter how much you want to take in your first year
-              greater_than: How much you take in your first year must be at least £1
-              less_than: How much you take in your first year must be less than your pension pot value
+              blank: enter a figure
+              not_a_number: use numbers only
+              greater_than: amount must be at least £1
+              less_than: amount must be less than your pension pot value
 
   calculators:
     take_cash_in_chunks:
@@ -49,10 +54,6 @@ en:
 
       form:
         heading: Estimate how much you could get
-        income_label: What is your yearly income?
         income_hint: Include money you get from work, benefits, savings and State Pension payments
-        pot_value_label: How much is in your pot?
-        chunk_label: How much do you want to take as your first cash chunk?
-
       show:
         back: Back to description

--- a/config/locales/calculators/take_whole_pot.en.yml
+++ b/config/locales/calculators/take_whole_pot.en.yml
@@ -1,17 +1,21 @@
 en:
   activemodel:
+    attributes:
+      calculators/take_whole_pot_form:
+        pot: How much is in your pot?
+        income: What is your yearly income?
     errors:
       models:
         calculators/take_whole_pot_form:
           attributes:
             pot:
-              blank: Please enter the amount in your pot
-              not_a_number: Using numbers, please enter the amount in your pot
-              greater_than: The amount in your pot must be at least £1
+              blank: enter a figure
+              not_a_number: use numbers only
+              greater_than: amount must be at least £1
             income:
-              blank: Please enter your income for the year
-              not_a_number: Using numbers, please enter your income for the year
-              greater_than_or_equal_to: Your income for the year must be £0 or more
+              blank: enter a figure
+              not_a_number: use numbers only
+              greater_than_or_equal_to: amount must be £0 or more
 
   calculators:
     take_whole_pot:
@@ -39,8 +43,6 @@ en:
 
       form:
         heading: Estimate what you’d get after tax
-        income_label: What is your yearly income?
         income_hint: Include money you get from work, benefits, savings and State Pension payments
-        pot_value_label: How much is in your pot?
       show:
         back: Back to description


### PR DESCRIPTION
This is to ensure that we have a consistent set of error messages
across the site

<img width="586" alt="screen shot 2017-04-13 at 17 36 45" src="https://cloud.githubusercontent.com/assets/6049076/25014470/cac39126-206f-11e7-81bc-3391e039842a.png">
