### PR TITLE
Reinstate explicit T&C acceptance

### DIFF
--- a/app/controllers/booking_requests_controller.rb
+++ b/app/controllers/booking_requests_controller.rb
@@ -68,7 +68,8 @@ class BookingRequestsController < ApplicationController
         :date_of_birth,
         :accessibility_requirements,
         :dc_pot,
-        :additional_info
+        :additional_info,
+        :opt_in
       )
   end
 

--- a/app/controllers/telephone_appointments_controller.rb
+++ b/app/controllers/telephone_appointments_controller.rb
@@ -103,6 +103,7 @@ class TelephoneAppointmentsController < ApplicationController
         :date_of_birth,
         :dc_pot_confirmed,
         :opt_out_of_market_research,
+        :accept_terms_and_conditions,
         :date_of_birth_year,
         :date_of_birth_month,
         :date_of_birth_day

--- a/app/forms/booking_request_form.rb
+++ b/app/forms/booking_request_form.rb
@@ -4,7 +4,7 @@ class BookingRequestForm
   attr_accessor :location_id, :primary_slot, :secondary_slot, :tertiary_slot,
                 :first_name, :last_name, :email, :telephone_number,
                 :memorable_word, :accessibility_requirements,
-                :date_of_birth, :dc_pot, :additional_info
+                :date_of_birth, :dc_pot, :additional_info, :opt_in
 
   validates :primary_slot, presence: true, if: :step_one?
 
@@ -15,6 +15,7 @@ class BookingRequestForm
     step_two.validates :telephone_number, presence: true, format: /\A([\d+\-\s\+()]+)\z/
     step_two.validates :memorable_word, presence: true
     step_two.validates :accessibility_requirements, inclusion: { in: %w(0 1) }
+    step_two.validates :opt_in, acceptance: { accept: '1' }
     step_two.validates :dc_pot, inclusion: { in: %w(yes no not-sure) }
     step_two.validates :date_of_birth, presence: true
     step_two.validates :additional_info, length: { maximum: 160 }, allow_blank: true

--- a/app/lib/booking_requests/api_mapper.rb
+++ b/app/lib/booking_requests/api_mapper.rb
@@ -12,7 +12,7 @@ module BookingRequests
           age_range: booking_request.appointment_type,
           date_of_birth: booking_request.date_of_birth.iso8601,
           accessibility_requirements: booking_request.accessibility_requirements,
-          marketing_opt_in: true,
+          marketing_opt_in: booking_request.opt_in,
           defined_contribution_pot_confirmed: dc_pot_as_boolean(booking_request.dc_pot),
           additional_info: booking_request.additional_info.to_s,
           slots: [

--- a/app/models/telephone_appointment.rb
+++ b/app/models/telephone_appointment.rb
@@ -14,6 +14,7 @@ class TelephoneAppointment
     :appointment_type,
     :date_of_birth,
     :opt_out_of_market_research,
+    :accept_terms_and_conditions,
     :dc_pot_confirmed,
     :date_of_birth_year,
     :date_of_birth_month,
@@ -28,6 +29,7 @@ class TelephoneAppointment
   validates :memorable_word, presence: true
   validates :date_of_birth, presence: true
   validates :dc_pot_confirmed, inclusion: { in: %w(yes no not-sure) }
+  validates :accept_terms_and_conditions, inclusion: { in: [true] }
 
   def advance!
     self.step += 1
@@ -77,6 +79,10 @@ class TelephoneAppointment
 
   def opt_out_of_market_research
     %w(1 true).include?(@opt_out_of_market_research)
+  end
+
+  def accept_terms_and_conditions
+    %w(1 true).include?(@accept_terms_and_conditions)
   end
 
   def selected_date

--- a/app/views/booking_requests/step_two.html.erb
+++ b/app/views/booking_requests/step_two.html.erb
@@ -193,6 +193,23 @@
         <%= f.text_area :additional_info, class: 'form-control form-control-3-4 js-character-limit-input', rows: 5, maxlength: 160, data: { maxlength: 160 } %>
       </div>
 
+      <div class="form-group <%= 'form-group-error' if @booking_request.errors.include?(:opt_in) %>">
+        <fieldset>
+          <legend>
+            <span class="visually-hidden">Terms and conditions</span>
+            <% if @booking_request.errors.include?(:opt_in) %>
+              <span class="error-message"><%= @booking_request.errors[:opt_in].to_sentence.capitalize %></span>
+            <% end %>
+          </legend>
+          <div class="multiple-choice">
+            <%= f.check_box :opt_in, class: 't-opt-in' %>
+            <%= f.label :opt_in do %>
+              I accept the <a href="/privacy" target="_blank">terms and conditions</a>
+            <% end %>
+          </div>
+        </fieldset>
+      </div>
+
       <div class="form-group">
         <%= f.submit 'Submit booking request', class: 'button t-submit', data: { disable_with: 'Please wait...' } %>
       </div>

--- a/app/views/telephone_appointments/_hidden_fields.html.erb
+++ b/app/views/telephone_appointments/_hidden_fields.html.erb
@@ -8,4 +8,5 @@
 <%= f.hidden_field :date_of_birth_day, id: "#{id_prefix}_date_of_birth_day" %>
 <%= f.hidden_field :dc_pot_confirmed, id: "#{id_prefix}_dc_pot_confirmed" %>
 <%= f.hidden_field :opt_out_of_market_research, id: "#{id_prefix}_opt_out_of_market_research" %>
+<%= f.hidden_field :accept_terms_and_conditions, id: "#{id_prefix}_accept_terms_and_conditions" %>
 <%= f.hidden_field :selected_date, id: "#{id_prefix}_selected_date" %>

--- a/app/views/telephone_appointments/_step_3.html.erb
+++ b/app/views/telephone_appointments/_step_3.html.erb
@@ -168,6 +168,23 @@
     </fieldset>
   </div>
 
+  <div class="form-group <%= 'form-group-error' if @telephone_appointment.errors.include?(:accept_terms_and_conditions) %>">
+    <fieldset>
+      <legend>
+        <span class="visually-hidden">Terms and conditions</span>
+        <% if @telephone_appointment.errors.include?(:accept_terms_and_conditions) %>
+          <span class="error-message"><%= @telephone_appointment.errors[:accept_terms_and_conditions].to_sentence.capitalize %></span>
+        <% end %>
+      </legend>
+      <div class="multiple-choice">
+        <%= f.check_box :accept_terms_and_conditions, class: 't-accept-terms-and-conditions' %>
+        <%= f.label :accept_terms_and_conditions, class: 't-opt-in' do %>
+          I accept the <a href="/privacy" target="_blank">terms and conditions</a>
+        <% end %>
+      </div>
+    </fieldset>
+  </div>
+
   <div class="form-group">
     <%= f.submit 'Confirm appointment', class: 'button t-submit', data: { disable_with: 'Please wait...' } %>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -85,6 +85,7 @@ en:
     attributes:
       telephone_appointment:
         dc_pot_confirmed: Defined contribution pension
+        accept_terms_and_conditions: Terms and conditions
       booking_request_form:
         primary_slot: Slot 1
         secondary_slot: Slot 2
@@ -149,6 +150,8 @@ en:
               blank: enter a valid date of birth
             dc_pot_confirmed:
               inclusion: select an option
+            accept_terms_and_conditions:
+              inclusion: please accept
         feedback_form:
           attributes:
             name:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -91,6 +91,7 @@ en:
         tertiary_slot: Slot 3
         appointment_type: Age range
         dc_pot: Defined contribution pension
+        opt_in: Terms and conditions
         telephone_number: Phone number
       appointment_summary:
         appointment_type: Your age
@@ -121,6 +122,8 @@ en:
               blank: enter a word
             date_of_birth:
               blank: enter a valid date of birth
+            opt_in:
+              accepted: please accept
             appointment_type:
               inclusion: must be 50 or over to be eligible for guidance
             dc_pot:

--- a/features/pages/booking_step_two.rb
+++ b/features/pages/booking_step_two.rb
@@ -13,6 +13,7 @@ module Pages
     element :telephone_number, '.t-telephone-number'
     element :memorable_word, '.t-memorable-word'
     element :accessibility_requirements, '.t-accessibility-requirements', visible: false
+    element :opt_in, '.t-opt-in', visible: false
 
     element :dc_pot_yes, '.t-dc-pot-1', visible: false
     element :dc_pot_no, '.t-dc-pot-2', visible: false

--- a/features/pages/new_telephone_appointment.rb
+++ b/features/pages/new_telephone_appointment.rb
@@ -15,6 +15,7 @@ module Pages
 
     element :dc_pot_confirmed_no, '.t-dc-confirmed-pot-no', visible: false
     element :opt_out_of_market_research, '.t-opt-out-of-market-research', visible: false
+    element :accept_terms_and_conditions, '.t-accept-terms-and-conditions', visible: false
 
     element :submit, '.t-submit'
 

--- a/features/step_definitions/customer_booking_request_steps.rb
+++ b/features/step_definitions/customer_booking_request_steps.rb
@@ -83,6 +83,7 @@ When(/^I provide my personal details$/) do
   @step_two.telephone_number.set '07715 930 459'
   @step_two.memorable_word.set 'birdperson'
   @step_two.accessibility_requirements.set false
+  @step_two.opt_in.set true
 end
 
 When(/^I enter an email address with a typo$/) do

--- a/features/step_definitions/telephone_booking_request_steps.rb
+++ b/features/step_definitions/telephone_booking_request_steps.rb
@@ -94,6 +94,7 @@ Given(/^they do not have a DC pot$/) do
 
   choose('No')
   @page.opt_out_of_market_research.set(true)
+  @page.accept_terms_and_conditions.set(true)
 
   @page.submit.click
 end
@@ -117,6 +118,7 @@ Given(/^they are below the minimum age$/) do
 
   choose('Yes')
   @page.opt_out_of_market_research.set(true)
+  @page.accept_terms_and_conditions.set(true)
 
   @page.submit.click
 end
@@ -137,6 +139,7 @@ Given(/^they are eligible for an appointment$/) do
 
   choose('Yes')
   @page.opt_out_of_market_research.set(true)
+  @page.accept_terms_and_conditions.set(true)
 
   @page.submit.click
 end
@@ -150,6 +153,7 @@ Then(/^their appointment is created$/) do
   expect(@created_telephone_appointment.memorable_word).to eq 'words'
   expect(@created_telephone_appointment.date_of_birth).to eq DateTime.new(1920, 10, 23).in_time_zone
   expect(@created_telephone_appointment.opt_out_of_market_research).to eq true
+  expect(@created_telephone_appointment.accept_terms_and_conditions).to eq true
 end
 
 Then(/^they see a confirmation of their appointment$/) do
@@ -175,6 +179,7 @@ When(/^the slot becomes unavailable while they are filling in their details$/) d
 
   choose('Yes')
   @page.opt_out_of_market_research.set(true)
+  @page.accept_terms_and_conditions.set(true)
 
   @page.submit.click
 end

--- a/spec/cassettes/BookingRequests_Api/_create/when_the_request_is_successful/returns_true.yml
+++ b/spec/cassettes/BookingRequests_Api/_create/when_the_request_is_successful/returns_true.yml
@@ -6,7 +6,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"booking_request":{"location_id":"4c852869-9cad-43bd-b3d5-357dd377e3d3","name":"Lucius
-        Needful","email":"lucius@example.com","phone":"0208 244 3987","memorable_word":"meseeks","age_range":"55-plus","accessibility_requirements":false,"marketing_opt_in":true,"defined_contribution_pot":true,"slots":[{"priority":1,"date":"2016-01-01","from":"0900","to":"1300"},{"priority":2,"date":"2016-01-01","from":"1300","to":"1700"},{"priority":3,"date":"2016-01-02","from":"0900","to":"1300"}]}}'
+        Needful","email":"lucius@example.com","phone":"0208 244 3987","memorable_word":"meseeks","age_range":"55-plus","accessibility_requirements":false,"marketing_opt_in":false,"defined_contribution_pot":true,"slots":[{"priority":1,"date":"2016-01-01","from":"0900","to":"1300"},{"priority":2,"date":"2016-01-01","from":"1300","to":"1700"},{"priority":3,"date":"2016-01-02","from":"0900","to":"1300"}]}}'
     headers:
       User-Agent:
       - PensionWise/1.0 (hurrdurr.local; benlovell; 92031) ruby/2.3.1 (112; x86_64-darwin15)
@@ -50,6 +50,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version:
+    http_version: 
   recorded_at: Sun, 03 Jul 2016 09:38:42 GMT
 recorded_with: VCR 2.9.3

--- a/spec/forms/booking_request_form_spec.rb
+++ b/spec/forms/booking_request_form_spec.rb
@@ -13,8 +13,9 @@ RSpec.describe BookingRequestForm do
         memorable_word: 'meseeks',
         date_of_birth: '1950-01-01',
         accessibility_requirements: '0',
-        dc_pot: 'yes',
-        additional_info: ''
+        additional_info: '',
+        opt_in: '1',
+        dc_pot: 'yes'
       )
     end
 
@@ -74,6 +75,11 @@ RSpec.describe BookingRequestForm do
 
       it 'requires accessibility_requirements to be true or false' do
         subject.accessibility_requirements = nil
+        expect(subject).not_to be_step_two_valid
+      end
+
+      it 'requires opt_in to be true' do
+        subject.opt_in = false
         expect(subject).not_to be_step_two_valid
       end
 

--- a/spec/lib/booking_requests/api_mapper_spec.rb
+++ b/spec/lib/booking_requests/api_mapper_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe BookingRequests::ApiMapper do
       date_of_birth: '1951-01-01',
       accessibility_requirements: false,
       additional_info: nil,
+      opt_in: false,
       dc_pot: 'yes'
     )
   end
@@ -37,7 +38,7 @@ RSpec.describe BookingRequests::ApiMapper do
           date_of_birth: '1951-01-01',
           accessibility_requirements: false,
           additional_info: '',
-          marketing_opt_in: true,
+          marketing_opt_in: false,
           defined_contribution_pot_confirmed: true,
           slots: [
             { priority: 1, date: '2016-01-01', from: '0900', to: '1300' },

--- a/spec/lib/telephone_appointments_api_spec.rb
+++ b/spec/lib/telephone_appointments_api_spec.rb
@@ -34,7 +34,8 @@ RSpec.describe TelephoneAppointmentsApi do
         date_of_birth_month: '10',
         date_of_birth_day: '23',
         dc_pot_confirmed: 'yes',
-        opt_out_of_market_research: 'true'
+        opt_out_of_market_research: 'true',
+        accept_terms_and_conditions: 'true'
       )
     end
 

--- a/spec/models/telephone_appointment_spec.rb
+++ b/spec/models/telephone_appointment_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe TelephoneAppointment, type: :model do
       date_of_birth_month: '10',
       date_of_birth_day: '23',
       dc_pot_confirmed: 'yes',
-      opt_out_of_market_research: 'true'
+      opt_out_of_market_research: 'true',
+      accept_terms_and_conditions: 'true'
     )
   end
 
@@ -131,6 +132,11 @@ RSpec.describe TelephoneAppointment, type: :model do
 
     it 'validates presence of date_of_birth' do
       subject.date_of_birth_year = nil
+      expect(subject).to_not be_valid
+    end
+
+    it 'validates truthiness of accept_terms_and_conditions' do
+      subject.accept_terms_and_conditions = nil
       expect(subject).to_not be_valid
     end
 

--- a/spec/requests/complete_booking_request_spec.rb
+++ b/spec/requests/complete_booking_request_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe 'POST /en/locations/:id/booking-request/complete', type: :request
           memorable_word: 'meseeks',
           date_of_birth: '1940-01-01',
           accessibility_requirements: '0',
+          opt_in: '1',
           dc_pot: 'yes'
         }
       }


### PR DESCRIPTION
This ensures the customer has explicitly accepted T&C during both the
face-to-face and telephone customer booking journeys.