### PR TITLE
Don't error when refreshing a confirmation

### DIFF
--- a/app/controllers/telephone_appointments_controller.rb
+++ b/app/controllers/telephone_appointments_controller.rb
@@ -18,6 +18,8 @@ class TelephoneAppointmentsController < ApplicationController
   end
 
   def confirmation
+    return redirect_to root_path unless params[:booking_reference]
+
     @booking_reference = params[:booking_reference]
     @booking_date      = Time.zone.parse(params[:booking_date])
   end

--- a/spec/features/telephone_appointment_spec.rb
+++ b/spec/features/telephone_appointment_spec.rb
@@ -1,0 +1,8 @@
+RSpec.feature 'Customer books a telephone appointment', type: :feature do
+  scenario 'Refreshing their confirmation' do
+    # visit without required params
+    visit confirmation_telephone_appointments_path(locale: :en)
+
+    expect(page.current_path).to eq(root_path(locale: :en))
+  end
+end


### PR DESCRIPTION
When customers return to an old browser session their device may refresh
the confirmation page without the requisite parameters. We are seeing
this occur a few times weekly in our error tracker. Rather than display
an error we should simply return them to the homepage.

I've only checked the presence of the `booking_reference` parameter
since one will not exist without the other when refreshing.