### PR TITLE
Ensure postcodes are never submitted in URL's

### DIFF
--- a/app/views/components/_locations_search.html.erb
+++ b/app/views/components/_locations_search.html.erb
@@ -1,5 +1,5 @@
 <% has_error = local_assigns[:has_error] %>
-<form action="<%= locations_path %>" method="get">
+<form action="<%= search_locations_path %>" method="post">
   <div class="form-group <%= 'form-group-error' if has_error %>">
     <label class="form-label-bold" for="location">
       Postcode


### PR DESCRIPTION
This was missed previously in the last round of changes to postcode
search, in order to avoid the passing of postcodes in URL's.