### PR TITLE
Increase phantomjs / poltergeist timeout

### DIFF
--- a/features/support/poltergeist.rb
+++ b/features/support/poltergeist.rb
@@ -1,7 +1,11 @@
 require 'capybara/poltergeist'
 
 Capybara.register_driver :poltergeist do |app|
-  Capybara::Poltergeist::Driver.new(app, url_whitelist: %w(127.0.0.1))
+  Capybara::Poltergeist::Driver.new(
+    app,
+    url_whitelist: %w(127.0.0.1),
+    timeout: ENV.fetch('PHANTOM_JS_TIMEOUT') { 60 }
+  )
 end
 
 Capybara.javascript_driver = :poltergeist

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,11 +3,9 @@ ENV['RAILS_ENV'] ||= 'test'
 require_relative '../config/environment'
 require 'rspec/rails'
 
-require 'capybara/poltergeist'
 require 'vcr'
 
-Capybara.javascript_driver = :poltergeist
-Capybara.default_max_wait_time = 20
+require_relative '../features/support/poltergeist'
 
 Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
 


### PR DESCRIPTION
We're seeing builds fail intermittently in CI due to the initial wait
time for asset compilation. This happens only once per build but causes
the whole build to fail. Setting this to a large maximum (60 seconds by
default) should address the build failures and need for rebuilds.