### PR TITLE
Alter booking form step one to show no availibility message

### DIFF
--- a/app/controllers/booking_requests_controller.rb
+++ b/app/controllers/booking_requests_controller.rb
@@ -6,6 +6,12 @@ class BookingRequestsController < ApplicationController
 
   def step_one
     @feedback = FeedbackForm.for_online_booking
+
+    if @booking_request.slots_for_calendar.empty?
+      render :no_availability
+    else
+      render :step_one
+    end
   end
 
   def step_two

--- a/app/forms/booking_request_form.rb
+++ b/app/forms/booking_request_form.rb
@@ -58,6 +58,10 @@ class BookingRequestForm
     booking_location.name_for(location_id)
   end
 
+  def twilio_number
+    booking_location.online_booking_twilio_number
+  end
+
   def step_one_valid?
     @step = 1
     valid?

--- a/app/views/booking_requests/no_availability.html.erb
+++ b/app/views/booking_requests/no_availability.html.erb
@@ -1,0 +1,10 @@
+<% content_for(:page_title, t('service.title', page_title: "Book an appointment at #{@booking_request.location_name}")) %>
+<div class="l-grid-row">
+  <div class="l-column-two-thirds">
+    <h1 class="t-location-name">Book an appointment at <%= @booking_request.location_name %></h1>
+    <p>There are no available appointments at this location.</p>
+    <p>For an appointment at an alternative location call <b class="t-phone"><%= @booking_request.twilio_number %></b>.</p>
+  </div>
+</div>
+
+

--- a/features/customer_booking_request.feature
+++ b/features/customer_booking_request.feature
@@ -88,3 +88,11 @@ Scenario: Customer leaves inline feedback
   And I opt to book online
   When I complete the inline feedback
   Then I see my feedback was sent
+
+@booking_locations @no_availability
+Scenario: Customer attempts to book a location with no availability
+  Given a location is enabled for online booking
+  When I browse for the location "Hackney"
+  And I opt to book online
+  Then I see the location name "Hackney"
+  And I see a message to phone for availability

--- a/features/pages/booking_step_one.rb
+++ b/features/pages/booking_step_one.rb
@@ -12,6 +12,8 @@ module Pages
     elements :available_days, '.BookingCalendar-date--bookable'
     elements :time_slots, '.SlotPicker-day.is-active > label'
 
+    element :phone, '.t-phone'
+
     section :feedback, Sections::Feedback, '.t-feedback'
 
     def morning_slot

--- a/features/step_definitions/customer_booking_request_steps.rb
+++ b/features/step_definitions/customer_booking_request_steps.rb
@@ -252,6 +252,10 @@ Then(/^I see a warning of an invalid email address$/) do
   expect(@step_two).to have_content("That doesn't look like a valid address")
 end
 
+Then(/^I see a message to phone for availability$/) do
+  expect(@step_one).to have_phone
+end
+
 def with_booking_locations
   previous_path = Locations.geo_json_path_or_url
   Locations.geo_json_path_or_url = Rails.root.join(*@locations_path)

--- a/features/support/booking_requests.rb
+++ b/features/support/booking_requests.rb
@@ -7,3 +7,19 @@ Around('@booking_requests') do |_, block|
     BookingRequests.api = previous_api
   end
 end
+
+Around('@no_availability') do |_, block|
+  begin
+    previous_api = BookingRequests.api
+
+    BookingRequests.api = Class.new do
+      def slots(*)
+        []
+      end
+    end.new
+
+    block.call
+  ensure
+    BookingRequests.api = previous_api
+  end
+end


### PR DESCRIPTION
If a location has no availability then this shows a message
for the customer to call the location instead of showing
an empty calendar.

<img width="887" alt="screen shot 2017-06-01 at 13 41 00" src="https://cloud.githubusercontent.com/assets/6049076/26680119/fafeedd2-46cf-11e7-920d-db81309bd828.png">
