### PR TITLE
Alter wording on location page to better clarify phone booking hours

### DIFF
--- a/app/views/locations/index.html.erb
+++ b/app/views/locations/index.html.erb
@@ -25,11 +25,11 @@
               <%= link_to 'Book online', booking_request_step_one_location_path(location.id), class: 'button t-book-online' %>
             </p>
             <p>
-              Or book by phone <strong class="t-phone"><%= location.phone %></strong>.
+              Or call <strong class="t-phone"><%= location.phone %></strong>.
             </p>
           <% else %>
             <p>
-              Book by phone <strong class="t-phone"><%= location.phone %></strong>.
+              Call <strong class="t-phone"><%= location.phone %></strong>.
             </p>
           <% end %>
         </div>

--- a/app/views/locations/show.html.erb
+++ b/app/views/locations/show.html.erb
@@ -41,9 +41,9 @@
         <%= link_to 'Book online', booking_request_step_one_location_path(@location.id), class: 'button t-book-online' %>
       </p>
 
-      Or book by phone <strong class="t-phone"><%= @location.phone %></strong>.
+      Or call <strong class="t-phone"><%= @location.phone %></strong>.
     <% else %>
-      Book by phone <strong class="t-phone"><%= @location.phone %></strong>.
+      Call <strong class="t-phone"><%= @location.phone %></strong>.
     <% end %>
 
     <% if @location.hours.present? %>


### PR DESCRIPTION
Customers have been geting confused about the wording of the
booking hours on the location pages. They were thinking that the
hours specified meant when the location was available for an
appointment rather than when the phone lines were open.

This alters the wording slightly to help reduce this confusion.

<img width="531" alt="screen shot 2017-05-08 at 11 09 57" src="https://cloud.githubusercontent.com/assets/6049076/25799909/f38f636e-33de-11e7-98a3-97413dfbc363.png">
