### PR TITLE
Bump `booking_locations`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,7 +68,7 @@ GEM
     babel-transpiler (0.7.0)
       babel-source (>= 4.0, < 6)
       execjs (~> 2.0)
-    booking_locations (0.17.0)
+    booking_locations (0.20.0)
       activesupport (>= 4, <= 6)
       globalid
     bugsnag (5.2.0)


### PR DESCRIPTION
This stops us from swallowing timeouts at the API adapter level.