### PR TITLE
Guard fake server startup

### DIFF
--- a/features/support/mock_mailgun.rb
+++ b/features/support/mock_mailgun.rb
@@ -13,8 +13,7 @@ Before('@mock_mailgun') do
 end
 
 After('@mock_mailgun') do
-  @mailgun_server.shutdown
-  @mailgun_thread.kill
+  @mailgun_thread.kill while system('lsof -t -i:9293 > /dev/null')
 end
 
 def with_mock_mailgun_response(response)


### PR DESCRIPTION
Due to a timing issue the mailgun fake was started twice between
individual test runs this change ensures this doesn't happen.