### PR TITLE
Use `z-index` to bring logo up above the language toggle container

### DIFF
--- a/app/assets/stylesheets/components/govspeak/_header-logo.scss
+++ b/app/assets/stylesheets/components/govspeak/_header-logo.scss
@@ -1,0 +1,6 @@
+// Modify z-index of the logo due to being
+// obscured by `.language-toggle`
+.header-logo {
+  position: relative;
+  z-index: 1;
+}


### PR DESCRIPTION
Checked back to the initial release of the localisation and this has been an issue since the start.

Made the `z-index` of the header 1, `position: relative` required as z-index only has an effect on "positioned" elements.

Tab sequence still the same as before so looks like no accessibility side effects.