### PR TITLE
Ensure locale is included in redirect

### DIFF
--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -2,13 +2,13 @@
 class QuestionsController < ApplicationController
   skip_before_action :verify_authenticity_token
 
-  def next
+  def next # rubocop:disable AbcSize
     question = GuideDecorator.cached_for(GuideRepository.new.find(params[:question_id]))
 
     if answer = question.metadata.answers[params[:response]]
       redirect_to answer
     else
-      redirect_to "/#{params[:question_id]}", alert: true
+      redirect_to "/#{I18n.locale}/#{params[:question_id]}", alert: true
     end
   end
 end

--- a/spec/controllers/questions_controller_spec.rb
+++ b/spec/controllers/questions_controller_spec.rb
@@ -4,6 +4,6 @@ RSpec.describe QuestionsController, type: :controller do
   subject { post 'next', params: { locale: :en, question_id: 'pension-type-tool/question-1' } }
 
   it 'correctly redirects back when no answer is provided' do
-    expect(subject).to redirect_to('http://test.host/pension-type-tool/question-1')
+    expect(subject).to redirect_to('http://test.host/en/pension-type-tool/question-1')
   end
 end


### PR DESCRIPTION
When questions are submitted without answer we should redirect back
with the locale fragment in the URI.