### PR TITLE
Improve display of summary document information on website

### DIFF
--- a/app/assets/stylesheets/components/summary-document.scss
+++ b/app/assets/stylesheets/components/summary-document.scss
@@ -1,23 +1,36 @@
 //*-------------- mixins --------------------*/
-@mixin bullet($color, $radius, $top: 5px) {
+@mixin bullet($color, $radius, $top: 2px) {
   &:before {
     content: "";
     display: block;
     position: absolute;
     top: $top;
-    left: -40px;
+    left: 0;
     width: $radius;
     height: $radius;
     border-radius: $radius;
     background: $color;
+
+    @include media(1080px) {
+      left: -30px;
+    }
   }
 }
 
 //*----------- summary document styles ----*/
 
 .summary-document {
+  .icon {
+    display: block;
+  }
+
   .option {
     position: relative;
+    padding-left: 25px;
+
+    @include media(1080px) {
+      padding-left: 0;
+    }
   }
 
   .option--untouched {
@@ -64,7 +77,7 @@
     &.option {
 
       &:before {
-        top: 15px;
+        top: 7px;
       }
     }
   }


### PR DESCRIPTION
This fixes some rendering issues with the text of the summary
document generated by the view your appointment summary tool.

## Before

<img width="311" alt="screen shot 2017-04-26 at 09 50 40" src="https://cloud.githubusercontent.com/assets/6049076/25426049/db4f3306-2a65-11e7-855e-e1b3562350de.png">
<img width="566" alt="screen shot 2017-04-26 at 09 50 28" src="https://cloud.githubusercontent.com/assets/6049076/25426050/db52a87e-2a65-11e7-89ab-9aabe5317c54.png">


## After

<img width="595" alt="screen shot 2017-04-26 at 09 49 36" src="https://cloud.githubusercontent.com/assets/6049076/25426001/b187d8ca-2a65-11e7-9c5b-07ece04e54b9.png">
<img width="302" alt="screen shot 2017-04-26 at 09 49 26" src="https://cloud.githubusercontent.com/assets/6049076/25426003/b1a0cb78-2a65-11e7-8ced-0dd8efb9802c.png">
<img width="662" alt="screen shot 2017-04-26 at 09 49 15" src="https://cloud.githubusercontent.com/assets/6049076/25426004/b1addf48-2a65-11e7-9dde-10d29c5bdd54.png">
