### PR TITLE
GDPR preferences for Tesco customer journey

### DIFF
--- a/app/controllers/tesco/bookings_controller.rb
+++ b/app/controllers/tesco/bookings_controller.rb
@@ -93,8 +93,7 @@ module Tesco
           :memorable_word,
           :date_of_birth,
           :dc_pot_confirmed,
-          :opt_out_of_market_research,
-          :accept_terms_and_conditions,
+          :gdpr_consent,
           :date_of_birth_year,
           :date_of_birth_month,
           :date_of_birth_day

--- a/app/models/tesco/booking.rb
+++ b/app/models/tesco/booking.rb
@@ -14,14 +14,13 @@ module Tesco
       :memorable_word,
       :appointment_type,
       :date_of_birth,
-      :opt_out_of_market_research,
-      :accept_terms_and_conditions,
       :dc_pot_confirmed,
       :date_of_birth_year,
       :date_of_birth_month,
       :date_of_birth_day,
       :location_id,
-      :room
+      :room,
+      :gdpr_consent
     )
 
     validates :start_at, presence: true
@@ -32,7 +31,6 @@ module Tesco
     validates :memorable_word, presence: true
     validates :date_of_birth, presence: true
     validates :dc_pot_confirmed, inclusion: { in: %w(yes no not-sure) }
-    validates :accept_terms_and_conditions, inclusion: { in: [true] }
 
     def advance!
       self.step += 1
@@ -61,8 +59,8 @@ module Tesco
         phone: phone,
         memorable_word: memorable_word,
         date_of_birth: date_of_birth,
-        opt_out_of_market_research: opt_out_of_market_research,
-        dc_pot_confirmed: dc_pot_confirmed == 'yes'
+        dc_pot_confirmed: dc_pot_confirmed == 'yes',
+        gdpr_consent: gdpr_consent.to_s
       }
     end
 
@@ -78,14 +76,6 @@ module Tesco
       parts.map!(&:to_i)
 
       Date.new(*parts)
-    end
-
-    def opt_out_of_market_research
-      %w(1 true).include?(@opt_out_of_market_research)
-    end
-
-    def accept_terms_and_conditions
-      %w(1 true).include?(@accept_terms_and_conditions)
     end
 
     def selected_date

--- a/app/views/tesco/bookings/_hidden_fields.html.erb
+++ b/app/views/tesco/bookings/_hidden_fields.html.erb
@@ -7,6 +7,5 @@
 <%= f.hidden_field :date_of_birth_month, id: "#{id_prefix}_date_of_birth_month" %>
 <%= f.hidden_field :date_of_birth_day, id: "#{id_prefix}_date_of_birth_day" %>
 <%= f.hidden_field :dc_pot_confirmed, id: "#{id_prefix}_dc_pot_confirmed" %>
-<%= f.hidden_field :opt_out_of_market_research, id: "#{id_prefix}_opt_out_of_market_research" %>
-<%= f.hidden_field :accept_terms_and_conditions, id: "#{id_prefix}_accept_terms_and_conditions" %>
+<%= f.hidden_field :gdpr_consent, id: "#{id_prefix}_gdpr_consent" %>
 <%= f.hidden_field :selected_date, id: "#{id_prefix}_selected_date" %>

--- a/app/views/tesco/bookings/_step_3.html.erb
+++ b/app/views/tesco/bookings/_step_3.html.erb
@@ -148,42 +148,36 @@
     </fieldset>
   </div>
 
-  <div class="form-group <%= 'form-group-error' if @booking.errors.include?(:opt_out_of_market_research) %>">
-    <fieldset>
-      <legend>
-        <% if @booking.errors.include?(:opt_in) %>
-          <span class="error-message"><%= @booking.errors[:opt_out_of_market_research].to_sentence.capitalize %></span>
-        <% end %>
-      </legend>
-      <div class="multiple-choice">
-        <%= f.check_box :opt_out_of_market_research, class: 't-opt-out-of-market-research' %>
-        <%= f.label :opt_out_of_market_research, class: 't-opt-in' do %>
-          I don't want to be contacted in the future
-          <span class="form-hint">If you don't want to tell us about your experience of Pension Wise</span>
-        <% end %>
-      </div>
-    </fieldset>
-  </div>
+  <div class="form-group t-gdpr-consent" id="tesco_appointment_gdpr_consent" tabindex="-1">
+    <fieldset class="inline">
+      <legend>Customer research consent</legend>
+      <span class="form-hint">
+        Your feedback helps us improve the service. Is it OK if we share your
+        contact details with our trusted research partner? Ipsos MORI may
+        contact you to ask if you would like to provide feedback and you can
+        decide then if you want to take part.
+      </span>
 
-  <div class="form-group <%= 'form-group-error' if @booking.errors.include?(:accept_terms_and_conditions) %>">
-    <fieldset>
-      <legend>
-        <span class="visually-hidden">Terms and conditions</span>
-        <% if @booking.errors.include?(:accept_terms_and_conditions) %>
-          <span class="error-message"><%= @booking.errors[:accept_terms_and_conditions].to_sentence.capitalize %></span>
-        <% end %>
-      </legend>
       <div class="multiple-choice">
-        <%= f.check_box :accept_terms_and_conditions, class: 't-accept-terms-and-conditions' %>
-        <%= f.label :accept_terms_and_conditions, class: 't-opt-in' do %>
-          I accept the <a href="/privacy" target="_blank">terms and conditions</a>
-        <% end %>
+        <%= f.radio_button :gdpr_consent, 'yes', class: 't-gdpr-consent-yes' %>
+        <%= f.label :gdpr_consent, value: 'yes' do %>Yes<% end %>
+      </div>
+
+      <div class="multiple-choice">
+        <%= f.radio_button :gdpr_consent, 'no', class: 't-gdpr-consent-no' %>
+        <%= f.label :gdpr_consent, value: 'no' do %>No<% end %>
       </div>
     </fieldset>
   </div>
 
   <div class="form-group">
     <%= f.submit 'Confirm appointment', class: 'button t-submit', data: { disable_with: 'Please wait...' } %>
+  </div>
+
+  <div role="note" aria-label="Information" class="application-notice info-notice">
+    <p>Pension Wise collects and stores personal data for the purpose of delivering Pensions Guidance.</p>
+    <p>Your data will be shared with Citizens Advice only where it is necessary to provide you with Pension Wise guidance.</p>
+    <p>Full details of our privacy policy, including information on your rights in relation to the data we hold can be <%= link_to 'found here', guide_path('privacy') %>.</p>
   </div>
 </div>
 <div class="l-column-third">

--- a/features/pages/tesco_booking.rb
+++ b/features/pages/tesco_booking.rb
@@ -12,8 +12,9 @@ module Pages
     element :memorable_word, '.t-memorable-word'
     element :dc_pot_confirmed, '.t-dc-pot-confirmed-yes', visible: false
     element :dc_pot_confirmed_no, '.t-dc-confirmed-pot-no', visible: false
-    element :opt_out_of_market_research, '.t-opt-out-of-market-research', visible: false
-    element :accept_terms_and_conditions, '.t-accept-terms-and-conditions', visible: false
+    element :gdpr_consent_yes, '.t-gdpr-consent-yes', visible: false
+    element :gdpr_consent_no, '.t-gdpr-consent-no', visible: false
+    element :gdpr_consent_no_response, '.t-gdpr-consent-no-response', visible: false
 
     element :submit, '.t-submit'
     element :continue, '.t-continue'

--- a/spec/cassettes/Tesco_Api/_create/responds_successfully.yml
+++ b/spec/cassettes/Tesco_Api/_create/responds_successfully.yml
@@ -5,11 +5,11 @@ http_interactions:
     uri: http://localhost:3008/api/v1/locations/1/appointments
     body:
       encoding: UTF-8
-      string: '{"start_at":"2017-10-02 08:15:00 UTC","first_name":"Rick","last_name":"Sanchez","email":"rick@example.com","phone":"07715
-        930 444","memorable_word":"cheese","date_of_birth":"1960-01-01","opt_out_of_market_research":false,"dc_pot_confirmed":false}'
+      string: '{"start_at":"2018-05-25 07:00:00 UTC","first_name":"Rick","last_name":"Sanchez","email":"rick@example.com","phone":"07715
+        930 444","memorable_word":"cheese","date_of_birth":"1960-01-01","dc_pot_confirmed":false,"gdpr_consent":""}'
     headers:
       User-Agent:
-      - PensionWise/1.0 (birdperson; benlovell; 47827) ruby/2.4.2 (198; x86_64-darwin16)
+      - PensionWise/1.0 (birdperson.local; benlovell; 47924) ruby/2.5.1 (57; x86_64-darwin17)
       Accept:
       - application/json
       Content-Type:
@@ -30,18 +30,18 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"937308918c580bbb0ec42b4173d1bbe5"
+      - W/"465308fb8468ba9ce856efa95a8dee4f"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 9f045795-38ee-4528-8fe9-3f11c34fb4f7
+      - 8b63dbaf-d1d5-4404-b9cc-7ddd126440c5
       X-Runtime:
-      - '0.414120'
+      - '0.155927'
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
-      string: '{"id":10,"room":"R1"}'
+      string: '{"id":299,"room":"HIGH 2.2"}'
     http_version: 
-  recorded_at: Sun, 01 Oct 2017 10:13:50 GMT
+  recorded_at: Mon, 21 May 2018 11:03:16 GMT
 recorded_with: VCR 3.0.3

--- a/spec/features/tesco_booking_spec.rb
+++ b/spec/features/tesco_booking_spec.rb
@@ -53,9 +53,7 @@ RSpec.feature 'Tesco Bookings' do
     @page.date_of_birth_month.set('01')
     @page.date_of_birth_year.set('1950')
     @page.memorable_word.set('snootboop')
-
-    @page.opt_out_of_market_research.set(true)
-    @page.accept_terms_and_conditions.set(true)
+    @page.gdpr_consent_yes.set(true)
     @page.dc_pot_confirmed.set(true)
 
     @page.submit.click

--- a/spec/lib/tesco/api_spec.rb
+++ b/spec/lib/tesco/api_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe Tesco::Api do
     it 'responds successfully' do
       booking = Tesco::Booking.new(
         location_id: 1,
-        start_at: '2017-10-02 08:15 UTC',
+        start_at: '2018-05-25 07:00 UTC',
         first_name: 'Rick',
         last_name: 'Sanchez',
         email: 'rick@example.com',
@@ -13,13 +13,13 @@ RSpec.describe Tesco::Api do
         date_of_birth_month: '01',
         date_of_birth_day: '01',
         dc_pot_confirmed: true,
-        opt_out_of_market_research: true
+        gdpr_consent: nil
       )
 
       described_class.new.create(booking)
 
-      expect(booking.id).to eq(10)
-      expect(booking.room).to eq('R1')
+      expect(booking.id).to eq(299)
+      expect(booking.room).to eq('HIGH 2.2')
     end
   end
 


### PR DESCRIPTION
Ensures we now capture GDPR contact consent from Tesco customers during
their booking journey. These changes supplant the 'terms and
conditions' and 'opt out of market research' preferences.

Release should be synchronised with guidance-guarantee-programme/tesco_planner#80