### PR TITLE
Ensure that pension type tool start button looks like govuk start button

### DIFF
--- a/content/pension_type_tool.md
+++ b/content/pension_type_tool.md
@@ -15,7 +15,7 @@ If you have a defined contribution (personal or workplace) pension you choose ho
 
 ^You’ll need to check each pension separately if you have more than one.^
 
-[Start now](/pension-type-tool/question-1){: .button}
+[Start now](/pension-type-tool/question-1){: .button .button-start}
 
 ## Before you start
 


### PR DESCRIPTION
Service manual for gov.uk states that a start button should have a
chevron and a bigger looking button than a standard one.

https://www.gov.uk/service-manual/design/start-pages

<img width="670" alt="screen shot 2017-04-24 at 09 51 30" src="https://cloud.githubusercontent.com/assets/6049076/25329445/9f563676-28d3-11e7-96fe-9ba0c18dea77.png">
