### PR TITLE
Revert "Include temporary new year confirmation"

### DIFF
--- a/app/views/booking_requests/completed.html.erb
+++ b/app/views/booking_requests/completed.html.erb
@@ -7,7 +7,7 @@
 
     <h2>What happens next?</h2>
 
-    <p>We’ll call or email you in the new year to confirm the date and time of
+    <p>We’ll call or email you within 2 working days to confirm the date and time of
     your appointment.</p>
 
     <div class="application-notice info-notice">


### PR DESCRIPTION
This no longer applies after the new year break.