### PR TITLE
Add a class to identify alternate location links for the purpose of GA

### DIFF
--- a/app/views/booking_requests/step_one.html.erb
+++ b/app/views/booking_requests/step_one.html.erb
@@ -8,7 +8,10 @@
         <p>There is limited availability in this location. Other locations near <%= @booking_request.location_name %>:</p>
         <ul>
           <% @locations.each do |location| %>
-          <li><a href="<%= booking_request_step_one_location_path(location.id) %>"><%= location.name %></a> (<%= location.distance %> miles away)</li>
+            <li>
+              <%= link_to location.name, booking_request_step_one_location_path(location.id), class: 'ga-alternate-location-link' %>
+              (<%= location.distance %> miles away)
+            </li>
           <% end %>
         </ul>
       </div>


### PR DESCRIPTION
We can target via css with GA but there aren't really any decent structural classes that we can leverage in order to reliably target these links, so adding some dedicated classes directly to the links.

Following the BEM pattern, went with a `ga-` prefix.