### PR TITLE
Customers can specify where they heard of us

### DIFF
--- a/app/controllers/telephone_appointments_controller.rb
+++ b/app/controllers/telephone_appointments_controller.rb
@@ -104,6 +104,7 @@ class TelephoneAppointmentsController < ApplicationController
         :dc_pot_confirmed,
         :opt_out_of_market_research,
         :accept_terms_and_conditions,
+        :where_you_heard,
         :date_of_birth_year,
         :date_of_birth_month,
         :date_of_birth_day

--- a/app/models/telephone_appointment.rb
+++ b/app/models/telephone_appointment.rb
@@ -16,6 +16,7 @@ class TelephoneAppointment
     :opt_out_of_market_research,
     :accept_terms_and_conditions,
     :dc_pot_confirmed,
+    :where_you_heard,
     :date_of_birth_year,
     :date_of_birth_month,
     :date_of_birth_day
@@ -30,6 +31,7 @@ class TelephoneAppointment
   validates :date_of_birth, presence: true
   validates :dc_pot_confirmed, inclusion: { in: %w(yes no not-sure) }
   validates :accept_terms_and_conditions, inclusion: { in: [true] }
+  validates :where_you_heard, inclusion: { in: WhereYouHeard::OPTIONS.keys }
 
   def advance!
     self.step += 1
@@ -59,7 +61,8 @@ class TelephoneAppointment
       memorable_word: memorable_word,
       date_of_birth: date_of_birth,
       opt_out_of_market_research: opt_out_of_market_research,
-      dc_pot_confirmed: dc_pot_confirmed == 'yes'
+      dc_pot_confirmed: dc_pot_confirmed == 'yes',
+      where_you_heard: where_you_heard
     }
   end
 

--- a/app/views/telephone_appointments/_hidden_fields.html.erb
+++ b/app/views/telephone_appointments/_hidden_fields.html.erb
@@ -10,3 +10,4 @@
 <%= f.hidden_field :opt_out_of_market_research, id: "#{id_prefix}_opt_out_of_market_research" %>
 <%= f.hidden_field :accept_terms_and_conditions, id: "#{id_prefix}_accept_terms_and_conditions" %>
 <%= f.hidden_field :selected_date, id: "#{id_prefix}_selected_date" %>
+<%= f.hidden_field :where_you_heard, id: "#{id_prefix}_where_you_heard" %>

--- a/app/views/telephone_appointments/_step_3.html.erb
+++ b/app/views/telephone_appointments/_step_3.html.erb
@@ -168,6 +168,18 @@
     </fieldset>
   </div>
 
+  <div class="form-group <%= 'form-group-error' if @telephone_appointment.errors.include?(:where_you_heard) %>">
+    <%= f.label :where_you_heard, 'Where did you first hear of Pension Wise?', class: 'form-label-bold' %>
+    <% if @telephone_appointment.errors.include?(:where_you_heard) %>
+      <span class="error-message"><%= @telephone_appointment.errors[:where_you_heard].to_sentence.capitalize %></span>
+    <% end %>
+    <%= f.select :where_you_heard,
+          options_for_select(WhereYouHeard::OPTIONS.invert.to_a, @telephone_appointment.where_you_heard),
+          { include_blank: true},
+          { class: "t-where-you-heard form-control #{'form-control-error' if @telephone_appointment.errors.include?(:where_you_heard)}" }
+    %>
+  </div>
+
   <div class="form-group <%= 'form-group-error' if @telephone_appointment.errors.include?(:accept_terms_and_conditions) %>">
     <fieldset>
       <legend>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -94,9 +94,6 @@ cy:
       tesco/booking:
         dc_pot_confirmed: Defined contribution pension
         accept_terms_and_conditions: Terms and conditions
-      telephone_appointment:
-        dc_pot_confirmed: Defined contribution pension
-        accept_terms_and_conditions: Terms and conditions
       booking_request_form:
         primary_slot: Slot 1
         secondary_slot: Slot 2
@@ -111,16 +108,7 @@ cy:
       telephone_appointment:
         dc_pot_confirmed: Defined contribution pension
         accept_terms_and_conditions: Terms and conditions
-      booking_request_form:
-        primary_slot: Slot 1
-        secondary_slot: Slot 2
-        tertiary_slot: Slot 3
-        appointment_type: Age range
-        dc_pot: Defined contribution pension
-        opt_in: Terms and conditions
-        telephone_number: Phone number
-      appointment_summary:
-        appointment_type: Your age
+        where_you_heard: Where did you first hear of Pension Wise
     errors:
       models:
         annuity_registration_form:
@@ -198,6 +186,8 @@ cy:
               inclusion: select an option
             accept_terms_and_conditions:
               inclusion: please accept
+            where_you_heard:
+              inclusion: select an option
         feedback_form:
           attributes:
             name:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -94,6 +94,7 @@ en:
       telephone_appointment:
         dc_pot_confirmed: Defined contribution pension
         accept_terms_and_conditions: Terms and conditions
+        where_you_heard: Where did you first hear of Pension Wise
       booking_request_form:
         primary_slot: Slot 1
         secondary_slot: Slot 2
@@ -182,6 +183,8 @@ en:
               inclusion: select an option
             accept_terms_and_conditions:
               inclusion: please accept
+            where_you_heard:
+              inclusion: select an option
         feedback_form:
           attributes:
             name:

--- a/features/pages/new_telephone_appointment.rb
+++ b/features/pages/new_telephone_appointment.rb
@@ -12,6 +12,7 @@ module Pages
     element :phone, '.t-phone'
     element :memorable_word, '.t-memorable-word'
     element :choose_other_time_message, '.t-choose-other-time-message'
+    element :where_you_heard, '.t-where-you-heard'
 
     element :dc_pot_confirmed_no, '.t-dc-confirmed-pot-no', visible: false
     element :opt_out_of_market_research, '.t-opt-out-of-market-research', visible: false

--- a/features/step_definitions/telephone_booking_request_steps.rb
+++ b/features/step_definitions/telephone_booking_request_steps.rb
@@ -95,6 +95,7 @@ Given(/^they do not have a DC pot$/) do
   choose('No')
   @page.opt_out_of_market_research.set(true)
   @page.accept_terms_and_conditions.set(true)
+  @page.where_you_heard.select('Other')
 
   @page.submit.click
 end
@@ -119,6 +120,7 @@ Given(/^they are below the minimum age$/) do
   choose('Yes')
   @page.opt_out_of_market_research.set(true)
   @page.accept_terms_and_conditions.set(true)
+  @page.where_you_heard.select('Other')
 
   @page.submit.click
 end
@@ -140,6 +142,7 @@ Given(/^they are eligible for an appointment$/) do
   choose('Yes')
   @page.opt_out_of_market_research.set(true)
   @page.accept_terms_and_conditions.set(true)
+  @page.where_you_heard.select('Other')
 
   @page.submit.click
 end
@@ -154,6 +157,7 @@ Then(/^their appointment is created$/) do
   expect(@created_telephone_appointment.date_of_birth).to eq DateTime.new(1920, 10, 23).in_time_zone
   expect(@created_telephone_appointment.opt_out_of_market_research).to eq true
   expect(@created_telephone_appointment.accept_terms_and_conditions).to eq true
+  expect(@created_telephone_appointment.where_you_heard).to eq '17'
 end
 
 Then(/^they see a confirmation of their appointment$/) do
@@ -180,6 +184,7 @@ When(/^the slot becomes unavailable while they are filling in their details$/) d
   choose('Yes')
   @page.opt_out_of_market_research.set(true)
   @page.accept_terms_and_conditions.set(true)
+  @page.where_you_heard.select('Other')
 
   @page.submit.click
 end

--- a/spec/models/telephone_appointment_spec.rb
+++ b/spec/models/telephone_appointment_spec.rb
@@ -12,7 +12,8 @@ RSpec.describe TelephoneAppointment, type: :model do
       date_of_birth_day: '23',
       dc_pot_confirmed: 'yes',
       opt_out_of_market_research: 'true',
-      accept_terms_and_conditions: 'true'
+      accept_terms_and_conditions: 'true',
+      where_you_heard: '1'
     )
   end
 


### PR DESCRIPTION
This gives customers the ability to specify where they heard of Pension
Wise when placing a telephone appointment.