### PR TITLE
Reset the current locale to `en` after each test

### DIFF
--- a/features/support/locale.rb
+++ b/features/support/locale.rb
@@ -1,0 +1,5 @@
+# Reset the locale after each scenario to ensure
+# all tests start with the expected default locale.
+After do
+  I18n.locale = :en
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -33,6 +33,12 @@ RSpec.configure do |config|
     mocks.syntax = :expect
     mocks.verify_partial_doubles = true
   end
+
+  # Reset the locale after each example to ensure
+  # all tests start with the expected default locale.
+  config.after(:each) do
+    I18n.locale = :en
+  end
 end
 
 VCR.configure do |config|


### PR DESCRIPTION
Locale state was leaking between specs and causing failures depending
on order. To address this we can simply 'reset' the locale back to
English after each test run in both RSpec and Cucumber.