### PR TITLE
Altering /locations to display an A-Z of all locations

### DIFF
--- a/app/assets/stylesheets/components/_locations-a-z.scss
+++ b/app/assets/stylesheets/components/_locations-a-z.scss
@@ -1,0 +1,24 @@
+.locations-a-z-total__count {
+  @include bold-80;
+}
+
+.locations-a-z-letter {
+  @include bold-48;
+
+  &:first-of-type {
+    @include media(tablet) {
+      margin-top: 0;
+    }
+  }
+}
+
+.locations-a-z-letter-list {
+  margin: 0;
+  padding: 0;
+}
+
+.locations-a-z-letter-list__location {
+  margin: 0 0 10px;
+  padding: 0;
+  list-style: none;
+}

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -8,10 +8,18 @@ class LocationsController < ApplicationController
   layout 'full_width_with_breadcrumbs', only: %i(show index)
 
   def index
-    return render :search if @postcode.nil?
-    return render :empty_postcode if @postcode.empty?
+    if @postcode.nil?
+      locations = Locations::Repository.new.all
 
-    retrieve_locations
+      @locations_by_letter = locations.group_by { |location| location.name.first }
+      @locations_total     = locations.count
+
+      render :a_to_z
+    elsif @postcode.empty?
+      render :empty_postcode
+    else
+      retrieve_locations
+    end
   end
 
   def show

--- a/app/views/locations/a_to_z.html.erb
+++ b/app/views/locations/a_to_z.html.erb
@@ -1,0 +1,22 @@
+<% content_for(:page_title, t('service.title', page_title: "Pension Wise appointment locations")) %>
+
+<h1>Pension Wise appointment locations</h1>
+
+<div class="l-grid-row">
+  <div class="l-column-third">
+    <span class="locations-a-z-total">
+      <div>Appointment locations</div>
+      <span class="locations-a-z-total__count"><%= @locations_total %></span>
+    </span>
+  </div>
+  <div class="l-column-two-thirds">
+    <% @locations_by_letter.each do |letter, locations| %>
+      <h2 class="locations-a-z-letter"><%= letter %></h2>
+      <ol class="locations-a-z-letter-list">
+        <% locations.each do |location| %>
+        <li class="locations-a-z-letter-list__location"><%= link_to location.name, location_path(location.id) %></li>
+        <% end %>
+      </ol>
+    <% end %>
+  </div>
+</div>

--- a/content/book_face_to_face.md
+++ b/content/book_face_to_face.md
@@ -17,6 +17,7 @@ Search for your nearest appointment locations.
     </label>
     <input type="text" class="form-control" id="postcode" name="postcode" value="" required="true">
     <input type="submit" class="button" id="btn-search" value="Search">
+    <p>or view the <a href="/locations">list of locations</a></p>
   </div>
 </form>
 

--- a/spec/controllers/locations_controller_spec.rb
+++ b/spec/controllers/locations_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe LocationsController, type: :controller do
     specify 'without a postcode param' do
       get :index
 
-      expect(response).to render_template(:search)
+      expect(response).to render_template(:a_to_z)
     end
 
     specify 'with an empty postcode' do


### PR DESCRIPTION
In order to make our location pages available to search engines
this creates an A-Z list of locations which is accessed by a link
under the location search box