### PR TITLE
Do not log customer IP addresses

### DIFF
--- a/app/controllers/lograge_filterer.rb
+++ b/app/controllers/lograge_filterer.rb
@@ -3,7 +3,6 @@ module LogrageFilterer
 
   def append_info_to_payload(payload)
     super
-    payload[:params]    = request.filtered_parameters
-    payload[:remote_ip] = request.remote_ip
+    payload[:params] = request.filtered_parameters
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -2,15 +2,14 @@ require 'redis-rails'
 
 EXCEPTIONS = %w(controller action format id).freeze
 
-Rails.application.configure do # rubocop:disable Metrics/BlockLength
+Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
   # Use lograge in the single-line heroku router style
   config.lograge.enabled = true
   config.lograge.custom_options = lambda do |event|
     {
-      params: event.payload[:params].except(*EXCEPTIONS),
-      remote_ip: event.payload[:remote_ip]
+      params: event.payload[:params].except(*EXCEPTIONS)
     }
   end
 


### PR DESCRIPTION
This helps with GDPR compliance plus we don't use this data anyway so
it's redundant.