### PR TITLE
Adding an additional info field to F2F booking form

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,6 +14,7 @@
 //= require components/SlotPicker
 //= require components/SlotPickerSingleTime
 //= require components/EmailValidation
+//= require components/CharacterLimit
 
 PWPG.clickTracker.init();
 PWPG.calculators.init();
@@ -54,4 +55,12 @@ $('[data-navigation]').each(function() {
   var $component = $(this);
 
   new PWPG.Navigation($component);
+});
+
+$('[data-character-limit]').each(function() {
+  'use strict';
+
+  var $component = $(this);
+
+  new PWPG.CharacterLimit($component);
 });

--- a/app/assets/javascripts/components/CharacterLimit.es6
+++ b/app/assets/javascripts/components/CharacterLimit.es6
@@ -1,0 +1,78 @@
+(function() {
+  'use strict';
+
+  class CharacterLimit extends PWPG.BaseComponent {
+    constructor($component) {
+      super($component);
+
+      this.$input = this.$component.find('.js-character-limit-input');
+      // ie9 doesn't recognise the maxlength attribute
+      this.characterLimit = this.$input.attr('data-maxlength');
+
+      if (!this.characterLimit) {
+        return;
+      }
+
+      this.insertCountdown();
+      this.bindEvents();
+    }
+
+    insertCountdown() {
+      const countdownId = `${this.$input.attr('id')}_characters_remaining`;
+
+      this.$remainingTextEl = $('<p />')
+        .attr('id', countdownId)
+        .html(this.getCountDownText());
+
+      this.$input.attr('aria-describedby', countdownId);
+
+      this.$remainingTextEl.insertAfter(this.$input);
+    }
+
+    getCountDownText() {
+      return `<span class="js-live-region">${this.getCharacterLeftCount()}
+        character${this.getCharacterLeftCount() === 1 ? '' : 's'} remaining</span>
+        of ${this.characterLimit} characters.
+      `;
+    }
+
+    bindEvents() {
+      this.$input.on('input propertychange keyup change', this.updateCount.bind(this));
+    }
+
+    updateCount() {
+      this.$remainingTextEl.html(this.getCountDownText());
+
+      const $liveRegion = this.$component.find('.js-live-region'),
+      percentageCharactersLeft = (this.getCharacterLeftCount() / this.characterLimit);
+
+      if (percentageCharactersLeft < 0) {
+        this.$input.val(this.$input.val().substr(0, this.characterLimit));
+        this.updateCount();
+      }
+
+      $liveRegion.removeAttr('aria-live aria-atomic');
+
+      if (percentageCharactersLeft <= 0.5) {
+        $liveRegion.attr('aria-live', 'polite');
+        $liveRegion.attr('aria-atomic', true);
+      }
+
+      if (percentageCharactersLeft <= 0.4) {
+        $liveRegion.attr('aria-atomic', false);
+      }
+
+      if (percentageCharactersLeft <= 0.2) {
+        $liveRegion.attr('aria-live', 'assertive');
+        $liveRegion.attr('aria-atomic', true);
+      }
+    }
+
+    getCharacterLeftCount() {
+      return this.characterLimit - this.$input.val().length;
+    }
+  }
+
+  window.PWPG = window.PWPG || {};
+  window.PWPG.CharacterLimit = CharacterLimit;
+})();

--- a/app/controllers/booking_requests_controller.rb
+++ b/app/controllers/booking_requests_controller.rb
@@ -63,7 +63,8 @@ class BookingRequestsController < ApplicationController
         :memorable_word,
         :date_of_birth,
         :accessibility_requirements,
-        :dc_pot
+        :dc_pot,
+        :additional_info
       )
   end
 

--- a/app/forms/booking_request_form.rb
+++ b/app/forms/booking_request_form.rb
@@ -4,7 +4,7 @@ class BookingRequestForm
   attr_accessor :location_id, :primary_slot, :secondary_slot, :tertiary_slot,
                 :first_name, :last_name, :email, :telephone_number,
                 :memorable_word, :accessibility_requirements,
-                :date_of_birth, :dc_pot
+                :date_of_birth, :dc_pot, :additional_info
 
   with_options if: :step_one? do |step_one|
     step_one.validates :primary_slot, presence: true
@@ -21,6 +21,7 @@ class BookingRequestForm
     step_two.validates :accessibility_requirements, inclusion: { in: %w(0 1) }
     step_two.validates :dc_pot, inclusion: { in: %w(yes no not-sure) }
     step_two.validates :date_of_birth, presence: true
+    step_two.validates :additional_info, length: { maximum: 160 }, allow_blank: true
   end
 
   def initialize(location_id, opts)

--- a/app/lib/booking_requests/api_mapper.rb
+++ b/app/lib/booking_requests/api_mapper.rb
@@ -14,6 +14,7 @@ module BookingRequests
           accessibility_requirements: booking_request.accessibility_requirements,
           marketing_opt_in: true,
           defined_contribution_pot_confirmed: dc_pot_as_boolean(booking_request.dc_pot),
+          additional_info: booking_request.additional_info,
           slots: [
             slot(1, booking_request.primary_slot),
             slot(2, booking_request.secondary_slot),

--- a/app/views/booking_requests/step_two.html.erb
+++ b/app/views/booking_requests/step_two.html.erb
@@ -183,6 +183,16 @@
         </div>
       </div>
 
+      <div class="form-group" data-character-limit>
+        <%= f.label :additional_info, class: 'form-label-bold' do %>
+          Additional information
+          <span class="form-hint">
+            eg Any times you’re not available
+          </span>
+        <% end %>
+        <%= f.text_area :additional_info, class: 'form-control form-control-3-4 js-character-limit-input', rows: 5, maxlength: 160, data: { maxlength: 160 } %>
+      </div>
+
       <div class="form-group">
         <%= f.submit 'Submit booking request', class: 'button t-submit', data: { disable_with: 'Please wait...' } %>
       </div>

--- a/spec/forms/booking_request_form_spec.rb
+++ b/spec/forms/booking_request_form_spec.rb
@@ -15,7 +15,8 @@ RSpec.describe BookingRequestForm do
         memorable_word: 'meseeks',
         date_of_birth: '1950-01-01',
         accessibility_requirements: '0',
-        dc_pot: 'yes'
+        dc_pot: 'yes',
+        additional_info: ''
       )
     end
 
@@ -84,6 +85,11 @@ RSpec.describe BookingRequestForm do
         subject.dc_pot = false
         expect(subject).not_to be_step_two_valid
         expect(subject).not_to be_eligible
+      end
+
+      it 'ensures `additional_info` is no longer than 160 characters' do
+        subject.additional_info = '*' * 161
+        expect(subject).not_to be_step_two_valid
       end
     end
   end

--- a/spec/lib/booking_requests/api_mapper_spec.rb
+++ b/spec/lib/booking_requests/api_mapper_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe BookingRequests::ApiMapper do
       memorable_word: 'meseeks',
       date_of_birth: '1951-01-01',
       accessibility_requirements: false,
+      additional_info: 'Additional Info',
       dc_pot: 'yes'
     )
   end
@@ -35,6 +36,7 @@ RSpec.describe BookingRequests::ApiMapper do
           age_range: '55-plus',
           date_of_birth: '1951-01-01',
           accessibility_requirements: false,
+          additional_info: 'Additional Info',
           marketing_opt_in: true,
           defined_contribution_pot_confirmed: true,
           slots: [


### PR DESCRIPTION
**This PR needs to be merge after this one https://github.com/guidance-guarantee-programme/planner/pull/169**

This introduces an additional information text field which allows customers to specify an additional amount of information about their booking request e.g. times they aren't available during
a AM/PM slot.

It also introduces a character limit module in JS which

a) Limits input to the textbox to 160 chars on older browsers which don't support the maxlength attribute on a <textarea>
b) Displays a character remaining count underneath the textarea
c) Makes use of the aria-live and aria-atomic attributes when the user is getting low on characters left, so screen reader users are aware that they are starting to hit the character limit.

![](http://g.recordit.co/jU6aK84IKO.gif)