### PR TITLE
Update robots.txt to take into account welsh language URLs

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,20 +1,17 @@
 # See http://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
 #
 User-agent: *
-Disallow: /book
-Disallow: /email/
-Disallow: /signposting/
-Disallow: /leave-pot-untouched/estimate
-Disallow: /take-whole-pot/estimate
-Disallow: /home-alternative
-Disallow: /pension-type-tool/question-2
-Disallow: /pension-type-tool/question-3
-Disallow: /pension-type-tool/question-4
-Disallow: /pension-type-tool/question-4
-Disallow: /pension-type-tool/defined-contribution
-Disallow: /pension-type-tool/might-defined-contribution
-Disallow: /pension-type-tool/most-cases-defined-benefit
-Disallow: /pension-type-tool/most-cases-defined-contribution
-Disallow: /facebook-landing
-Disallow: /landing
-Disallow: /telephone-appointments/
+Disallow: /*/leave-pot-untouched/estimate
+Disallow: /*/take-whole-pot/estimate
+Disallow: /*/pension-type-tool/question-2
+Disallow: /*/pension-type-tool/question-3
+Disallow: /*/pension-type-tool/question-4
+Disallow: /*/pension-type-tool/defined-contribution
+Disallow: /*/pension-type-tool/might-defined-contribution
+Disallow: /*/pension-type-tool/most-cases-defined-benefit
+Disallow: /*/pension-type-tool/most-cases-defined-contribution
+Disallow: /*/facebook-landing
+Disallow: /*/landing
+Disallow: /*/about
+Disallow: /*/telephone-appointments/
+Disallow: /*/booking-request/


### PR DESCRIPTION
This puts a wildcard language directory at the start of URLs
in the robots.txt file.

It also removes some URLs from the robots.txt which are no
longer valid, and adds in /*/booking-request/ to avoid
step one of the f2f booking process from being indexed.

It was felt that allowing customers to go straight to the
booking form without explaining who is suitable for a
Pension Wise appointment might increase the chances of
getting invalid appointments.