### PR TITLE
Fix JS error that occurs on marketing page

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -48,4 +48,10 @@ $('[data-email-validation]').each(function() {
   new PWPG.EmailValidation($component);
 });
 
-new PWPG.Navigation();
+$('[data-navigation]').each(function() {
+  'use strict';
+
+  var $component = $(this);
+
+  new PWPG.Navigation($component);
+});

--- a/app/assets/javascripts/components/Navigation.es6
+++ b/app/assets/javascripts/components/Navigation.es6
@@ -10,7 +10,6 @@
     init() {
       this.$trigger = $('.js-nav-toggler');
       this.$target = $('.js-nav');
-      this.$nav = $('.l-page-nav');
       this.mobileSize = 'mobile';
 
       this.setNavigationHiddenStatus();
@@ -18,7 +17,7 @@
     }
 
     getPageSize() {
-      const el = window.getComputedStyle(this.$nav[0], ':after');
+      const el = window.getComputedStyle(this.$component[0], ':after');
 
       return el ? el.getPropertyValue('content') : this.mobileSize;
     }

--- a/app/views/components/_page_nav.html.erb
+++ b/app/views/components/_page_nav.html.erb
@@ -1,5 +1,5 @@
 <% cache "page_nav_#{I18n.locale}", expires_in: 2.hours do %>
-  <div class="l-page-nav">
+  <div class="l-page-nav" data-navigation>
     <%= render 'components/nav' %>
   </div>
 <% end %>

--- a/spec/javascripts/navigationSpec.js
+++ b/spec/javascripts/navigationSpec.js
@@ -33,7 +33,7 @@ describe('navigation', function() {
   describe('toggles visibility of the navigation', function() {
     beforeEach(function() {
       loadFixtures('navigation.html');
-      new PWPG.Navigation();
+      new PWPG.Navigation($('.js-nav'));
     });
 
     it('adds `active` class and correct aria attributes on first click', function() {


### PR DESCRIPTION
An error was being generated from the navigation module on the marketing page.

This was down to the navigation menu not appearing on the marketing page.

This ensures that the navigation module is only executed when the
navigation is present on a page.