### PR TITLE
Encode address for map links

### DIFF
--- a/app/views/locations/show.html.erb
+++ b/app/views/locations/show.html.erb
@@ -29,7 +29,7 @@
   <div class="l-column-half">
     <h2 style="margin-top: 0;">Find us here:</h2>
 
-    <a href="https://maps.google.com/maps?q=<%= @location.address %>" target="_blank">
+    <a href="https://maps.google.com/maps?q=<%= @location.address_encoded %>" target="_blank">
       <img
         height="450"
         alt="map showing the location of <%= @location.name %> (link opens external website in new window)"


### PR DESCRIPTION
This was not being encoded so had newline characters and unencoded
fragments causing the link to point at the wrong location when clicked.