### PR TITLE
Permit between one and three face-to-face slots

### DIFF
--- a/app/forms/booking_request_form.rb
+++ b/app/forms/booking_request_form.rb
@@ -6,11 +6,7 @@ class BookingRequestForm
                 :memorable_word, :accessibility_requirements,
                 :date_of_birth, :dc_pot, :additional_info
 
-  with_options if: :step_one? do |step_one|
-    step_one.validates :primary_slot, presence: true
-    step_one.validates :secondary_slot, presence: true
-    step_one.validates :tertiary_slot, presence: true
-  end
+  validates :primary_slot, presence: true, if: :step_one?
 
   with_options if: :step_two? do |step_two|
     step_two.validates :first_name, presence: true

--- a/app/lib/booking_requests/api_mapper.rb
+++ b/app/lib/booking_requests/api_mapper.rb
@@ -19,12 +19,14 @@ module BookingRequests
             slot(1, booking_request.primary_slot),
             slot(2, booking_request.secondary_slot),
             slot(3, booking_request.tertiary_slot)
-          ]
+          ].compact
         }
       }
     end
 
     def self.slot(priority, slot_text)
+      return if slot_text.blank?
+
       date, from, to = slot_text.match(/\A(\d{4}-\d{2}-\d{2})-(\d{4})-(\d{4})\z/).captures
 
       {

--- a/app/views/booking_requests/step_one.html.erb
+++ b/app/views/booking_requests/step_one.html.erb
@@ -11,14 +11,14 @@
           There was a problem with your chosen dates
         </h1>
 
-        <p>Please select 3 dates for your appointment.</p>
+        <p>Please select at least 1 date for your appointment.</p>
       </div>
     </div>
   <% end %>
 
   <div class="SlotPicker"
        data-today="<%= Date.today %>"
-       data-limit-exceeded-error="You can only select 3 choices. Go back to change your dates or continue.">
+       data-limit-exceeded-error="You can only select up to 3 choices. Go back to change your dates or continue.">
     <div class="l-column-half">
       <div class="SlotPicker-timeSlots show-only-with-js">
         <ul class="SlotPicker-days">
@@ -49,7 +49,7 @@
         <%= f.select(:primary_slot, @booking_request.slots, { include_blank: "" }, { class: 'SlotPicker-input hide-only-with-js' }) %>
         <%= f.select(:secondary_slot, @booking_request.slots, { include_blank: "" }, { class: 'SlotPicker-input hide-only-with-js' }) %>
         <%= f.select(:tertiary_slot, @booking_request.slots, { include_blank: "" }, { class: 'SlotPicker-input hide-only-with-js' }) %>
-        <p>Appointment availability depends on location. You may not get your requested dates. We may need to call you to arrange an alternative date.</p>
+        <p>Appointment availability depends on location. We may need to call you to arrange an alternative date.</p>
         <p><%= f.button('Continue', type: 'submit', class: 'button t-continue') %></p>
       <% end %>
     </div>
@@ -169,7 +169,7 @@
   </div>
 
   {{#if first}}
-  <p class="SlotPicker-slot-explainer">Choose 2 alternative dates in case your first choice isn’t available.</p>
+  <p class="SlotPicker-slot-explainer">If shown as available choose up to 2 alternative dates in case your first choice isn’t available.</p>
   {{/if}}
 </script>
 

--- a/app/views/booking_requests/step_two.html.erb
+++ b/app/views/booking_requests/step_two.html.erb
@@ -218,6 +218,7 @@
         </div>
       </div>
 
+      <% if @booking_request.secondary_slot.present? %>
       <div class="SlotPicker-choice is-chosen">
         <div class="SlotPicker-choiceInner">
           <div class="SlotPicker-position"><span>2</span></div>
@@ -228,7 +229,9 @@
           </div>
         </div>
       </div>
+      <% end %>
 
+      <% if @booking_request.tertiary_slot.present? %>
       <div class="SlotPicker-choice is-chosen">
         <div class="SlotPicker-choiceInner">
           <div class="SlotPicker-position"><span>3</span></div>
@@ -239,6 +242,7 @@
           </div>
         </div>
       </div>
+      <% end %>
     </div>
 
     <p>

--- a/app/views/booking_requests/step_two.html.erb
+++ b/app/views/booking_requests/step_two.html.erb
@@ -206,7 +206,7 @@
     <h2>Your dates</h2>
     <p>You requested these dates for an appointment.</p>
 
-    <div class="SlotPicker-choices is-chosen SlotPicker--selected SlotPicker--read-only">
+    <div class="is-chosen SlotPicker--selected SlotPicker--read-only">
       <div class="SlotPicker-choice is-chosen">
         <div class="SlotPicker-choiceInner">
           <div class="SlotPicker-position"><span>1</span></div>

--- a/features/customer_booking_request.feature
+++ b/features/customer_booking_request.feature
@@ -55,14 +55,12 @@ Scenario: Customer makes a mistakes in their email address and gets a suggestion
   Then I see a warning of an invalid email address
 
 @javascript @booking_locations @time_travel
-Scenario: Customer attempts an invalid Booking Request
+Scenario: Customer chooses a single slot
   Given a location is enabled for online booking
   And the date is "2016-06-17"
   When I browse for the location "Hackney"
   And I opt to book online
   And I choose one available appointment slot
-  Then I am told to choose further slots
-  When I choose a further two appointment slots
   Then I progress to the personal details step
   When I pass the basic eligibility requirements
   And I submit my incomplete Booking Request

--- a/spec/forms/booking_request_form_spec.rb
+++ b/spec/forms/booking_request_form_spec.rb
@@ -6,8 +6,6 @@ RSpec.describe BookingRequestForm do
       described_class.new(
         location_id,
         primary_slot: '2016-01-01-0900-1300',
-        secondary_slot: '2016-01-01-1300-1700',
-        tertiary_slot: '2016-01-02-0900-1300',
         first_name: 'Lucius',
         last_name: 'Needful',
         email: 'lucius@example.com',
@@ -27,12 +25,10 @@ RSpec.describe BookingRequestForm do
     end
 
     context 'step one' do
-      %w(primary secondary tertiary).each do |slot|
-        it "requires the #{slot} slot" do
-          subject.public_send("#{slot}_slot=", nil)
+      it 'requires the first slot' do
+        subject.primary_slot = nil
 
-          expect(subject).to_not be_step_one_valid
-        end
+        expect(subject).to_not be_step_one_valid
       end
     end
 

--- a/spec/lib/booking_requests/api_mapper_spec.rb
+++ b/spec/lib/booking_requests/api_mapper_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe BookingRequests::ApiMapper do
       location_id,
       primary_slot: '2016-01-01-0900-1300',
       secondary_slot: '2016-01-01-1300-1700',
-      tertiary_slot: '2016-01-02-0900-1300',
+      tertiary_slot: '',
       first_name: 'Lucius',
       last_name: 'Needful',
       email: 'lucius@example.com',
@@ -41,8 +41,7 @@ RSpec.describe BookingRequests::ApiMapper do
           defined_contribution_pot_confirmed: true,
           slots: [
             { priority: 1, date: '2016-01-01', from: '0900', to: '1300' },
-            { priority: 2, date: '2016-01-01', from: '1300', to: '1700' },
-            { priority: 3, date: '2016-01-02', from: '0900', to: '1300' }
+            { priority: 2, date: '2016-01-01', from: '1300', to: '1700' }
           ]
         }
       )


### PR DESCRIPTION
Previously we required three choices at all times. We now need just one
slot chosen for the customer to proceed but still recommend up to 3
choices.

Needs coordination with guidance-guarantee-programme/planner#175.

![journey](https://user-images.githubusercontent.com/41963/27692213-0688075a-5cde-11e7-837b-3c71d4afa5ce.png)
