### PR TITLE
Cache footer categories

### DIFF
--- a/app/views/layouts/_base.html.erb
+++ b/app/views/layouts/_base.html.erb
@@ -74,7 +74,11 @@
 <% end %>
 
 <% content_for :footer_top do %>
-  <%= render 'components/footer_categories', categories: navigation.topics if footer? %>
+  <% if footer? %>
+    <% cache "footer_categories_#{I18n.locale}", expires_in: 2.hours do %>
+      <%= render 'components/footer_categories', categories: navigation.topics %>
+    <% end %>
+  <% end %>
 <% end %>
 
 <% content_for :body_end do %>


### PR DESCRIPTION
This was causing a significant increase in time taken to render the
base layout since calculating topics/categories is quite expensive to
compute. Caching these fragments is a quick-win.

<img width="816" alt="screen shot 2017-05-30 at 20 09 31" src="https://cloud.githubusercontent.com/assets/41963/26602267/d93a2398-457a-11e7-9055-6780fa38e3e7.png">
