### PR TITLE
Correct issue with ERB response

### DIFF
--- a/app/views/locations/index.html.erb
+++ b/app/views/locations/index.html.erb
@@ -59,5 +59,5 @@
 <%= render 'components/locations_search' %>
 
 <div class="application-notice info-notice">
-  <p>You can also <% link_to 'book a phone appointment', guide_path('book', anchor: 'by-phone') %>.</p>
+  <p>You can also <%= link_to 'book a phone appointment', guide_path('book-phone') %>.</p>
 </div>


### PR DESCRIPTION
The `=` was missing thus the `link_to` was not being evaluated. I've
also changed the path to go directly to the guide for phone bookings,
to be consistent with our usage elsewhere.