### PR TITLE
Adding email validation to email fields

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,78 +1,82 @@
-source 'https://rubygems.org'
-
 ruby IO.read('.ruby-version').strip
 
 # force Bundler to use HTTPS for github repos
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}.git" }
 
-gem 'autoprefixer-rails'
-gem 'booking_locations'
-gem 'bugsnag'
-gem 'canonical-rails'
-gem 'email_validation'
-gem 'faraday'
-gem 'faraday-conductivity'
-gem 'faraday_middleware'
-gem 'foreman'
-gem 'gaffe'
-gem 'govspeak', '~> 3.2'
-gem 'govuk_elements_rails'
-gem 'govuk_frontend_toolkit'
-gem 'govuk_template'
-gem 'humanize'
-gem 'inline_svg'
-gem 'newrelic_rpm'
-gem 'nokogiri'
-gem 'output-templates', '~> 4.6.0', github: 'guidance-guarantee-programme/output-templates'
-gem 'phoner'
-gem 'postcodes_io'
-# https://github.com/mbleigh/princely/pull/53
-gem 'princely', github: 'guidance-guarantee-programme/princely', branch: 'remove-alias-method-chain'
-gem 'puma'
-gem 'rails', '~> 5.0.1'
-gem 'redis'
-gem 'rgeo'
-gem 'rgeo-geojson'
-gem 'rubytree', github: 'guidance-guarantee-programme/rubytree', branch: '24fix'
-gem 'sassc-rails'
-gem 'sprockets-es6'
-gem 'sprockets-rails'
-gem 'uglifier', '3.0.4'
-gem 'uk_postcode'
-gem 'utf8-cleaner'
-gem 'zendesk_api'
-
-group :development, :test do
-  gem 'jasmine-jquery-rails'
-  gem 'jasmine-rails'
-  gem 'pry-byebug'
-  gem 'rspec-rails'
-  gem 'shoulda-matchers'
+source 'https://rails-assets.org' do
+  gem 'rails-assets-mailgun-validator-jquery', '0.0.3'
 end
 
-group :development do
-  gem 'rubocop', require: false
-end
+source 'https://rubygems.org' do # rubocop:disable Metrics/BlockLength
+  gem 'autoprefixer-rails'
+  gem 'booking_locations'
+  gem 'bugsnag'
+  gem 'canonical-rails'
+  gem 'email_validation'
+  gem 'faraday'
+  gem 'faraday-conductivity'
+  gem 'faraday_middleware'
+  gem 'foreman'
+  gem 'gaffe'
+  gem 'govspeak', '~> 3.2'
+  gem 'govuk_elements_rails'
+  gem 'govuk_frontend_toolkit'
+  gem 'govuk_template'
+  gem 'humanize'
+  gem 'inline_svg'
+  gem 'newrelic_rpm'
+  gem 'nokogiri'
+  gem 'output-templates', '~> 4.6.0', github: 'guidance-guarantee-programme/output-templates'
+  gem 'phoner'
+  gem 'postcodes_io'
+  # https://github.com/mbleigh/princely/pull/53
+  gem 'princely', github: 'guidance-guarantee-programme/princely', branch: 'remove-alias-method-chain'
+  gem 'puma'
+  gem 'rails', '~> 5.0.1'
+  gem 'redis'
+  gem 'rgeo'
+  gem 'rgeo-geojson'
+  gem 'rubytree', github: 'guidance-guarantee-programme/rubytree', branch: '24fix'
+  gem 'sassc-rails'
+  gem 'sprockets-es6'
+  gem 'sprockets-rails'
+  gem 'uglifier', '3.0.4'
+  gem 'uk_postcode'
+  gem 'utf8-cleaner'
+  gem 'zendesk_api'
 
-group :test do
-  gem 'axe-matchers'
-  gem 'cucumber-rails', require: false
-  gem 'fakeredis'
-  gem 'launchy'
-  gem 'pdf-inspector', require: 'pdf/inspector'
-  gem 'phantomjs-binaries'
-  gem 'poltergeist'
-  gem 'rails-controller-testing'
-  gem 'scss-lint', '~> 0.30'
-  gem 'site_prism'
-  gem 'timecop'
-  gem 'vcr'
-  gem 'webmock'
-  gem 'wraith'
-end
+  group :development, :test do
+    gem 'jasmine-jquery-rails'
+    gem 'jasmine-rails'
+    gem 'pry-byebug'
+    gem 'rspec-rails'
+    gem 'shoulda-matchers'
+  end
 
-group :staging, :production do
-  gem 'lograge'
-  gem 'rails_12factor'
-  gem 'redis-rails', require: false
+  group :development do
+    gem 'rubocop', require: false
+  end
+
+  group :test do
+    gem 'axe-matchers'
+    gem 'cucumber-rails', require: false
+    gem 'fakeredis'
+    gem 'launchy'
+    gem 'pdf-inspector', require: 'pdf/inspector'
+    gem 'phantomjs-binaries'
+    gem 'poltergeist'
+    gem 'rails-controller-testing'
+    gem 'scss-lint', '~> 0.30'
+    gem 'site_prism'
+    gem 'timecop'
+    gem 'vcr'
+    gem 'webmock'
+    gem 'wraith'
+  end
+
+  group :staging, :production do
+    gem 'lograge'
+    gem 'rails_12factor'
+    gem 'redis-rails', require: false
+  end
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,6 +22,7 @@ GIT
       json (~> 1.8)
 
 GEM
+  remote: https://rails-assets.org/
   remote: https://rubygems.org/
   specs:
     Ascii85 (1.0.2)
@@ -257,6 +258,7 @@ GEM
       bundler (>= 1.3.0, < 2.0)
       railties (= 5.0.2)
       sprockets-rails (>= 2.0.0)
+    rails-assets-mailgun-validator-jquery (0.0.3)
     rails-controller-testing (1.0.1)
       actionpack (~> 5.x)
       actionview (~> 5.x)
@@ -411,64 +413,65 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  autoprefixer-rails
-  axe-matchers
-  booking_locations
-  bugsnag
-  canonical-rails
-  cucumber-rails
-  email_validation
-  fakeredis
-  faraday
-  faraday-conductivity
-  faraday_middleware
-  foreman
-  gaffe
-  govspeak (~> 3.2)
-  govuk_elements_rails
-  govuk_frontend_toolkit
-  govuk_template
-  humanize
-  inline_svg
-  jasmine-jquery-rails
-  jasmine-rails
-  launchy
-  lograge
-  newrelic_rpm
-  nokogiri
+  autoprefixer-rails!
+  axe-matchers!
+  booking_locations!
+  bugsnag!
+  canonical-rails!
+  cucumber-rails!
+  email_validation!
+  fakeredis!
+  faraday!
+  faraday-conductivity!
+  faraday_middleware!
+  foreman!
+  gaffe!
+  govspeak (~> 3.2)!
+  govuk_elements_rails!
+  govuk_frontend_toolkit!
+  govuk_template!
+  humanize!
+  inline_svg!
+  jasmine-jquery-rails!
+  jasmine-rails!
+  launchy!
+  lograge!
+  newrelic_rpm!
+  nokogiri!
   output-templates (~> 4.6.0)!
-  pdf-inspector
-  phantomjs-binaries
-  phoner
-  poltergeist
-  postcodes_io
+  pdf-inspector!
+  phantomjs-binaries!
+  phoner!
+  poltergeist!
+  postcodes_io!
   princely!
-  pry-byebug
-  puma
-  rails (~> 5.0.1)
-  rails-controller-testing
-  rails_12factor
-  redis
-  redis-rails
-  rgeo
-  rgeo-geojson
-  rspec-rails
-  rubocop
+  pry-byebug!
+  puma!
+  rails (~> 5.0.1)!
+  rails-assets-mailgun-validator-jquery (= 0.0.3)!
+  rails-controller-testing!
+  rails_12factor!
+  redis!
+  redis-rails!
+  rgeo!
+  rgeo-geojson!
+  rspec-rails!
+  rubocop!
   rubytree!
-  sassc-rails
-  scss-lint (~> 0.30)
-  shoulda-matchers
-  site_prism
-  sprockets-es6
-  sprockets-rails
-  timecop
-  uglifier (= 3.0.4)
-  uk_postcode
-  utf8-cleaner
-  vcr
-  webmock
-  wraith
-  zendesk_api
+  sassc-rails!
+  scss-lint (~> 0.30)!
+  shoulda-matchers!
+  site_prism!
+  sprockets-es6!
+  sprockets-rails!
+  timecop!
+  uglifier (= 3.0.4)!
+  uk_postcode!
+  utf8-cleaner!
+  vcr!
+  webmock!
+  wraith!
+  zendesk_api!
 
 RUBY VERSION
    ruby 2.4.1p111

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,4 +1,5 @@
 //= require jquery/dist/jquery.min.js
+//= require mailgun-validator-jquery
 //= require pubsub.js
 //= require govuk_toolkit
 //= stub govuk/selection-buttons
@@ -12,6 +13,7 @@
 //= require components/Slider
 //= require components/SlotPicker
 //= require components/SlotPickerSingleTime
+//= require components/EmailValidation
 
 PWPG.clickTracker.init();
 PWPG.calculators.init();
@@ -36,6 +38,14 @@ $('[data-slot-picker-single-time]').each(function() {
     $form = $('.js-day-picker-form');
 
   new PWPG.SlotPickerSingleTime($component, $form);
+});
+
+$('[data-email-validation]').each(function() {
+  'use strict';
+
+  var $component = $(this);
+
+  new PWPG.EmailValidation($component);
 });
 
 new PWPG.Navigation();

--- a/app/assets/javascripts/components/EmailValidation.es6
+++ b/app/assets/javascripts/components/EmailValidation.es6
@@ -1,0 +1,101 @@
+(function() {
+  'use strict';
+
+  class EmailValidation extends PWPG.BaseComponent {
+    constructor($component) {
+      super($component);
+
+      this.$component.mailgun_validator({
+        api_key: this.$component.data('api-key'),
+        api_host: this.$component.data('api-host'),
+        in_progress: this.showLoadingSpinner.bind(this),
+        success: this.onSuccess.bind(this),
+        error: this.onError.bind(this)
+      });
+
+      this.insertSuggestionContainer();
+      this.insertLoadingSpinner();
+    }
+
+    onSuccess(data) {
+      this.hideLoadingSpinner();
+
+      if (!data.is_valid || data.did_you_mean) {
+        this.showSuggestion(data.is_valid, data.did_you_mean);
+      } else {
+        this.clearSuggestion();
+      }
+    }
+
+    onError(message) {
+      this.hideLoadingSpinner();
+      this.$suggestionContainer.html(message);
+    }
+
+    insertLoadingSpinner() {
+      if (this.$loadingSpinner) {
+        return;
+      }
+
+      this.$loadingSpinner = $('<div class="ajax-loader ajax-loader--24px hidden"></div>');
+      this.$loadingSpinner.insertAfter(this.$component);
+    }
+
+    showLoadingSpinner() {
+      this.clearSuggestion();
+      this.$loadingSpinner.removeClass('hidden');
+    }
+
+    hideLoadingSpinner() {
+      this.$loadingSpinner.addClass('hidden');
+    }
+
+    insertSuggestionContainer() {
+      if (this.$suggestionContainer) {
+        return;
+      }
+
+      this.$suggestionContainer = $('<div class="form-hint email-suggestion" aria-live="polite" />');
+      this.$suggestionContainer.insertAfter(this.$component);
+    }
+
+    showSuggestion(isValid, didYouMean) {
+      let messages = [],
+          message;
+
+      if (!isValid) {
+        messages.push("that doesn't look like a valid address");
+      }
+
+      // Null (falsey) if no suggestion
+      if (didYouMean) {
+        messages.push(
+          `did you mean
+          <button class="button-link t-suggestion js-populate-suggested-email">${didYouMean}</button>?
+        `);
+      }
+
+      message = messages.join(', ');
+      message = message.charAt(0).toUpperCase() + message.slice(1);
+
+      // Insert the message
+      this.$suggestionContainer.html(message);
+
+      // And now add the click behaviour to populate the suggestion
+      $('.js-populate-suggested-email').click((event) => {
+        event.preventDefault();
+
+        // Populate the suggestion and then remove the message
+        this.$component.val(event.target.innerHTML);
+        this.clearSuggestion();
+      });
+    }
+
+    clearSuggestion() {
+      this.$suggestionContainer.empty();
+    }
+  }
+
+  window.PWPG = window.PWPG || {};
+  window.PWPG.EmailValidation = EmailValidation;
+})();

--- a/app/assets/stylesheets/components/_ajax-loader.scss
+++ b/app/assets/stylesheets/components/_ajax-loader.scss
@@ -1,61 +1,70 @@
 $loader-color: $color-black;
-$loader-size: 48px;
-$loader-size-half: $loader-size / 2;
 $number-of-circles: 8;
-$circle-size: $loader-size / $number-of-circles;
-$circle-size-half: $circle-size / 2;
 $sin-of-forty-five-degrees: .70711;
-$forty-five-degrees-in-pixels: (1 - $sin-of-forty-five-degrees) * $loader-size-half;
 $circle-animation-length: .8s;
 
-$circles:
-  (x: 0, y: $loader-size-half, spread: $circle-size-half $circle-size-half / 2 0 0 0 0 0 0),
-  (x: -($loader-size-half - $forty-five-degrees-in-pixels), y: $loader-size-half - $forty-five-degrees-in-pixels, spread: 0 $circle-size-half $circle-size-half / 2 0 0 0 0 0),
-  (x: -$loader-size-half, y: 0, spread: 0 0 $circle-size-half $circle-size-half / 2 0 0 0 0),
-  (x: -($loader-size-half - $forty-five-degrees-in-pixels), y: -($loader-size-half - $forty-five-degrees-in-pixels), spread: 0 0 0 $circle-size-half $circle-size-half / 2 0 0 0),
-  (x: 0, y: -$loader-size-half, spread: 0 0 0 0 $circle-size-half $circle-size-half / 2 0 0),
-  (x: $loader-size-half - $forty-five-degrees-in-pixels, y: -($loader-size-half - $forty-five-degrees-in-pixels), spread: 0 0 0 0 0 $circle-size-half $circle-size-half / 2 0),
-  (x: $loader-size-half, y: 0, spread: 0 0 0 0 0 0 $circle-size-half $circle-size-half / 2),
-  (x: $loader-size-half - $forty-five-degrees-in-pixels, y: $loader-size-half - $forty-five-degrees-in-pixels, spread: $circle-size-half / 2 0 0 0 0 0 0 $circle-size-half);
-
-@function circle($num) {
-  $line: null;
-
-  @each $circle in $circles {
-    $line: append($line, map-get($circle, "x") map-get($circle, "y") 0 nth(map-get($circle, "spread"), $num) $loader-color, "comma");
-  }
-
-  @return $line;
-}
+$ajax-loaders: 24px 48px;
 
 .ajax-loader {
-  display: block;
-  width: $loader-size;
-  height: $loader-size;
   position: relative;
 
   &:after {
     content: "";
     display: block;
-    width: $circle-size;
-    height: $circle-size;
     border-radius: 50%;
-    top: $loader-size-half - $circle-size-half;
-    left: $loader-size-half - $circle-size-half;
     position: absolute;
-    animation: loader-pulse $circle-animation-length infinite;
     animation-fill-mode: forwards;
-    box-shadow: circle(1);
   }
 }
 
-@keyframes loader-pulse {
-  0% { box-shadow: circle(1); }
+@each $loader-size in $ajax-loaders {
+  $loader-size-half: $loader-size / 2;
+  $circle-size: $loader-size / $number-of-circles;
+  $circle-size-half: $circle-size / 2;
+  $forty-five-degrees-in-pixels: (1 - $sin-of-forty-five-degrees) * $loader-size-half;
 
-  @for $i from 1 through ($number-of-circles - 1) {
-    #{(($i - 1) * 100/$number-of-circles) + 100/$number-of-circles}% { box-shadow: circle($i); }
-    #{(($i - 1) * 100/$number-of-circles) + 100/$number-of-circles + .001}% { box-shadow: circle($i + 1); }
+  $circles:
+    (x: 0, y: $loader-size-half, spread: $circle-size-half $circle-size-half / 2 0 0 0 0 0 0),
+    (x: -($loader-size-half - $forty-five-degrees-in-pixels), y: $loader-size-half - $forty-five-degrees-in-pixels, spread: 0 $circle-size-half $circle-size-half / 2 0 0 0 0 0),
+    (x: -$loader-size-half, y: 0, spread: 0 0 $circle-size-half $circle-size-half / 2 0 0 0 0),
+    (x: -($loader-size-half - $forty-five-degrees-in-pixels), y: -($loader-size-half - $forty-five-degrees-in-pixels), spread: 0 0 0 $circle-size-half $circle-size-half / 2 0 0 0),
+    (x: 0, y: -$loader-size-half, spread: 0 0 0 0 $circle-size-half $circle-size-half / 2 0 0),
+    (x: $loader-size-half - $forty-five-degrees-in-pixels, y: -($loader-size-half - $forty-five-degrees-in-pixels), spread: 0 0 0 0 0 $circle-size-half $circle-size-half / 2 0),
+    (x: $loader-size-half, y: 0, spread: 0 0 0 0 0 0 $circle-size-half $circle-size-half / 2),
+    (x: $loader-size-half - $forty-five-degrees-in-pixels, y: $loader-size-half - $forty-five-degrees-in-pixels, spread: $circle-size-half / 2 0 0 0 0 0 0 $circle-size-half);
+
+  @function circle($num) {
+    $line: null;
+
+    @each $circle in $circles {
+      $line: append($line, map-get($circle, "x") map-get($circle, "y") 0 nth(map-get($circle, "spread"), $num) $loader-color, "comma");
+    }
+
+    @return $line;
   }
 
-  99.999% { box-shadow: circle($number-of-circles); }
+  .ajax-loader--#{$loader-size} {
+    width: $loader-size;
+    height: $loader-size;
+
+    &:after {
+      width: $circle-size;
+      height: $circle-size;
+      top: $loader-size-half - $circle-size-half;
+      left: $loader-size-half - $circle-size-half;
+      animation: loader-pulse-#{$loader-size} $circle-animation-length infinite;
+      box-shadow: circle(1);
+    }
+  }
+
+  @keyframes loader-pulse-#{$loader-size} {
+    0% { box-shadow: circle(1); }
+
+    @for $i from 1 through ($number-of-circles - 1) {
+      #{(($i - 1) * 100/$number-of-circles) + 100/$number-of-circles}% { box-shadow: circle($i); }
+      #{(($i - 1) * 100/$number-of-circles) + 100/$number-of-circles + .001}% { box-shadow: circle($i + 1); }
+    }
+
+    99.999% { box-shadow: circle($number-of-circles); }
+  }
 }

--- a/app/assets/stylesheets/components/_button-link.scss
+++ b/app/assets/stylesheets/components/_button-link.scss
@@ -1,0 +1,15 @@
+.button-link {
+  @include core-19;
+  background: transparent;
+  border: 0;
+  color: $color-blue-endeavour;
+  cursor: pointer;
+  display: inline;
+  padding: 0;
+  text-decoration: underline;
+  user-select: text;
+
+  &:hover {
+    color: $color-blue-curious;
+  }
+}

--- a/app/assets/stylesheets/components/_email-outer.scss
+++ b/app/assets/stylesheets/components/_email-outer.scss
@@ -1,0 +1,14 @@
+.email-outer {
+  position: relative;
+
+  .ajax-loader {
+    position: absolute;
+    top: 5px;
+    right: 2%;
+
+    @include media(tablet) {
+      right: 51%;
+      top: 8px;
+    }
+  }
+}

--- a/app/assets/stylesheets/components/_email-suggestion.scss
+++ b/app/assets/stylesheets/components/_email-suggestion.scss
@@ -1,0 +1,3 @@
+.email-suggestion {
+  margin-top: 5px;
+}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -14,4 +14,12 @@ module ApplicationHelper
       concat link_to(guide.label, guide.url, class: 't-guide-link')
     end
   end
+
+  def email_validation_data_attributes
+    {
+      'email-validation': true,
+      api_key: 'pubkey-b37c931b1fcef90bf2d83b7cdfd6df39',
+      api_host: Rails.env.test? ? 'http://localhost:9293' : nil
+    }
+  end
 end

--- a/app/views/booking_requests/step_two.html.erb
+++ b/app/views/booking_requests/step_two.html.erb
@@ -49,7 +49,9 @@
           <span class="error-message"><%= @booking_request.errors[:email].to_sentence.capitalize %></span>
         <% end %>
 
-        <%= f.email_field :email, class: "t-email form-control #{'form-control-error' if @booking_request.errors.include?(:email)}" %>
+        <div class="email-outer">
+          <%= f.email_field :email, class: "t-email form-control #{'form-control-error' if @booking_request.errors.include?(:email)}", data: email_validation_data_attributes %>
+        </div>
       </div>
 
       <div class="form-group <%= 'form-group-error' if @booking_request.errors.include?(:telephone_number) %>">

--- a/app/views/feedbacks/_form.html.erb
+++ b/app/views/feedbacks/_form.html.erb
@@ -29,7 +29,10 @@
     <% if @feedback.errors.include?(:email) %>
       <span class="error-message"><%= @feedback.errors[:email].to_sentence.capitalize %></span>
     <% end %>
-    <%= f.text_field :email, class: "t-feedback-email form-control #{'form-control-error' if @feedback.errors.include?(:email)}" %>
+
+    <div class="email-outer">
+      <%= f.text_field :email, class: "t-feedback-email form-control #{'form-control-error' if @feedback.errors.include?(:email)}", data: email_validation_data_attributes %>
+    </div>
   </div>
 
   <div class="form-group <%= 'form-group-error' if @feedback.errors.include?(:message) %>">

--- a/app/views/telephone_appointments/_step_3.html.erb
+++ b/app/views/telephone_appointments/_step_3.html.erb
@@ -31,7 +31,9 @@
       <span class="error-message"><%= @telephone_appointment.errors[:email].to_sentence.capitalize %></span>
     <% end %>
 
-    <%= f.email_field :email, class: "t-email form-control #{'form-control-error' if @telephone_appointment.errors.include?(:email)}" %>
+    <div class="email-outer">
+      <%= f.email_field :email, class: "t-email form-control #{'form-control-error' if @telephone_appointment.errors.include?(:email)}", data: email_validation_data_attributes %>
+    </div>
   </div>
 
   <div class="form-group <%= 'form-group-error' if @telephone_appointment.errors.include?(:phone) %>">

--- a/app/views/telephone_appointments/_times_js.html.erb
+++ b/app/views/telephone_appointments/_times_js.html.erb
@@ -1,5 +1,5 @@
 <script type="text/html" id="slot-picker-ajax-loader">
-  <div class="ajax-loader slot-picker-ajax-loader">
+  <div class="ajax-loader ajax-loader--48px slot-picker-ajax-loader">
     <span class="visually-hidden">Loading times</span>
   </div>
 </script>

--- a/features/customer_booking_request.feature
+++ b/features/customer_booking_request.feature
@@ -51,6 +51,18 @@ Scenario: Customer navigates between Booking Request steps
   And I submit my completed Booking Request
   Then my Booking Request is confirmed
 
+@javascript @booking_locations @booking_requests @time_travel @mock_mailgun
+Scenario: Customer makes a mistakes in their email address and gets a suggestions
+  Given a location is enabled for online booking
+  And the date is "2016-06-17"
+  When I browse for the location "Hackney"
+  And I opt to book online
+  And I choose three available appointment slots
+  And I enter an email address with a typo
+  Then I see a correction suggestion
+  When I enter an invalid email address
+  Then I see a warning of an invalid email address
+
 @javascript @booking_locations @booking_requests @time_travel
 Scenario: Customer attempts an invalid Booking Request
   Given a location is enabled for online booking

--- a/features/pages/booking_step_two.rb
+++ b/features/pages/booking_step_two.rb
@@ -6,6 +6,7 @@ module Pages
     element :first_name, '.t-first-name'
     element :last_name, '.t-last-name'
     element :email, '.t-email'
+    element :email_suggestion, '.t-suggestion'
     element :date_of_birth_day, '.t-date-of-birth-day'
     element :date_of_birth_month, '.t-date-of-birth-month'
     element :date_of_birth_year, '.t-date-of-birth-year'

--- a/features/pages/new_telephone_appointment.rb
+++ b/features/pages/new_telephone_appointment.rb
@@ -5,6 +5,7 @@ module Pages
     element :first_name, '.t-first-name'
     element :last_name, '.t-last-name'
     element :email, '.t-email'
+    element :email_suggestion, '.t-suggestion'
     element :date_of_birth_day, '.t-date-of-birth-day'
     element :date_of_birth_month, '.t-date-of-birth-month'
     element :date_of_birth_year, '.t-date-of-birth-year'

--- a/features/step_definitions/customer_booking_request_steps.rb
+++ b/features/step_definitions/customer_booking_request_steps.rb
@@ -91,6 +91,41 @@ When(/^I provide my personal details$/) do
   @step_two.accessibility_requirements.set false
 end
 
+When(/^I enter an email address with a typo$/) do
+  with_mock_mailgun_response(
+    is_valid: false,
+    address: 'morty.sanchez@gmall.com',
+    parts: {
+      display_name: nil,
+      local_part: 'morty.sanchez',
+      domain: 'gmall.com'
+    },
+    did_you_mean: 'morty.sanchez@gmail.com'
+  )
+
+  @step_two = Pages::BookingStepTwo.new
+  expect(@step_two).to be_displayed
+
+  @step_two.email.set 'morty.sanchez@gmall.com'
+  @step_two.telephone_number.click
+end
+
+When(/^I enter an invalid email address$/) do
+  with_mock_mailgun_response(
+    is_valid: false,
+    address: 'morty.sanchez@totallyinvalid',
+    parts: {
+      display_name: nil,
+      local_part: 'morty.sanchez',
+      domain: 'totallyinvalid'
+    },
+    did_you_mean: nil
+  )
+
+  @step_two.email.set 'morty.sanchez@totallyinvalid'
+  @step_two.telephone_number.click
+end
+
 When(/^I pass the basic eligibility requirements$/) do
   @step_two.date_of_birth_day.set '01'
   @step_two.date_of_birth_month.set '01'
@@ -213,6 +248,14 @@ end
 
 Then(/^I see my feedback was sent$/) do
   expect(page).to have_content('Thank you for your help')
+end
+
+Then(/^I see a correction suggestion$/) do
+  expect(@step_two.email_suggestion).to have_content('morty.sanchez@gmail.com')
+end
+
+Then(/^I see a warning of an invalid email address$/) do
+  expect(@step_two).to have_content("That doesn't look like a valid address")
 end
 
 def with_booking_locations

--- a/features/step_definitions/telephone_booking_request_steps.rb
+++ b/features/step_definitions/telephone_booking_request_steps.rb
@@ -23,6 +23,48 @@ Given(/^the customer wants to book a phone appointment$/) do
   expect(@page).to be_displayed
 end
 
+When(/^they fill in an email address with a typo$/) do
+  choose_date_and_time
+
+  with_mock_mailgun_response(
+    is_valid: false,
+    address: 'something@gmall.com',
+    parts: {
+      display_name: nil,
+      local_part: 'something',
+      domain: 'gmall.com'
+    },
+    did_you_mean: 'something@gmail.com'
+  )
+
+  @page.email.set 'something@gmall.com'
+  @page.phone.click
+end
+
+When(/^they fill in an invalid email address$/) do
+  with_mock_mailgun_response(
+    is_valid: false,
+    address: 'something@totallyinvalid',
+    parts: {
+      display_name: nil,
+      local_part: 'something',
+      domain: 'totallyinvalid'
+    },
+    did_you_mean: nil
+  )
+
+  @page.email.set 'something@totallyinvalid'
+  @page.phone.click
+end
+
+Then(/^they see a message suggesting a correct email address$/) do
+  expect(@page.email_suggestion).to have_content('something@gmail.com')
+end
+
+Then(/^they see a message saying the email address is invalid$/) do
+  expect(@page).to have_content("That doesn't look like a valid address")
+end
+
 When(/^they choose a date after the slots on that day have been taken$/) do
   @page.find('button[value="2017-01-21"]').click
 end

--- a/features/support/mock_mailgun.rb
+++ b/features/support/mock_mailgun.rb
@@ -1,0 +1,27 @@
+require 'webrick'
+
+Before('@mock_mailgun') do
+  @mailgun_server = WEBrick::HTTPServer.new(
+    Port: 9293,
+    StartCallback: -> { @mailgun_server_running = true },
+    Logger: Rails.logger,
+    AccessLog: Rails.logger
+  )
+
+  @mailgun_thread = Thread.new { @mailgun_server.start }
+  Timeout.timeout(1) { :wait until @mailgun_server_running }
+end
+
+After('@mock_mailgun') do
+  @mailgun_server.shutdown
+  @mailgun_thread.kill
+end
+
+def with_mock_mailgun_response(response)
+  @mailgun_server.mount '/v2/address/validate', Rack::Handler::WEBrick, lambda { |env|
+    req = Rack::Request.new(env)
+    response_body = "#{req.params['callback']}(#{response.to_json})"
+
+    [200, {}, [response_body]]
+  }
+end

--- a/features/support/poltergeist.rb
+++ b/features/support/poltergeist.rb
@@ -3,7 +3,7 @@ require 'capybara/poltergeist'
 Capybara.register_driver :poltergeist do |app|
   Capybara::Poltergeist::Driver.new(
     app,
-    url_whitelist: %w(127.0.0.1),
+    url_whitelist: %w(127.0.0.1 localhost),
     timeout: ENV.fetch('PHANTOM_JS_TIMEOUT') { 60 }
   )
 end

--- a/features/telephone_booking_request.feature
+++ b/features/telephone_booking_request.feature
@@ -20,6 +20,14 @@ Scenario: Customer books a telephone appointment but the slot becomes unavailabl
   Then their appointment is created
   And they see a confirmation of their appointment
 
+@javascript @mock_mailgun
+Scenario: Eligible customer makes mistakes in their email address
+  Given the customer wants to book a phone appointment
+  When they fill in an email address with a typo
+  Then they see a message suggesting a correct email address
+  When they fill in an invalid email address
+  Then they see a message saying the email address is invalid
+
 Scenario: Eligible customer books a telephone appointment
   Given the customer wants to book a phone appointment
   When they are eligible for an appointment


### PR DESCRIPTION
Using mailgun's email validation API to check email addresses
inputted into booking forms.

Suggests alternative email addresses if it detects the
domain is maybe a typo.

Added to both booking journeys and feedback form.

![](http://g.recordit.co/J03C3f7UdA.gif)