### PR TITLE
Disable New Relic Browser

### DIFF
--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -90,7 +90,7 @@ common: &default_settings
   browser_monitoring:
       # By default the agent automatically injects the monitoring JavaScript
       # into web pages. Set this attribute to false to turn off this behavior.
-      auto_instrument: true
+      auto_instrument: false
 
   # Proxy settings for connecting to the New Relic server.
   #


### PR DESCRIPTION
We are not using the New Relic browser features, so
best turn it off to reduce the frontend HTTP requests