### PR TITLE
Amend error messages for guaranteed income calculator

### DIFF
--- a/config/locales/calculators/guaranteed_income.en.yml
+++ b/config/locales/calculators/guaranteed_income.en.yml
@@ -15,8 +15,8 @@ en:
             age:
               blank: enter a figure
               not_a_number: use numbers only
-              greater_than_or_equal_to: We can only provide an estimate for people aged 55 to 75. If you’re over 75 you can compare annuities on the <a href="https://www.moneyadviceservice.org.uk/en/tools/annuities">Money Advice Service website</a>.
-              less_than_or_equal_to: We can only provide an estimate for people aged 55 to 75. If you’re over 75 you can compare annuities on the <a href="https://www.moneyadviceservice.org.uk/en/tools/annuities">Money Advice Service website</a>.
+              greater_than_or_equal_to: you must be aged 55 to 75
+              less_than_or_equal_to: you must be aged 55 to 75 – you can compare annuities on the <a href="https://www.moneyadviceservice.org.uk/en/tools/annuities">Money Advice Service website</a>
 
   calculators:
     guaranteed_income:


### PR DESCRIPTION
After feedback from the content team it has been decided to
amend the error message for users who enter an age younger
than 55 or older then 75.

## Older than 75
<img width="570" alt="screen shot 2017-04-18 at 16 02 29" src="https://cloud.githubusercontent.com/assets/6049076/25137726/7f28e2c2-2450-11e7-801b-1779afdb259f.png">


## Younger than 55
<img width="559" alt="screen shot 2017-04-18 at 16 02 34" src="https://cloud.githubusercontent.com/assets/6049076/25137727/804669b8-2450-11e7-8d8a-65d058e99095.png">

