### PR TITLE
Customers can specify where they heard of us

### DIFF
--- a/app/controllers/booking_requests_controller.rb
+++ b/app/controllers/booking_requests_controller.rb
@@ -69,6 +69,7 @@ class BookingRequestsController < ApplicationController
         :accessibility_requirements,
         :dc_pot,
         :additional_info,
+        :where_you_heard,
         :opt_in
       ).merge(remote_ip: request.remote_ip)
   end

--- a/app/forms/booking_request_form.rb
+++ b/app/forms/booking_request_form.rb
@@ -5,7 +5,7 @@ class BookingRequestForm
                 :first_name, :last_name, :email, :telephone_number,
                 :memorable_word, :accessibility_requirements,
                 :date_of_birth, :dc_pot, :additional_info, :opt_in,
-                :remote_ip
+                :remote_ip, :where_you_heard
 
   validates :primary_slot, presence: true, if: :step_one?
 
@@ -20,6 +20,7 @@ class BookingRequestForm
     step_two.validates :dc_pot, inclusion: { in: %w(yes no not-sure) }
     step_two.validates :date_of_birth, presence: true
     step_two.validates :additional_info, length: { maximum: 160 }, allow_blank: true
+    step_two.validates :where_you_heard, inclusion: { in: WhereYouHeard::OPTIONS.keys }
   end
 
   def initialize(location_id, opts)

--- a/app/lib/booking_requests/api_mapper.rb
+++ b/app/lib/booking_requests/api_mapper.rb
@@ -16,6 +16,7 @@ module BookingRequests
           defined_contribution_pot_confirmed: dc_pot_as_boolean(booking_request.dc_pot),
           additional_info: booking_request.additional_info.to_s,
           placed_by_agent: booking_request.placed_by_agent?,
+          where_you_heard: booking_request.where_you_heard,
           slots: [
             slot(1, booking_request.primary_slot),
             slot(2, booking_request.secondary_slot),

--- a/app/lib/where_you_heard.rb
+++ b/app/lib/where_you_heard.rb
@@ -1,0 +1,21 @@
+class WhereYouHeard
+  OPTIONS = {
+    '1'  => 'An employer',
+    '2'  => 'A Pension Provider',
+    '3'  => 'Internet search',
+    '4'  => 'Online advertising',
+    '5'  => 'Social media',
+    '6'  => 'The Government’s GOV.UK website',
+    '7'  => 'TV advert',
+    '8'  => 'Radio advert',
+    '9'  => 'Newspaper/Magazine advert',
+    '10' => 'Local advertising - billboards, buses, bus stops',
+    '11' => 'Mentioned in a TV/radio programme or newspaper/magazine/online article',
+    '12' => 'A Financial Adviser',
+    '13' => 'Money Advice Service (MAS)',
+    '14' => 'The Pensions Advisory Service (TPAS)',
+    '15' => 'Citizens Advice',
+    '16' => 'Relative/Friend/Colleague',
+    '17' => 'Other'
+  }.freeze
+end

--- a/app/views/booking_requests/step_two.html.erb
+++ b/app/views/booking_requests/step_two.html.erb
@@ -193,6 +193,18 @@
         <%= f.text_area :additional_info, class: 'form-control form-control-3-4 js-character-limit-input', rows: 5, maxlength: 160, data: { maxlength: 160 } %>
       </div>
 
+      <div class="form-group <%= 'form-group-error' if @booking_request.errors.include?(:where_you_heard) %>">
+        <%= f.label :where_you_heard, 'Where did you first hear of Pension Wise?', class: 'form-label-bold' %>
+        <% if @booking_request.errors.include?(:where_you_heard) %>
+          <span class="error-message"><%= @booking_request.errors[:where_you_heard].to_sentence.capitalize %></span>
+        <% end %>
+        <%= f.select :where_you_heard,
+              options_for_select(WhereYouHeard::OPTIONS.invert.to_a, @booking_request.where_you_heard),
+              { include_blank: true},
+              { class: "t-where-you-heard form-control #{'form-control-error' if @booking_request.errors.include?(:where_you_heard)}" }
+        %>
+      </div>
+
       <div class="form-group <%= 'form-group-error' if @booking_request.errors.include?(:opt_in) %>">
         <fieldset>
           <legend>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -105,6 +105,7 @@ cy:
         dc_pot: Defined contribution pension
         opt_in: Terms and conditions
         telephone_number: Phone number
+        where_you_heard: Where did you first hear of Pension Wise
       appointment_summary:
         appointment_type: Your age
       telephone_appointment:
@@ -151,6 +152,8 @@ cy:
             appointment_type:
               inclusion: must be 50 or over to be eligible for guidance
             dc_pot:
+              inclusion: select an option
+            where_you_heard:
               inclusion: select an option
         complaint:
           attributes:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -102,6 +102,7 @@ en:
         dc_pot: Defined contribution pension
         opt_in: Terms and conditions
         telephone_number: Phone number
+        where_you_heard: Where did you first hear of Pension Wise
       appointment_summary:
         appointment_type: Your age
     errors:
@@ -136,6 +137,8 @@ en:
             appointment_type:
               inclusion: must be 50 or over to be eligible for guidance
             dc_pot:
+              inclusion: select an option
+            where_you_heard:
               inclusion: select an option
         complaint:
           attributes:

--- a/features/pages/booking_step_two.rb
+++ b/features/pages/booking_step_two.rb
@@ -13,6 +13,7 @@ module Pages
     element :telephone_number, '.t-telephone-number'
     element :memorable_word, '.t-memorable-word'
     element :accessibility_requirements, '.t-accessibility-requirements', visible: false
+    element :where_you_heard, '.t-where-you-heard'
     element :opt_in, '.t-opt-in', visible: false
 
     element :dc_pot_yes, '.t-dc-pot-1', visible: false

--- a/features/step_definitions/customer_booking_request_steps.rb
+++ b/features/step_definitions/customer_booking_request_steps.rb
@@ -83,6 +83,7 @@ When(/^I provide my personal details$/) do
   @step_two.telephone_number.set '07715 930 459'
   @step_two.memorable_word.set 'birdperson'
   @step_two.accessibility_requirements.set false
+  @step_two.where_you_heard.select 'Other'
   @step_two.opt_in.set true
 end
 

--- a/spec/forms/booking_request_form_spec.rb
+++ b/spec/forms/booking_request_form_spec.rb
@@ -16,7 +16,8 @@ RSpec.describe BookingRequestForm do
         additional_info: '',
         opt_in: '1',
         dc_pot: 'yes',
-        remote_ip: '214.142.214.142'
+        remote_ip: '214.142.214.142',
+        where_you_heard: '1'
       )
     end
 
@@ -116,6 +117,11 @@ RSpec.describe BookingRequestForm do
 
       it 'ensures `additional_info` is no longer than 160 characters' do
         subject.additional_info = '*' * 161
+        expect(subject).not_to be_step_two_valid
+      end
+
+      it 'requires the `where_you_heard`' do
+        subject.where_you_heard = ''
         expect(subject).not_to be_step_two_valid
       end
     end

--- a/spec/lib/booking_requests/api_mapper_spec.rb
+++ b/spec/lib/booking_requests/api_mapper_spec.rb
@@ -19,7 +19,8 @@ RSpec.describe BookingRequests::ApiMapper do
       additional_info: nil,
       opt_in: false,
       dc_pot: 'yes',
-      remote_ip: '127.0.0.1'
+      remote_ip: '127.0.0.1',
+      where_you_heard: '1'
     )
   end
 
@@ -42,6 +43,7 @@ RSpec.describe BookingRequests::ApiMapper do
           marketing_opt_in: false,
           defined_contribution_pot_confirmed: true,
           placed_by_agent: false,
+          where_you_heard: '1',
           slots: [
             { priority: 1, date: '2016-01-01', from: '0900', to: '1300' },
             { priority: 2, date: '2016-01-01', from: '1300', to: '1700' }

--- a/spec/requests/complete_booking_request_spec.rb
+++ b/spec/requests/complete_booking_request_spec.rb
@@ -22,7 +22,8 @@ RSpec.describe 'POST /en/locations/:id/booking-request/complete', type: :request
           date_of_birth: '1940-01-01',
           accessibility_requirements: '0',
           opt_in: '1',
-          dc_pot: 'yes'
+          dc_pot: 'yes',
+          where_you_heard: '1'
         }
       }
 


### PR DESCRIPTION
This is during the face-to-face journey. The customer can now specify
where they first heard of Pension Wise. This option is currently
mandatory.