### PR TITLE
Removing reference to Citizens Advice from all location pages

### DIFF
--- a/app/views/locations/show.html.erb
+++ b/app/views/locations/show.html.erb
@@ -25,7 +25,7 @@
 <div class="l-grid-row">
   <div class="l-column-half">
     <p>
-      Your appointment will be at <%= @location.name %> Citizens Advice with a trained Pension Wise
+      Your appointment will be with a trained Pension Wise
       guidance specialist.
     </p>
 


### PR DESCRIPTION
As all location addresses have been updated fully we no longer require
the location title and Citizens Advice reference as this does not apply
to a number of locations. The 1st line of the address contains the
information whether its a Age Uk or Citizens advice location.