### PR TITLE
Prevent flicker effect when A/B test is run

### DIFF
--- a/app/views/home/experiment.html.erb
+++ b/app/views/home/experiment.html.erb
@@ -1,3 +1,11 @@
+<% content_for :head do %>
+  <style>.async-hide { opacity: 0 !important} </style>
+  <script>(function(a,s,y,n,c,h,i,d,e){s.className+=' '+y;h.start=1*new Date;
+  h.end=i=function(){s.className=s.className.replace(RegExp(' ?'+y),'')};
+  (a[n]=a[n]||[]).hide=h;setTimeout(function(){i();h.end=null},c);h.timeout=c;
+  })(window,document.documentElement,'async-hide','dataLayer',4000,
+  {'GTM-PPZZQ9':true});</script>
+<% end %>
 <% content_for(:page_title, t('service.homepage.title')) %>
 <% content_for(:meta_description, 'A free and impartial government service that helps you understand ' +
   'the options for your pension pot.') %>

--- a/app/views/home/show.html.erb
+++ b/app/views/home/show.html.erb
@@ -1,3 +1,11 @@
+<% content_for :head do %>
+  <style>.async-hide { opacity: 0 !important} </style>
+  <script>(function(a,s,y,n,c,h,i,d,e){s.className+=' '+y;h.start=1*new Date;
+  h.end=i=function(){s.className=s.className.replace(RegExp(' ?'+y),'')};
+  (a[n]=a[n]||[]).hide=h;setTimeout(function(){i();h.end=null},c);h.timeout=c;
+  })(window,document.documentElement,'async-hide','dataLayer',4000,
+  {'GTM-PPZZQ9':true});</script>
+<% end %>
 <% content_for(:page_title, t('service.homepage.title')) %>
 <% content_for(:meta_description, 'A free and impartial government service that helps you understand ' +
   'the options for your pension pot.') %>


### PR DESCRIPTION
Analytics team have recommended we add the 'page hiding script'
to our A/B testing pages (homepage) to avoid a page flicker
when the page loads.

More details:
http://www.lunametrics.com/blog/2017/03/02/install-google-optimize/#3-how-to-install-the-optimize-snippet