### PR TITLE
Revert "Track printing and downloading of pension summaries"

### DIFF
--- a/app/assets/javascripts/click-tracker.js
+++ b/app/assets/javascripts/click-tracker.js
@@ -34,10 +34,6 @@
       track('article a', 'content');
       track('.ga-options-table a', 'options table');
       track('.pager a', 'pager');
-
-      // pension summaries
-      track('.js-print-pension-summary-button', 'print pension summary');
-      track('.js-download-pension-summary-button', 'download pension summary');
     }
   };
 

--- a/app/views/pension_summaries/summary.html.erb
+++ b/app/views/pension_summaries/summary.html.erb
@@ -45,8 +45,8 @@
             </li>
           <% end %>
         </ul>
-        <%= link_to t('.sidebar.print_button'), print_summary_path, class: 'button js-print-pension-summary-button' %>
-        <%= link_to t('.sidebar.download_button'), download_summary_path, class: 'button js-download-pension-summary-button' %>
+        <%= link_to t('.sidebar.print_button'), print_summary_path, class: 'button' %>
+        <%= link_to t('.sidebar.download_button'), download_summary_path, class: 'button' %>
       </div>
     </div>
   </aside>


### PR DESCRIPTION
Now that we have worked out how to track these clicks via GTM, revert this initial attempt at doing so.