### PR TITLE
Bump `output-templates`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ source 'https://rubygems.org' do # rubocop:disable Metrics/BlockLength
   gem 'inline_svg'
   gem 'newrelic_rpm'
   gem 'nokogiri'
-  gem 'output-templates', '~> 4.6.0', github: 'guidance-guarantee-programme/output-templates'
+  gem 'output-templates', '~> 4.7.0', github: 'guidance-guarantee-programme/output-templates'
   gem 'phoner'
   gem 'postcodes_io'
   # https://github.com/mbleigh/princely/pull/53

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: https://github.com/guidance-guarantee-programme/output-templates.git
-  revision: 35cdfd7faf753cf7572a07c46a42c62355d86a9a
+  revision: 3beff20ba153a85e26e637f248fea93543e49e35
   specs:
-    output-templates (4.6.0)
+    output-templates (4.7.0)
       actionview
       sass
 
@@ -438,7 +438,7 @@ DEPENDENCIES
   lograge!
   newrelic_rpm!
   nokogiri!
-  output-templates (~> 4.6.0)!
+  output-templates (~> 4.7.0)!
   pdf-inspector!
   phantomjs-binaries!
   phoner!


### PR DESCRIPTION
Bumps `output-templates` for the latest changes based on recent guider
feedback.