### PR TITLE
Calculate age at date of appointment

### DIFF
--- a/app/models/tesco/booking.rb
+++ b/app/models/tesco/booking.rb
@@ -45,7 +45,7 @@ module Tesco
     end
 
     def eligible?
-      age >= 50 && dc_pot_confirmed != 'no'
+      age_at_appointment >= 50 && dc_pot_confirmed != 'no'
     end
 
     def ineligible?
@@ -106,14 +106,10 @@ module Tesco
       Tesco.create(self)
     end
 
-    private
+    def age_at_appointment
+      return 0 unless date_of_birth && start_at
 
-    def age
-      return 0 unless date_of_birth
-
-      age = Time.zone.today.year - date_of_birth.year
-      age -= 1 if Time.zone.today.to_date < date_of_birth + age.years
-      age
+      ((start_at.to_date - date_of_birth) / 365).floor
     end
   end
 end

--- a/spec/models/tesco/booking_spec.rb
+++ b/spec/models/tesco/booking_spec.rb
@@ -1,0 +1,24 @@
+RSpec.describe Tesco::Booking do
+  describe '#age_at_appointment' do
+    context 'when `date_of_birth` is not present' do
+      it 'returns 0' do
+        expect(described_class.new.age_at_appointment).to be_zero
+      end
+    end
+
+    context 'when it can be calculated' do
+      subject do
+        described_class.new(
+          date_of_birth_year: '1967',
+          date_of_birth_month: '02',
+          date_of_birth_day: '02',
+          start_at: '2017-11-05 13:00UTC'
+        )
+      end
+
+      it 'returns the correct age at appointment' do
+        expect(subject.age_at_appointment).to eq(50)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This ensures that customers turning 50 by the time of their appointment
are eligible and thus can place a booking.