### PR TITLE
Use `phantomjs` instead of the binaries package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: ruby
 cache:
   bundler: true
   directories:
+  - $HOME/.phantomjs
   - ".downloads"
   - node_modules
   - tmp/cache/assets/test

--- a/Gemfile
+++ b/Gemfile
@@ -64,7 +64,7 @@ source 'https://rubygems.org' do # rubocop:disable Metrics/BlockLength
     gem 'fakeredis'
     gem 'launchy'
     gem 'pdf-inspector', require: 'pdf/inspector'
-    gem 'phantomjs-binaries'
+    gem 'phantomjs'
     gem 'poltergeist'
     gem 'rails-controller-testing'
     gem 'scss-lint', '~> 0.30'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -226,8 +226,6 @@ GEM
       ruby-rc4
       ttfunk
     phantomjs (2.1.1.0)
-    phantomjs-binaries (2.1.1.1)
-      sys-uname (= 0.9.0)
     phoner (1.0.1)
       activesupport
     poltergeist (1.13.0)
@@ -366,8 +364,6 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    sys-uname (0.9.0)
-      ffi (>= 1.0.0)
     thor (0.19.4)
     thread_safe (0.3.6)
     tilt (2.0.6)
@@ -444,7 +440,7 @@ DEPENDENCIES
   nokogiri!
   output-templates (~> 4.8)!
   pdf-inspector!
-  phantomjs-binaries!
+  phantomjs!
   phoner!
   poltergeist!
   postcodes_io!

--- a/features/support/poltergeist.rb
+++ b/features/support/poltergeist.rb
@@ -3,6 +3,7 @@ require 'capybara/poltergeist'
 Capybara.register_driver :poltergeist do |app|
   Capybara::Poltergeist::Driver.new(
     app,
+    phantomjs: Phantomjs.path,
     url_whitelist: %w(127.0.0.1 localhost),
     timeout: ENV.fetch('PHANTOM_JS_TIMEOUT') { 60 }
   )


### PR DESCRIPTION
This is safe now they've sorted out their CDN. This is also faster to
use, I suspect this is something to do with how `phantomjs-binaries`
wraps the actual binary in Ruby.