### PR TITLE
Don't show phone number with no availability

### DIFF
--- a/app/views/locations/_location.html.erb
+++ b/app/views/locations/_location.html.erb
@@ -1,0 +1,31 @@
+<% if location.limited_availability? %>
+  <div class="notice notice--extra-spacing">
+    <i class="icon icon-information">
+      <span class="visually-hidden">Info</span>
+    </i>
+    <strong class="small">Limited appointment availability</strong>
+  </div>
+<% end %>
+
+<% if location.online_booking_enabled? %>
+  <% if location.slots_available? %>
+    <% if agent? %>
+      <p><%= link_to 'Book on behalf of customer', agent_booking_path(location.id), class: 'button t-agent-book-online' %></p>
+    <% else %>
+      <p>
+        <%= link_to 'Book online', booking_request_step_one_location_path(location.id), class: 'button t-book-online' %>
+      </p>
+    <% end %>
+  <% else %>
+    <div class="notice notice--extra-spacing">
+      <i class="icon icon-information">
+        <span class="visually-hidden">Info</span>
+      </i>
+      <strong class="small">No appointment availability</strong>
+    </div>
+  <% end %>
+<% else %>
+  <p>
+    Call <strong class="t-phone"><%= location.phone %></strong>.
+  </p>
+<% end %>

--- a/app/views/locations/index.html.erb
+++ b/app/views/locations/index.html.erb
@@ -20,31 +20,7 @@
             <%= location.distance %> miles
           </p>
 
-          <% if location.limited_availability? %>
-            <div class="notice notice--extra-spacing">
-              <i class="icon icon-information">
-                <span class="visually-hidden">Info</span>
-              </i>
-              <strong class="small">Limited appointment availability</strong>
-            </div>
-          <% end %>
-
-          <% if location.online_booking_enabled? && location.slots_available? %>
-            <% if agent? %>
-              <p><%= link_to 'Book on behalf of customer', agent_booking_path(location.id), class: 'button t-agent-book-online' %></p>
-            <% else %>
-              <p>
-                <%= link_to 'Book online', booking_request_step_one_location_path(location.id), class: 'button t-book-online' %>
-              </p>
-            <% end %>
-            <p>
-              Or call <strong class="t-phone"><%= location.phone %></strong>.
-            </p>
-          <% else %>
-            <p>
-              Call <strong class="t-phone"><%= location.phone %></strong>.
-            </p>
-          <% end %>
+          <%= render partial: 'location', locals: { location: location } %>
         </div>
 
         <div class="l-column-third">

--- a/app/views/locations/show.html.erb
+++ b/app/views/locations/show.html.erb
@@ -34,40 +34,13 @@
       <%= simple_format(@location.address) %>
     </div>
 
-    <h2>How to book</h2>
+    <%= render partial: 'location', locals: { location: @location } %>
 
-    <% if @location.limited_availability? %>
-      <div class="notice notice--extra-spacing">
-        <i class="icon icon-information">
-          <span class="visually-hidden">Info</span>
-        </i>
-        <strong class="small">Limited appointment availability</strong>
-      </div>
+    <% if @location.slots_available? %>
+      <h2>Before you book</h2>
+
+      <p>You should be aged <b>50 or over</b> and have a <%= link_to 'defined contribution', guide_path('pension-types') %> pension (not a final salary or career average pension).</p>
     <% end %>
-
-    <% if @location.online_booking_enabled? && @location.slots_available? %>
-      <% if agent? %>
-        <p><%= link_to 'Book on behalf of customer', agent_booking_path(@location.id), class: 'button t-agent-book-online' %></p>
-      <% else %>
-        <p>
-          <%= link_to 'Book online', booking_request_step_one_location_path(@location.id), class: 'button t-book-online' %>
-        </p>
-      <% end %>
-
-      Or call <strong class="t-phone"><%= @location.phone %></strong>.
-    <% else %>
-      Call <strong class="t-phone"><%= @location.phone %></strong>.
-    <% end %>
-
-    <% if @location.hours.present? %>
-      <div class="t-hours"><%= simple_format(@location.hours) %></div>
-    <% end %>
-
-    <p>The appointment times available can change depending on your location.</p>
-
-    <h2>Before you book</h2>
-
-    <p>You should be aged <b>50 or over</b> and have a <%= link_to 'defined contribution', guide_path('pension-types') %> pension (not a final salary or career average pension).</p>
   </div>
 
   <div class="l-column-half">

--- a/features/step_definitions/location_steps.rb
+++ b/features/step_definitions/location_steps.rb
@@ -77,7 +77,7 @@ Then(/^I should see the details of that appointment location$/) do
   expect(location).to be_displayed(id: 'london')
   expect(location.name.text).to eq('London')
 
-  %i(address phone hours).each do |element|
+  %i(address phone).each do |element|
     expect(location.public_send(element)).to be_visible
   end
 

--- a/features/view_face-to-face_appointment_location_details.feature
+++ b/features/view_face-to-face_appointment_location_details.feature
@@ -22,7 +22,6 @@ Scenario: Appointment location that handles its own booking
   Then I should see the following appointment location details:
     | its name                              |
     | its address                           |
-    | its opening hours                     |
     | its Pension Wise booking phone number |
   And there are no search results to return to
 
@@ -31,5 +30,4 @@ Scenario: Appointment location that doesn't handle its own booking
   Then I should see the following appointment location details:
     | its name                                           |
     | its address                                        |
-    | booking location opening hours                     |
     | booking location Pension Wise booking phone number |


### PR DESCRIPTION
When the location is enabled for online bookings and the location has
no availability the customer was always presented the call centre
number. If they called the number they would be told the location has
no availability and they would reach a dead end. This change ensures
they are made aware early on when the location has no appointment
availability.