### PR TITLE
Add 'Pension Wise for employers' page

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -52,6 +52,8 @@ cy:
         url: '/cy/after-your-appointment'
         options:
           class: t-appointment-summary-link
+      - title: Pension Wise i gyflogwyr
+        url: '/cy/for-employers'
 
   pagination:
     previous: Blaenorol

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -49,6 +49,8 @@ en:
         url: '/en/after-your-appointment'
         options:
           class: t-appointment-summary-link
+      - title: Pension Wise for employers
+        url: '/en/for-employers'
 
   pagination:
     previous: Previous

--- a/content/for_employers.cy.md
+++ b/content/for_employers.cy.md
@@ -1,0 +1,31 @@
+# Pension Wise i gyflogwyr
+
+Gall Pension Wise weithio yn uniongyrchol gyda chyflogwyr sydd:
+
+- cynllun pensiwn cyfraniadau wedi’u diffinio ar gyfer eu gweithwyr
+- gweithwyr sy’n 50 oed neu drosodd
+
+## Beth fyddwch yn ei gael
+
+Fel cyflogwr byddwch yn cael gwasanaeth am ddim i’ch gweithwyr sy’n cynnwys:
+
+- apwyntiadau un i un gydag arbenigwyr pensiynau achrededig
+- taflenni a phosteri hyrwyddo i’w harddangos mewn mannau staff ac mewn cyfarfodydd cyn ymddeol
+- yr opsiwn o gael stondinau gwybodaeth mewn digwyddiadau cwmni
+- cynnwys Pension Wise ar gyfer safleoedd mewnrwyd
+
+## Beth fydd eich gweithwyr yn ei gael
+
+Gyda phensiwn cyfraniadau wedi’u diffinio mae eich gweithwyr yn penderfynu sut i gymryd eu harian pensiwn. Bydd Pension Wise yn eu helpu i ddeall y ffyrdd gwahanol y gallant wneud hyn.
+
+Byddant yn cael apwyntiad arweiniad am ddim gydag un o’n harbenigwyr pensiynau. Mae apwyntiad yn para am tua 45 i 60 munud a byddwn yn:
+
+- egluro’r opsiynau ar gyfer cymryd eu harian pensiwn
+- egluro sut mae bob opsiwn yn cael ei drethu
+- rhoi’r camau nesaf iddynt eu cymryd
+
+Gall yr apwyntiad fod dros y ffÙn neu wyneb yn wyneb rhywle sy’n lleol iddynt ac o bosib yn y gweithle ar gyfer staff cymwys.
+
+^Mae ein harweiniad yn ddiduedd ac ni fyddwn yn argymell unrhyw gynnyrch neu gwmnÔau ac ni fyddwn yn dweud wrthynt sut i fuddsoddi eu harian.^
+
+Darganfyddwch fwy am weithio’n uniongyrchol gyda Pension Wise drwy ein e-bostio yn <contact@pensionwise.gov.uk>

--- a/content/for_employers.en.md
+++ b/content/for_employers.en.md
@@ -1,0 +1,31 @@
+# Pension Wise for employers
+
+Pension Wise can work directly with employers who have:
+
+- a defined contribution (DC) pension scheme for their employees
+- employees aged 50 or over
+
+## What you’ll get
+
+As an employer you’ll get a free service for your employees that includes:
+
+- one-to-one appointments with accredited pensions specialists
+- promotional leaflets and posters for display in staff areas and at pre-retirement seminars
+- the option of information stalls at company events
+- Pension Wise content for intranet sites
+
+## What your employees will get
+
+With a DC pension your employees choose how to take their pension money. Pension Wise will help them understand the different ways they can do this.
+
+They’ll get a free guidance appointment with one of our pensions specialists. An appointment lasts around 45 to 60 minutes and we will:
+
+- explain the options for taking their pension money
+- explain how each option is taxed
+- give them next steps to take
+
+The appointment can be over the phone or face to face somewhere local to them – possibly in the workplace for eligible staff.
+
+^Our guidance is impartial – we won’t recommend any products or companies and won’t tell them how to invest their money.^
+
+Find out more about working directly with Pension Wise by emailing us at <contact@pensionwise.gov.uk>


### PR DESCRIPTION
Slug is `/en/for-employers` (and `/cy/for-employers`).

## English

![pension wise for employers pension wise](https://user-images.githubusercontent.com/9943/28406607-2d0195ee-6d29-11e7-8f83-fd85ea7249d6.png)

## Welsh

![pension wise i gyflogwyr pension wise](https://user-images.githubusercontent.com/9943/28406652-58eb8c46-6d29-11e7-8c55-460eb774cda5.png)
