### PR TITLE
Remove the stickiness of the explore-your-options/summary sidebar

### DIFF
--- a/app/views/pension_summaries/summary.html.erb
+++ b/app/views/pension_summaries/summary.html.erb
@@ -49,7 +49,7 @@
     </div>
   </aside>
 
-  <div class="sticky-sidebar js-sticky-sidebar">
+  <div>
     <div class="sidebar-hr"></div>
     <div class="sticky-sidebar__nav">
       <span class="sticky-sidebar__heading">

--- a/app/views/pension_summaries/summary.html.erb
+++ b/app/views/pension_summaries/summary.html.erb
@@ -28,26 +28,24 @@
   </p>
 <% end %>
 
-<% content_for :sticky_sidebar do %>
-  <aside class="l-sticky-sidebar">
-    <div class="sticky-sidebar js-sticky-sidebar">
-      <div class="sidebar-hr"></div>
-      <div class="sticky-sidebar__nav">
-        <span class="sticky-sidebar__heading">
-          <strong><%= t('.sidebar.heading') %></strong>
-        </span>
-        <ul class="sticky-sidebar__list nav">
-          <% @summary.selected_steps.each do |step| %>
-            <li>
-              <%= link_to skip_to_step_path(step), class: 'sticky-sidebar__link' do %>
-                <%= t("pension_summaries.options.#{step}.title") %>
-              <% end %>
-            </li>
-          <% end %>
-        </ul>
-        <%= link_to t('.sidebar.print_button'), print_summary_path, class: 'button' %>
-        <%= link_to t('.sidebar.download_button'), download_summary_path, class: 'button' %>
-      </div>
+<% content_for :sidebar do %>
+  <aside>
+    <div class="sidebar-hr"></div>
+    <div class="sticky-sidebar__nav">
+      <span class="sticky-sidebar__heading">
+        <strong><%= t('.sidebar.heading') %></strong>
+      </span>
+      <ul class="sticky-sidebar__list nav">
+        <% @summary.selected_steps.each do |step| %>
+          <li>
+            <%= link_to skip_to_step_path(step), class: 'sticky-sidebar__link' do %>
+              <%= t("pension_summaries.options.#{step}.title") %>
+            <% end %>
+          </li>
+        <% end %>
+      </ul>
+      <%= link_to t('.sidebar.print_button'), print_summary_path, class: 'button' %>
+      <%= link_to t('.sidebar.download_button'), download_summary_path, class: 'button' %>
     </div>
   </aside>
 


### PR DESCRIPTION
Not looking for a merge here - more a steer.

Prior to this - the sidebar on /en/explore-your-options/summary disappears in the mobile view rather than be positioned underneath the main content. This is bad because the sidebar contains buttons the user needs to be able to click.

Looking around the app - /en/summary-document is another page using the same "sticky_sidebar" module, where the sidebar also disappears in the mobile view. However, here it's likely that's intended behaviour since the sidebar just contains subsection navigation.

The `.sticky-sidebar` CSS module is hidden by default (the mobile view), and becomes visible for tablets and above.

Stickiness aside /en/explore-your-options/summary is making use of `.sticky-sidebar__nav`, `.sticky-sidebar__heading`, `sticky-sidebar__list` etc. I am guessing we want to keep it's current visual appearance while getting rid of it's disappearing/sticky trick.

This commit probably makes it appear as intended... but it makes sense to extract the relevant styles into a separate module. eg `sidebar__heading`, sidebar__heading` etc and those styles/elements are used within a `sticky-sidebar`. Or the whole of `sticky-sidebar` could become `sidebar` and it gets a `--sticky` modifier or something.. I've no feel for how messy that would be yet..

Any preferences @benlovell?

Screenshot of the current commit in mobile view below..

![screen shot 2018-04-17 at 16 37 42](https://user-images.githubusercontent.com/78311/38882841-309e3f3a-4263-11e8-87a4-f0f2b909a895.png)

