### PR TITLE
Use English url for ANY page’s canonical tag when not yet translated

### DIFF
--- a/app/views/guides/show.html.erb
+++ b/app/views/guides/show.html.erb
@@ -1,8 +1,5 @@
 <% content_for(:page_title, t('service.title', page_title: @guide.title)) %>
 <% content_for(:meta_description, @guide.description) %>
-<% if !default_locale? && !content_lang_matches_locale? %>
-  <% content_for(:canonical_path, guide_path(params[:id], locale: I18n.default_locale)) %>
-<% end %>
 
 <%= render 'option' if @guide.option? %>
 

--- a/app/views/home/show.html.erb
+++ b/app/views/home/show.html.erb
@@ -1,7 +1,6 @@
 <% content_for(:page_title, t('service.homepage.title')) %>
 <% content_for(:meta_description, 'A free and impartial government service that helps you understand ' +
   'the options for your pension pot.') %>
-<% content_for(:canonical_path, root_path) %>
 
 <div class="home-intro l-page-container">
   <p class="home-intro__text">Phone <b>0800 138 3944</b> to <%= link_to 'book a free appointment', guide_path('appointments', icn: 'book-appointment', ici: 'top-homepage') %></p>

--- a/app/views/layouts/_base.html.erb
+++ b/app/views/layouts/_base.html.erb
@@ -18,10 +18,10 @@
     <% end %>
   <% end %>
 
-  <% unless content_for?(:canonical_path) %>
-    <%= canonical_tag rescue nil %>
+  <% if !default_locale? && !content_lang_matches_locale? %>
+    <link href="<%= url_for(params.permit!.merge(locale: I18n.default_locale, host: canonical_host, protocol: canonical_protocol)) %>" rel="canonical" />
   <% else %>
-    <link href="<%= canonical_protocol + canonical_host + content_for(:canonical_path) %>" rel="canonical" />
+    <%= canonical_tag rescue nil %>
   <% end %>
 
   <% if content_for?(:meta_description) %>


### PR DESCRIPTION
Previous PR for this only addressed guides, but needed to be applied to any and all pages.

The logic that makes the decision has been moved into the the base layout, negating the need for the `canonical_path` content_for area.