### PR TITLE
Ensure correct locations are suggested

### DIFF
--- a/app/forms/booking_request_form.rb
+++ b/app/forms/booking_request_form.rb
@@ -96,7 +96,7 @@ class BookingRequestForm
   def alternate_locations(limit: 5, radius: 5)
     Locations
       .nearest_to_postcode(location.postcode, radius: radius)
-      .reject { |l| l.id == location_id || l.limited_availability? || l.no_availability? }
+      .reject { |l| l.id == location_id || l.online_booking_disabled? || l.limited_availability? || l.no_availability? }
       .take(limit)
       .map { |l| LocationSearchResultDecorator.new(l) }
   end

--- a/app/lib/locations/location.rb
+++ b/app/lib/locations/location.rb
@@ -16,6 +16,10 @@ module Locations
       online_booking_enabled
     end
 
+    def online_booking_disabled?
+      !online_booking_enabled
+    end
+
     def slots
       @slots ||= BookingRequests.slots(id)
     end

--- a/spec/cassettes/Alternative_locations/when_there_are_less_than_three_slots_available/and_nearby_alternatives.yml
+++ b/spec/cassettes/Alternative_locations/when_there_are_less_than_three_slots_available/and_nearby_alternatives.yml
@@ -17,7 +17,7 @@ http_interactions:
       Server:
       - nginx/1.11.5
       Date:
-      - Wed, 07 Jun 2017 11:17:16 GMT
+      - Sat, 15 Jul 2017 10:33:13 GMT
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
@@ -39,5 +39,5 @@ http_interactions:
         unparished area","admin_county":null,"admin_ward":"Homerton","ccg":"NHS City
         and Hackney","nuts":"Hackney and Newham","codes":{"admin_district":"E09000012","admin_county":"E99999999","admin_ward":"E05009376","parish":"E43000202","ccg":"E38000035","nuts":"UKI41"}}}'
     http_version: 
-  recorded_at: Wed, 07 Jun 2017 11:17:11 GMT
+  recorded_at: Sat, 15 Jul 2017 10:33:11 GMT
 recorded_with: VCR 3.0.3

--- a/spec/features/alternative_locations_spec.rb
+++ b/spec/features/alternative_locations_spec.rb
@@ -14,6 +14,7 @@ RSpec.feature 'Alternative locations' do
       given_a_location_with_limited_availability_and_available_alternatives do
         when_i_try_to_book_an_appointment
         then_i_should_see_suggested_alternative_locations
+        and_i_should_not_see_online_booking_disabled_locations
         and_i_should_not_be_suggested_anywhere_more_than_5_miles_away
         and_i_should_not_be_suggested_anywhere_with_less_than_3_slots
       end
@@ -94,6 +95,12 @@ end
 
 def then_i_should_see_suggested_alternative_locations
   expect(page).to have_selector('.t-limited-availability')
+end
+
+def and_i_should_not_see_online_booking_disabled_locations
+  within('.t-limited-availability') do
+    expect(page).to have_no_content('Newham')
+  end
 end
 
 def and_i_should_not_be_suggested_anywhere_more_than_5_miles_away

--- a/spec/fixtures/locations_with_alternates.json
+++ b/spec/fixtures/locations_with_alternates.json
@@ -97,7 +97,7 @@
         "phone":"",
         "hours":"",
         "twilio_number":"+442030952775",
-        "online_booking_enabled":true
+        "online_booking_enabled":false
       }
     },
     {


### PR DESCRIPTION
When suggesting alternate locations we should exclude those that are
not available for online bookings.