### PR TITLE
Filter away cloudflare trusted proxies

### DIFF
--- a/app/controllers/lograge_filterer.rb
+++ b/app/controllers/lograge_filterer.rb
@@ -3,6 +3,7 @@ module LogrageFilterer
 
   def append_info_to_payload(payload)
     super
-    payload[:params] = request.filtered_parameters
+    payload[:params]    = request.filtered_parameters
+    payload[:remote_ip] = request.remote_ip
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,7 +11,26 @@ require_relative '../app/middleware/strip_session_cookie'
 
 Bundler.require(*Rails.groups)
 
+require 'ipaddr'
+
 module PensionGuidance
+  TRUSTED_CLOUDFLARE_IPS = %w(
+    103.21.244.0/22
+    103.22.200.0/22
+    103.31.4.0/22
+    104.16.0.0/12
+    108.162.192.0/18
+    131.0.72.0/22
+    141.101.64.0/18
+    162.158.0.0/15
+    172.64.0.0/13
+    173.245.48.0/20
+    188.114.96.0/20
+    190.93.240.0/20
+    197.234.240.0/22
+    198.41.128.0/17
+  ).map { |ip| IPAddr.new(ip) }
+
   class Application < Rails::Application
     config.action_controller.include_all_helpers = false
     config.action_dispatch.rescue_responses.merge! 'CategoryRepository::CategoryNotFound' => :not_found,
@@ -37,6 +56,13 @@ module PensionGuidance
       ActionDispatch::Cookies,
       Middleware::StripSessionCookie,
       paths: cacheable_paths
+    )
+
+    config.middleware.swap(
+      ActionDispatch::RemoteIp,
+      ActionDispatch::RemoteIp,
+      true,
+      TRUSTED_CLOUDFLARE_IPS
     )
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -2,14 +2,15 @@ require 'redis-rails'
 
 EXCEPTIONS = %w(controller action format id).freeze
 
-Rails.application.configure do
+Rails.application.configure do # rubocop:disable Metrics/BlockLength
   # Settings specified here will take precedence over those in config/application.rb.
 
   # Use lograge in the single-line heroku router style
   config.lograge.enabled = true
   config.lograge.custom_options = lambda do |event|
     {
-      params: event.payload[:params].except(*EXCEPTIONS)
+      params: event.payload[:params].except(*EXCEPTIONS),
+      remote_ip: event.payload[:remote_ip]
     }
   end
 


### PR DESCRIPTION
Ensures that the correct remote IP is inferred.