### PR TITLE
Remove google experiments code which prevents page flicker

### DIFF
--- a/app/views/home/show.html.erb
+++ b/app/views/home/show.html.erb
@@ -1,11 +1,3 @@
-<% content_for :head do %>
-  <style>.async-hide { opacity: 0 !important} </style>
-  <script>(function(a,s,y,n,c,h,i,d,e){s.className+=' '+y;h.start=1*new Date;
-  h.end=i=function(){s.className=s.className.replace(RegExp(' ?'+y),'')};
-  (a[n]=a[n]||[]).hide=h;setTimeout(function(){i();h.end=null},c);h.timeout=c;
-  })(window,document.documentElement,'async-hide','dataLayer',4000,
-  {'GTM-PPZZQ9':true});</script>
-<% end %>
 <% content_for(:page_title, t('service.homepage.title')) %>
 <% content_for(:meta_description, 'A free and impartial government service that helps you understand ' +
   'the options for your pension pot.') %>


### PR DESCRIPTION
Now that we have ended the A/B test for the homepage we can
now remove this 'page hiding script'

Originally added in:
https://github.com/guidance-guarantee-programme/pension_guidance/commit/3b8c633b12194fc6184082b8841cf68484d53045