### PR TITLE
Update link from pension type tool to self serve journey

### DIFF
--- a/content/pension_type_tool/defined_contribution.cy.md
+++ b/content/pension_type_tool/defined_contribution.cy.md
@@ -16,6 +16,6 @@ You can book a free Pension Wise appointment to talk about your options for taki
 
 [Book a free appointment](/cy/appointments){: .button}
 
-^You can also [check another pension](/cy/pension-type-tool).^
+^You can also [check another pension](/cy/pension-type-tool) or [explore your pension options](/cy/explore-your-options).^
 
 [Give us your feedback](http://research.pensionwise.gov.uk/s/PTTfeedback/)

--- a/content/pension_type_tool/defined_contribution.en.md
+++ b/content/pension_type_tool/defined_contribution.en.md
@@ -16,6 +16,6 @@ You can book a free Pension Wise appointment to talk about your options for taki
 
 [Book a free appointment](/en/appointments){: .button}
 
-^You can also [check another pension](/en/pension-type-tool).^
+^You can also [check another pension](/en/pension-type-tool) or [explore your pension options](/en/explore-your-options).^
 
 [Give us your feedback](http://research.pensionwise.gov.uk/s/PTTfeedback/)

--- a/content/pension_type_tool/might_defined_contribution.cy.md
+++ b/content/pension_type_tool/might_defined_contribution.cy.md
@@ -16,6 +16,6 @@ You can book a free Pension Wise appointment to talk about your options for taki
 
 [Book a free appointment](/cy/appointments){: .button}
 
-^You can also [check another pension](/cy/pension-type-tool).^
+^You can also [check another pension](/cy/pension-type-tool) or [explore your pension options](/cy/explore-your-options).^
 
 [Give us your feedback](http://research.pensionwise.gov.uk/s/PTTfeedback/)

--- a/content/pension_type_tool/might_defined_contribution.en.md
+++ b/content/pension_type_tool/might_defined_contribution.en.md
@@ -16,6 +16,6 @@ You can book a free Pension Wise appointment to talk about your options for taki
 
 [Book a free appointment](/en/appointments){: .button}
 
-^You can also [check another pension](/en/pension-type-tool).^
+^You can also [check another pension](/en/pension-type-tool) or [explore your pension options](/en/explore-your-options).^
 
 [Give us your feedback](http://research.pensionwise.gov.uk/s/PTTfeedback/)

--- a/content/pension_type_tool/most_cases_defined_contribution.cy.md
+++ b/content/pension_type_tool/most_cases_defined_contribution.cy.md
@@ -16,6 +16,6 @@ You can book a free Pension Wise appointment to talk about your options for taki
 
 [Book a free appointment](/cy/appointments){: .button}
 
-^You can also [check another pension](/cy/pension-type-tool).^
+^You can also [check another pension](/cy/pension-type-tool) or [explore your pension options](/cy/explore-your-options).^
 
 [Give us your feedback](http://research.pensionwise.gov.uk/s/PTTfeedback/)

--- a/content/pension_type_tool/most_cases_defined_contribution.en.md
+++ b/content/pension_type_tool/most_cases_defined_contribution.en.md
@@ -16,6 +16,6 @@ You can book a free Pension Wise appointment to talk about your options for taki
 
 [Book a free appointment](/en/appointments){: .button}
 
-^You can also [check another pension](/en/pension-type-tool).^
+^You can also [check another pension](/en/pension-type-tool) or [explore your pension options](/en/explore-your-options).^
 
 [Give us your feedback](http://research.pensionwise.gov.uk/s/PTTfeedback/)


### PR DESCRIPTION
A link in the pension type tool that previously linked back to the start of the tool, now linking to the self serve journey.