### PR TITLE
Designated provider content

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -74,6 +74,8 @@ cy:
           class: t-appointment-summary-link
       - title: Pension Wise i gyflogwyr
         url: '/cy/for-employers'
+      - title: Designated providers
+        url: '/cy/designated-providers'
 
   pagination:
     previous: Blaenorol

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -71,6 +71,8 @@ en:
           class: t-appointment-summary-link
       - title: Pension Wise for employers
         url: '/en/for-employers'
+      - title: Designated providers
+        url: '/en/designated-providers'
 
   pagination:
     previous: Previous

--- a/content/designated_providers.cy.md
+++ b/content/designated_providers.cy.md
@@ -1,0 +1,14 @@
+---
+label: Designated providers of Pension Wise guidance
+description: Designated providers of Pension Wise guidance
+---
+
+# Designated providers of Pension Wise guidance
+
+The designated providers of Pension Wise guidance are:
+
+* The Pensions Advisory Service Limited
+* The National Association of Citizens Advice Bureaux
+* The Scottish Association of Citizens Advice Bureaux
+* The Northern Ireland Association of Citizens Advice Bureaux
+* Teleperformance SE

--- a/content/designated_providers.en.md
+++ b/content/designated_providers.en.md
@@ -1,0 +1,14 @@
+---
+label: Designated providers of Pension Wise guidance
+description: Designated providers of Pension Wise guidance
+---
+
+# Designated providers of Pension Wise guidance
+
+The designated providers of Pension Wise guidance are:
+
+* The Pensions Advisory Service Limited
+* The National Association of Citizens Advice Bureaux
+* The Scottish Association of Citizens Advice Bureaux
+* The Northern Ireland Association of Citizens Advice Bureaux
+* Teleperformance SE


### PR DESCRIPTION
Provides the content and navigation links for Pension Wise's designated
guidance providers.