### PR TITLE
Tidy implementation of generic guide error

### DIFF
--- a/app/views/layouts/guides.html.erb
+++ b/app/views/layouts/guides.html.erb
@@ -2,9 +2,9 @@
   <article role="article" class="text">
     <% if flash[:alert] %>
       <div class="error-summary alert-alert" aria-labelledby="error-summary-heading" role="group">
-        <h2 class="heading-medium error-summary-heading" id="error-summary-heading"><%= t('pension_type_tool.error_title') %></h2>
+        <h2 class="heading-medium error-summary-heading" id="error-summary-heading"><%= t('calculators.error_summary.heading') %></h2>
         <ul>
-          <li><%= link_to t('pension_type_tool.error'), '#question' %></li>
+          <li><%= link_to t('calculators.error_summary.select_an_answer'), '#question' %></li>
         </ul>
       </div>
     <% end %>

--- a/config/locales/calculators.en.yml
+++ b/config/locales/calculators.en.yml
@@ -2,5 +2,6 @@ en:
   calculators:
     error_summary:
       heading: Unable to submit the form
+      select_an_answer: Select an answer
     form_input_submit:
       submit_tag: Calculate

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,8 +1,4 @@
 en:
-  pension_type_tool:
-    error_title: 'Unable to submit the form'
-    error: 'Select an answer'
-
   service:
     title: '%{page_title} - Pension Wise'
     homepage:

--- a/spec/features/questions_spec.rb
+++ b/spec/features/questions_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature 'Questions', type: :feature do
       page.click_on 'Next step'
 
       expect(page.current_url).to match(guide.slug)
-      expect(page).to have_content(I18n.t('pension_type_tool.error'))
+      expect(page).to have_content(I18n.t('calculators.error_summary.select_an_answer'))
     end
   end
 


### PR DESCRIPTION
These appear to be displayed in response to [non specific errors when handling questions](https://github.com/guidance-guarantee-programme/pension_guidance/blob/master/app/controllers/questions_controller.rb#L11).

- Don’t source a calculator translation from outside of the dedicated calculator locale files
- Reuse an existing locale file entry where possible