### PR TITLE
WIP - Track clicks of alternate locations on the booking request page

### DIFF
--- a/app/assets/javascripts/click-tracker.js
+++ b/app/assets/javascripts/click-tracker.js
@@ -38,6 +38,9 @@
       // pension summaries
       track('.js-print-pension-summary-button', 'print pension summary');
       track('.js-download-pension-summary-button', 'download pension summary');
+
+      // booking requests
+      track('.js-alternate-location-link', 'alternate location');
     }
   };
 

--- a/app/views/booking_requests/step_one.html.erb
+++ b/app/views/booking_requests/step_one.html.erb
@@ -8,7 +8,10 @@
         <p>There is limited availability in this location. Other locations near <%= @booking_request.location_name %>:</p>
         <ul>
           <% @locations.each do |location| %>
-          <li><a href="<%= booking_request_step_one_location_path(location.id) %>"><%= location.name %></a> (<%= location.distance %> miles away)</li>
+          <li>
+            <%= link_to location.name, booking_request_step_one_location_path(location.id), class: 'js-alternate-location-link' %>
+            (<%= location.distance %> miles away)
+          </li>
           <% end %>
         </ul>
       </div>


### PR DESCRIPTION
In order to track effectiveness of the alternate locations prompt, a custom event to fire whenever someone clicks through from a booking request to one of the offered locations.