### PR TITLE
Limited availability only for online booking

### DIFF
--- a/app/lib/locations/location.rb
+++ b/app/lib/locations/location.rb
@@ -33,7 +33,7 @@ module Locations
     end
 
     def limited_availability?
-      slots_available? && slots.size < 3
+      online_booking_enabled? && slots_available? && slots.size < 3
     end
 
     def postcode

--- a/spec/lib/locations/location_spec.rb
+++ b/spec/lib/locations/location_spec.rb
@@ -1,0 +1,23 @@
+RSpec.describe Locations::Location do
+  subject { described_class.new(id: 1) }
+
+  before do
+    allow(BookingRequests).to receive(:slots) { [1] }
+  end
+
+  context 'when online booking is disabled' do
+    it 'does not report limited availability' do
+      subject.online_booking_enabled = false
+
+      expect(subject).to_not be_limited_availability
+    end
+  end
+
+  context 'when online booking is enabled' do
+    it 'reports limited availability' do
+      subject.online_booking_enabled = true
+
+      expect(subject).to be_limited_availability
+    end
+  end
+end


### PR DESCRIPTION
Locations that are not enabled for online booking should never report
limited availability.