### PR TITLE
Validate feedback emails more robustly

### DIFF
--- a/app/forms/feedback_form.rb
+++ b/app/forms/feedback_form.rb
@@ -4,7 +4,7 @@ class FeedbackForm
   attr_accessor :name, :email, :message, :feedback_type
 
   validates :name, presence: true
-  validates :email, format: { with: /.+@.+\..+/ }
+  validates :email, email: true
   validates :message, presence: true
   validates :feedback_type, inclusion: { in: %w(online_booking pension_type_tool) }
 

--- a/spec/forms/feedback_form_spec.rb
+++ b/spec/forms/feedback_form_spec.rb
@@ -1,0 +1,22 @@
+RSpec.describe FeedbackForm do
+  subject do
+    described_class.new(
+      name: 'Dave Smith',
+      email: 'dave@example.com',
+      message: 'This is great!',
+      feedback_type: 'online_booking'
+    )
+  end
+
+  describe 'validation' do
+    it 'is valid with valid attributes' do
+      expect(subject).to be_valid
+    end
+
+    it 'requires a valid email' do
+      subject.email = 'dave@talk talk.net'
+
+      expect(subject).to be_invalid
+    end
+  end
+end


### PR DESCRIPTION
We were permitting incorrectly formatted email addresses for feedback
and when these get through they're refused by ZenDesk resulting in an
error message to the customer. This change ensures we validate emails
more rigorously.