### PR TITLE
Hide 'Book online' button when a location has no availability

### DIFF
--- a/app/controllers/booking_requests_controller.rb
+++ b/app/controllers/booking_requests_controller.rb
@@ -7,7 +7,7 @@ class BookingRequestsController < ApplicationController
   def step_one
     @feedback = FeedbackForm.for_online_booking
 
-    if @booking_request.slots_for_calendar.empty?
+    if @booking_request.no_availability?
       render :no_availability
     else
       render :step_one

--- a/app/forms/booking_request_form.rb
+++ b/app/forms/booking_request_form.rb
@@ -45,13 +45,15 @@ class BookingRequestForm
     end
   end
 
-  def slots_for_calendar
-    @slots_for_calendar ||= BookingRequests.slots(location_id)
+  def location
+    @location ||= Locations.find(location_id)
   end
 
   def booking_location
     @booking_location ||= BookingLocations.find(location_id)
   end
+
+  delegate :slots, :no_availability?, to: :location
 
   delegate :id, to: :booking_location, prefix: :booking_location
 

--- a/app/lib/locations/location.rb
+++ b/app/lib/locations/location.rb
@@ -23,5 +23,9 @@ module Locations
     def no_availability?
       slots.empty?
     end
+
+    def slots_available?
+      !no_availability?
+    end
   end
 end

--- a/app/lib/locations/location.rb
+++ b/app/lib/locations/location.rb
@@ -15,5 +15,13 @@ module Locations
     def online_booking_enabled?
       online_booking_enabled
     end
+
+    def slots
+      @slots ||= BookingRequests.slots(id)
+    end
+
+    def no_availability?
+      slots.empty?
+    end
   end
 end

--- a/app/views/booking_requests/step_one.html.erb
+++ b/app/views/booking_requests/step_one.html.erb
@@ -46,9 +46,9 @@
       </div>
 
       <%= form_for @booking_request, url: booking_request_step_two_location_path(id: location_id), as: :booking_request do |f| %>
-        <%= f.select(:primary_slot, @booking_request.slots_for_calendar, { include_blank: "" }, { class: 'SlotPicker-input hide-only-with-js' }) %>
-        <%= f.select(:secondary_slot, @booking_request.slots_for_calendar, { include_blank: "" }, { class: 'SlotPicker-input hide-only-with-js' }) %>
-        <%= f.select(:tertiary_slot, @booking_request.slots_for_calendar, { include_blank: "" }, { class: 'SlotPicker-input hide-only-with-js' }) %>
+        <%= f.select(:primary_slot, @booking_request.slots, { include_blank: "" }, { class: 'SlotPicker-input hide-only-with-js' }) %>
+        <%= f.select(:secondary_slot, @booking_request.slots, { include_blank: "" }, { class: 'SlotPicker-input hide-only-with-js' }) %>
+        <%= f.select(:tertiary_slot, @booking_request.slots, { include_blank: "" }, { class: 'SlotPicker-input hide-only-with-js' }) %>
         <p>Appointment availability depends on location. You may not get your requested dates. We may need to call you to arrange an alternative date.</p>
         <p><%= f.button('Continue', type: 'submit', class: 'button t-continue') %></p>
       <% end %>

--- a/app/views/locations/index.html.erb
+++ b/app/views/locations/index.html.erb
@@ -20,7 +20,7 @@
             <%= location.distance %> miles
           </p>
 
-          <% if location.online_booking_enabled? %>
+          <% if location.online_booking_enabled? && location.slots_available? %>
             <p>
               <%= link_to 'Book online', booking_request_step_one_location_path(location.id), class: 'button t-book-online' %>
             </p>

--- a/app/views/locations/show.html.erb
+++ b/app/views/locations/show.html.erb
@@ -36,7 +36,7 @@
 
     <h2>How to book</h2>
 
-    <% if @location.online_booking_enabled? %>
+    <% if @location.online_booking_enabled? && @location.slots_available? %>
       <p>
         <%= link_to 'Book online', booking_request_step_one_location_path(@location.id), class: 'button t-book-online' %>
       </p>

--- a/config/initializers/online_booking_requests.rb
+++ b/config/initializers/online_booking_requests.rb
@@ -1,4 +1,4 @@
-BookingRequests.api = if Rails.env.development?
+BookingRequests.api = if Rails.env.development? || Rails.env.test?
                         BookingRequests::StubApi.new
                       else
                         BookingRequests::Api.new

--- a/features/accessibility.feature
+++ b/features/accessibility.feature
@@ -27,7 +27,7 @@ Feature: Accessibility of pages
     When I visit the appointment summary page
     Then the page should be accessible
 
-  @booking_locations @booking_requests
+  @booking_locations
   Scenario: Slot picker for face to face booking is not accessible while we develop our own slot picker
     When I view the face to face booking form
     Then the page should be accessible excluding ".SlotPicker"

--- a/features/customer_booking_request.feature
+++ b/features/customer_booking_request.feature
@@ -13,7 +13,7 @@ Scenario: Customer browses a regular location
   When I browse for the location "Hackney"
   Then I cannot book online
 
-@javascript @booking_locations @booking_requests @time_travel
+@javascript @booking_locations @time_travel
 Scenario: Customer makes an online Booking Request
   Given a location is enabled for online booking
   And the date is "2016-06-17"
@@ -26,7 +26,7 @@ Scenario: Customer makes an online Booking Request
   And I submit my completed Booking Request
   Then my Booking Request is confirmed
 
-@javascript @booking_locations @booking_requests @time_travel
+@javascript @booking_locations @time_travel
 Scenario: Customer navigates between Booking Request steps
   Given a location is enabled for online booking
   And the date is "2016-06-17"
@@ -42,7 +42,7 @@ Scenario: Customer navigates between Booking Request steps
   And I submit my completed Booking Request
   Then my Booking Request is confirmed
 
-@javascript @booking_locations @booking_requests @time_travel @mock_mailgun
+@javascript @booking_locations @time_travel @mock_mailgun
 Scenario: Customer makes a mistakes in their email address and gets a suggestions
   Given a location is enabled for online booking
   And the date is "2016-06-17"
@@ -54,7 +54,7 @@ Scenario: Customer makes a mistakes in their email address and gets a suggestion
   When I enter an invalid email address
   Then I see a warning of an invalid email address
 
-@javascript @booking_locations @booking_requests @time_travel
+@javascript @booking_locations @time_travel
 Scenario: Customer attempts an invalid Booking Request
   Given a location is enabled for online booking
   And the date is "2016-06-17"
@@ -68,7 +68,7 @@ Scenario: Customer attempts an invalid Booking Request
   And I submit my incomplete Booking Request
   Then I am told to complete my personal details
 
-@javascript @booking_locations @booking_requests @time_travel
+@javascript @booking_locations @time_travel
 Scenario: Customer is ineligible for guidance
   Given a location is enabled for online booking
   And the date is "2016-06-17"
@@ -80,7 +80,7 @@ Scenario: Customer is ineligible for guidance
   When I submit my completed Booking Request
   Then I am told I am ineligible for guidance
 
-@javascript @booking_locations @time_travel @booking_requests
+@javascript @booking_locations @time_travel
 Scenario: Customer leaves inline feedback
   Given a location is enabled for online booking
   And the date is "2016-06-17"

--- a/features/customer_booking_request.feature
+++ b/features/customer_booking_request.feature
@@ -93,6 +93,4 @@ Scenario: Customer leaves inline feedback
 Scenario: Customer attempts to book a location with no availability
   Given a location is enabled for online booking
   When I browse for the location "Hackney"
-  And I opt to book online
-  Then I see the location name "Hackney"
-  And I see a message to phone for availability
+  Then I cannot book online

--- a/features/fixtures/locations.json
+++ b/features/fixtures/locations.json
@@ -21,6 +21,24 @@
     },
     {
       "type": "Feature",
+      "id": "ac7112c3-e3cf-45cd-a8ff-9ba827b8e7ef",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -0.0551488,
+          51.5443995
+        ]
+      },
+      "properties": {
+        "title": "Hackney",
+        "address": "Hackney Citizens Advice\n300 Mare St\nHackney\nLondon\nE8 1HE",
+        "phone": "345 6789",
+        "hours": "Mon-Fri 9-5",
+        "twilio_number": "+442086291106"
+      }
+    },
+    {
+      "type": "Feature",
       "id": "paris",
       "geometry": {
         "type": "Point",

--- a/features/step_definitions/location_steps.rb
+++ b/features/step_definitions/location_steps.rb
@@ -46,9 +46,10 @@ end
 Then(/^I should see the (\d+) appointment locations nearest to that postcode$/) do |_number_of_locations|
   page_locations = Pages::Locations.new.locations
 
-  expected_locations = ['London', 'Paris', 'New York']
+  expected_locations = ['London', 'Hackney', 'Paris', 'New York']
   expected_addresses = [
     '1 Horse Guards Road SW1A 2HQ',
+    'Hackney Citizens Advice 300 Mare St Hackney London E8 1HE',
     '35 Rue du Faubourg Saint-Honoré 75008 Paris',
     'Manhattan NY 10036 United States'
   ]

--- a/features/support/booking_requests.rb
+++ b/features/support/booking_requests.rb
@@ -1,13 +1,3 @@
-Around('@booking_requests') do |_, block|
-  begin
-    previous_api = BookingRequests.api
-    BookingRequests.api = BookingRequests::StubApi.new
-    block.call
-  ensure
-    BookingRequests.api = previous_api
-  end
-end
-
 Around('@no_availability') do |_, block|
   begin
     previous_api = BookingRequests.api

--- a/spec/lib/booking_requests/booking_requests_spec.rb
+++ b/spec/lib/booking_requests/booking_requests_spec.rb
@@ -2,8 +2,11 @@ RSpec.describe BookingRequests do
   let(:api) { instance_double(BookingRequests::Api) }
 
   describe '.slots' do
+    around do |example|
+      with_stubbed_booking_requests_api(api, example)
+    end
+
     before do
-      BookingRequests.api = api
       allow(api).to receive(:slots).and_return(
         [{ 'date' => '2017-06-02', 'start' => '0900', 'end' => '1300' }]
       )
@@ -24,8 +27,11 @@ RSpec.describe BookingRequests do
       let(:booking_request) { Hash[blah: 'welp'] }
       let(:result) { Hash.new }
 
+      around do |example|
+        with_stubbed_booking_requests_api(api, example)
+      end
+
       before do
-        BookingRequests.api = api
         allow(BookingRequests::ApiMapper).to receive(:map).with(booking_request).and_return(result)
         allow(api).to receive(:create).with(result).and_return(true)
       end

--- a/spec/support/helpers/with_stub_booking_requests_api.rb
+++ b/spec/support/helpers/with_stub_booking_requests_api.rb
@@ -1,0 +1,14 @@
+module WithStubBookingRequestsApi
+  def with_stubbed_booking_requests_api(api, example)
+    previous_api = BookingRequests.api
+    BookingRequests.api = api
+
+    example.run
+  ensure
+    BookingRequests.api = previous_api
+  end
+end
+
+RSpec.configure do |config|
+  config.include WithStubBookingRequestsApi
+end


### PR DESCRIPTION
Some ground work needed before making the very simple addition of view logic to perform the task at hand, but handily was able to pull over a few of the commits from my parked [limited availability PR](https://github.com/guidance-guarantee-programme/pension_guidance/pull/946).