### PR TITLE
Updates to “Popular on Pension Wise” links on homepage

### DIFF
--- a/app/views/home/show.html.erb
+++ b/app/views/home/show.html.erb
@@ -16,11 +16,11 @@
     <div class="quick-links">
       <h2 class="quick-links__header">Popular on Pension Wise</h2>
       <ul class="quick-links__list">
+        <li class="quick-links__item"><%= link_to 'What you can do with your pot', guide_path('pension-pot-options'), class: 'quick-links__link' %></li>
         <li class="quick-links__item"><%= link_to 'Check how much is in your pot', guide_path('pension-pot-value'), class: 'quick-links__link' %></li>
         <li class="quick-links__item"><%= link_to 'Tax and pensions', guide_path('tax'), class: 'quick-links__link' %></li>
         <li class="quick-links__item"><%= link_to 'The State Pension', guide_path('state-pension'), class: 'quick-links__link' %></li>
         <li class="quick-links__item"><%= link_to 'How to avoid a pension scam', guide_path('scams'), class: 'quick-links__link' %></li>
-        <li class="quick-links__item"><%= link_to 'Understand your pension statement', guide_path('pension-statements'), class: 'quick-links__link' %></li>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
Remove 'Understand your pension statement'.

Add at the top of the list 'What you can do with you pot'