### PR TITLE
Hide appointment link in mobile

### DIFF
--- a/app/assets/stylesheets/components/_buttons.scss
+++ b/app/assets/stylesheets/components/_buttons.scss
@@ -1,3 +1,11 @@
 .button {
   margin: 0 15px 15px 0;
 }
+
+.summary {
+  display: none;
+
+  @include media(tablet) {
+    display: block;
+  }
+}

--- a/app/views/pension_summaries/summary.html.erb
+++ b/app/views/pension_summaries/summary.html.erb
@@ -24,7 +24,7 @@
   <% end %>
 
   <p>
-    <%= link_to t('.book_a_free_appointment_link'), guide_path('appointments') %>
+    <%= link_to t('.book_a_free_appointment_link'), guide_path('appointments'), class: 'summary' %>
   </p>
 <% end %>
 


### PR DESCRIPTION
This was stacking with the sidebar appointment link and since it was
titled the same it looked a bit weird.

## Before

<img width="393" alt="before" src="https://user-images.githubusercontent.com/41963/38928159-d625b98c-42ff-11e8-9a5c-8ca090846dae.png">

## After

<img width="391" alt="after" src="https://user-images.githubusercontent.com/41963/38928165-db9ebcc4-42ff-11e8-8ce8-32efef9dafcc.png">
