### PR TITLE
Bumping output-templates version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ source 'https://rubygems.org' do # rubocop:disable Metrics/BlockLength
   gem 'inline_svg'
   gem 'newrelic_rpm'
   gem 'nokogiri'
-  gem 'output-templates', '~> 4.7.0', github: 'guidance-guarantee-programme/output-templates'
+  gem 'output-templates', '~> 4.7.1', github: 'guidance-guarantee-programme/output-templates'
   gem 'phoner'
   gem 'postcodes_io'
   # https://github.com/mbleigh/princely/pull/53

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: https://github.com/guidance-guarantee-programme/output-templates.git
-  revision: 3beff20ba153a85e26e637f248fea93543e49e35
+  revision: fd1176195e1d297553b38d4bd0ef5323cfe25482
   specs:
-    output-templates (4.7.0)
+    output-templates (4.7.1)
       actionview
       sass
 
@@ -438,7 +438,7 @@ DEPENDENCIES
   lograge!
   newrelic_rpm!
   nokogiri!
-  output-templates (~> 4.7.0)!
+  output-templates (~> 4.7.1)!
   pdf-inspector!
   phantomjs-binaries!
   phoner!


### PR DESCRIPTION
Updating version of output-templates based on typo fixes to the summary
document