### PR TITLE
Default requester email when not provided

### DIFF
--- a/app/models/complaint.rb
+++ b/app/models/complaint.rb
@@ -13,13 +13,19 @@ class Complaint
     valid?
   end
 
+  def requester_email
+    return email_address if email_address.present?
+
+    'contact@pensionwise.gov.uk'
+  end
+
   private
 
   def zendesk_content
     {
       subject: 'Complaint',
       name: name,
-      email: email_address,
+      email: requester_email,
       message: combined_message,
       tags: %w(complaint)
     }

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -7,4 +7,8 @@ Rails.application.config.filter_parameters += %i(
   phone
   telephone_number
   memorable_word
+  email_address
+  phone_booking_message
+  face_to_face_message
+  other_message
 )

--- a/spec/models/complaint_spec.rb
+++ b/spec/models/complaint_spec.rb
@@ -1,0 +1,6 @@
+RSpec.describe Complaint do
+  it 'defaults a missing requester email' do
+    complaint = described_class.new(email_address: '')
+    expect(complaint.requester_email).to be_present
+  end
+end


### PR DESCRIPTION
Ensures zendesk does not raise an error when the ticket is submitted.