### PR TITLE
Retrieve bookable slots from planner API

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,8 +83,8 @@ GEM
     babel-transpiler (0.7.0)
       babel-source (>= 4.0, < 6)
       execjs (~> 2.0)
-    booking_locations (0.13.0)
-      activesupport (>= 4, < 5.1)
+    booking_locations (0.16.0)
+      activesupport (>= 4, <= 6)
       globalid
     bugsnag (5.2.0)
     builder (3.2.3)
@@ -146,8 +146,8 @@ GEM
     gaffe (1.2.0)
       rails (>= 4.0.0)
     gherkin (4.0.0)
-    globalid (0.3.7)
-      activesupport (>= 4.1.0)
+    globalid (0.4.0)
+      activesupport (>= 4.2.0)
     govspeak (3.6.2)
       addressable (~> 2.3.8)
       htmlentities (~> 4)
@@ -204,7 +204,7 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
     mini_portile2 (2.1.0)
-    minitest (5.10.1)
+    minitest (5.10.2)
     multi_json (1.12.1)
     multi_test (0.1.2)
     multipart-post (2.0.0)
@@ -477,4 +477,4 @@ RUBY VERSION
    ruby 2.4.1p111
 
 BUNDLED WITH
-   1.14.6
+   1.15.0

--- a/app/forms/booking_request_form.rb
+++ b/app/forms/booking_request_form.rb
@@ -45,7 +45,7 @@ class BookingRequestForm
   end
 
   def slots_for_calendar
-    @slots_for_calendar ||= booking_location.location_for(location_id).slots.map(&:to_calendar)
+    @slots_for_calendar ||= BookingRequests.slots(location_id)
   end
 
   def booking_location

--- a/app/lib/booking_requests.rb
+++ b/app/lib/booking_requests.rb
@@ -6,4 +6,10 @@ module BookingRequests
 
     api.create(payload)
   end
+
+  def self.slots(location_id)
+    response = api.slots(location_id)
+
+    response.map { |slot| Slot.new(slot).to_calendar }
+  end
 end

--- a/app/lib/booking_requests/api.rb
+++ b/app/lib/booking_requests/api.rb
@@ -6,6 +6,11 @@ module BookingRequests
       true
     end
 
+    def slots(location_id)
+      response = connection.get "/api/v1/locations/#{location_id}/bookable_slots"
+      response.body
+    end
+
     private
 
     def connection

--- a/app/lib/booking_requests/slot.rb
+++ b/app/lib/booking_requests/slot.rb
@@ -1,0 +1,17 @@
+require 'ostruct'
+
+module BookingRequests
+  class Slot < OpenStruct
+    def to_calendar
+      ["#{calendar_date} - #{period}", "#{date}-#{start}-#{self.end}"]
+    end
+
+    def calendar_date
+      Date.parse(date).strftime('%A, %b %e')
+    end
+
+    def period
+      start == '0900' ? 'Morning' : 'Afternoon'
+    end
+  end
+end

--- a/app/lib/booking_requests/stub_api.rb
+++ b/app/lib/booking_requests/stub_api.rb
@@ -3,5 +3,14 @@ module BookingRequests
     def create(*)
       true
     end
+
+    def slots(*)
+      (Date.current..6.weeks.from_now.to_date).reject(&:on_weekend?).map do |date|
+        [
+          { date: date.iso8601, start: '0900', end: '1300' },
+          { date: date.iso8601, start: '1300', end: '1700' }
+        ]
+      end.flatten
+    end
   end
 end

--- a/features/accessibility.feature
+++ b/features/accessibility.feature
@@ -27,7 +27,7 @@ Feature: Accessibility of pages
     When I visit the appointment summary page
     Then the page should be accessible
 
-  @booking_locations
+  @booking_locations @booking_requests
   Scenario: Slot picker for face to face booking is not accessible while we develop our own slot picker
     When I view the face to face booking form
     Then the page should be accessible excluding ".SlotPicker"

--- a/features/customer_booking_request.feature
+++ b/features/customer_booking_request.feature
@@ -14,15 +14,6 @@ Scenario: Customer browses a regular location
   Then I cannot book online
 
 @javascript @booking_locations @booking_requests @time_travel
-Scenario: Customer books a closing location
-  Given a location is enabled for online booking
-  And the date is "2016-06-17"
-  When I browse for the location "Dalston"
-  And I opt to book online
-  Then I see the location name "Dalston"
-  And I see slots up to the day of closure
-
-@javascript @booking_locations @booking_requests @time_travel
 Scenario: Customer makes an online Booking Request
   Given a location is enabled for online booking
   And the date is "2016-06-17"

--- a/features/customer_booking_request.feature
+++ b/features/customer_booking_request.feature
@@ -80,7 +80,7 @@ Scenario: Customer is ineligible for guidance
   When I submit my completed Booking Request
   Then I am told I am ineligible for guidance
 
-@javascript @booking_locations @time_travel
+@javascript @booking_locations @time_travel @booking_requests
 Scenario: Customer leaves inline feedback
   Given a location is enabled for online booking
   And the date is "2016-06-17"

--- a/features/step_definitions/customer_booking_request_steps.rb
+++ b/features/step_definitions/customer_booking_request_steps.rb
@@ -42,12 +42,6 @@ Then(/^I see the location name "(.*?)"$/) do |name|
   expect(@step_one.location_name.text).to include(name)
 end
 
-Then(/^I see slots up to the day of closure$/) do
-  @step_one.wait_for_available_days
-
-  expect(@step_one).to have_available_days(count: 1)
-end
-
 When(/^I view the face to face booking form$/) do
   step('a location is enabled for online booking')
   step('I browse for the location "Hackney"')

--- a/spec/cassettes/BookingRequests_Api/_slots/returns_slots_for_the_given_location.yml
+++ b/spec/cassettes/BookingRequests_Api/_slots/returns_slots_for_the_given_location.yml
@@ -1,0 +1,44 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3002/api/v1/locations/ac7112c3-e3cf-45cd-a8ff-9ba827b8e7ef/bookable_slots
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - PensionWise/1.0 (birdperson.local; benlovell; 4960) ruby/2.4.1 (111; x86_64-darwin16)
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"30e0980a6990368b8a05d93d3b57ae26"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - ce71f102-595d-4c92-b209-c435e3c61926
+      X-Runtime:
+      - '0.153204'
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '[{"date":"2017-06-02","start":"0900","end":"1300"},{"date":"2017-06-02","start":"1300","end":"1700"},{"date":"2017-06-07","start":"0900","end":"1300"},{"date":"2017-06-07","start":"1300","end":"1700"},{"date":"2017-06-09","start":"0900","end":"1300"},{"date":"2017-06-09","start":"1300","end":"1700"},{"date":"2017-06-14","start":"0900","end":"1300"},{"date":"2017-06-14","start":"1300","end":"1700"},{"date":"2017-06-16","start":"0900","end":"1300"},{"date":"2017-06-16","start":"1300","end":"1700"},{"date":"2017-06-21","start":"0900","end":"1300"},{"date":"2017-06-21","start":"1300","end":"1700"},{"date":"2017-06-23","start":"0900","end":"1300"},{"date":"2017-06-23","start":"1300","end":"1700"},{"date":"2017-06-28","start":"0900","end":"1300"},{"date":"2017-06-28","start":"1300","end":"1700"},{"date":"2017-06-30","start":"0900","end":"1300"},{"date":"2017-06-30","start":"1300","end":"1700"},{"date":"2017-07-05","start":"0900","end":"1300"},{"date":"2017-07-05","start":"1300","end":"1700"},{"date":"2017-07-07","start":"0900","end":"1300"},{"date":"2017-07-07","start":"1300","end":"1700"}]'
+    http_version: 
+  recorded_at: Tue, 30 May 2017 11:37:09 GMT
+recorded_with: VCR 3.0.3

--- a/spec/lib/booking_requests/api_spec.rb
+++ b/spec/lib/booking_requests/api_spec.rb
@@ -31,4 +31,17 @@ RSpec.describe BookingRequests::Api, :vcr do
       end
     end
   end
+
+  describe '#slots' do
+    it 'returns slots for the given location' do
+      slots = subject.slots('ac7112c3-e3cf-45cd-a8ff-9ba827b8e7ef')
+
+      expect(slots).to be_present
+      expect(slots.first).to eq(
+        'date'  => '2017-06-02',
+        'start' => '0900',
+        'end'   => '1300'
+      )
+    end
+  end
 end

--- a/spec/lib/booking_requests/booking_requests_spec.rb
+++ b/spec/lib/booking_requests/booking_requests_spec.rb
@@ -1,9 +1,28 @@
 RSpec.describe BookingRequests do
+  let(:api) { instance_double(BookingRequests::Api) }
+
+  describe '.slots' do
+    before do
+      BookingRequests.api = api
+      allow(api).to receive(:slots).and_return(
+        [{ 'date' => '2017-06-02', 'start' => '0900', 'end' => '1300' }]
+      )
+    end
+
+    it 'returns slots for the calendar' do
+      response = BookingRequests.slots('ac7112c3-e3cf-45cd-a8ff-9ba827b8e7ef')
+
+      expect(response.first).to include(
+        'Friday, Jun  2 - Morning',
+        '2017-06-02-0900-1300'
+      )
+    end
+  end
+
   describe '.create' do
     context 'with a valid booking request' do
       let(:booking_request) { Hash[blah: 'welp'] }
       let(:result) { Hash.new }
-      let(:api) { instance_double(BookingRequests::Api) }
 
       before do
         BookingRequests.api = api


### PR DESCRIPTION
Bookable slots for face-to-face appointments are no longer the domain of
our location register and have been replaced by real schedules/availability
from the newly introduced planner API.