### PR TITLE
Pool Redis connections for locations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ source 'https://rubygems.org' do # rubocop:disable Metrics/BlockLength
   gem 'booking_locations'
   gem 'bugsnag'
   gem 'canonical-rails'
+  gem 'connection_pool'
   gem 'email_validation'
   gem 'faraday'
   gem 'faraday-conductivity'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,6 +103,7 @@ GEM
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
     concurrent-ruby (1.0.5)
+    connection_pool (2.2.1)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     cucumber (2.4.0)
@@ -418,6 +419,7 @@ DEPENDENCIES
   booking_locations!
   bugsnag!
   canonical-rails!
+  connection_pool!
   cucumber-rails!
   email_validation!
   fakeredis!
@@ -477,4 +479,4 @@ RUBY VERSION
    ruby 2.4.1p111
 
 BUNDLED WITH
-   1.15.0
+   1.15.1

--- a/config/initializers/redis_pool.rb
+++ b/config/initializers/redis_pool.rb
@@ -1,0 +1,4 @@
+REDIS_POOL = ConnectionPool.new(
+  size:    ENV.fetch('REDIS_POOL_SIZE') { 10 }.to_i,
+  timeout: ENV.fetch('REDIS_POOL_TIMEOUT') { 5 }.to_i
+) { Redis.new }


### PR DESCRIPTION
Previously Redis connections were unbounded by the location reader.
This change ensures they are monentarily checked out from a bounded
connection pool, so that during times of increased load we are not
exhausting all available Redis connections. This was particularly
evident while the location pages are crawled by various bots.