### PR TITLE
Correct a typo in the pension summary tool

### DIFF
--- a/config/locales/pension_summaries.en.yml
+++ b/config/locales/pension_summaries.en.yml
@@ -114,7 +114,7 @@ en:
         three: Neither satisfied nor dissatisfied
         four: Fairly satisfied
         five: Very satisfied
-      comments: "Please let use know anything that has made you particularly satisfied or dissatisfied with the Pension Wise service:"
+      comments: "Please let us know anything that has made you particularly satisfied or dissatisfied with the Pension Wise service:"
       where_you_heard:
         label: Where did you first hear of Pension Wise?
         options:

--- a/spec/features/pension_summary_spec.rb
+++ b/spec/features/pension_summary_spec.rb
@@ -110,7 +110,7 @@ end
 
 def and_i_fill_out_the_your_experience_form
   choose('Very satisfied')
-  fill_in('Please let use know anything that has made you particularly satisfied or dissatisfied with the Pension Wise service:', with: 'Everything was great')
+  fill_in('Please let us know anything that has made you particularly satisfied or dissatisfied with the Pension Wise service:', with: 'Everything was great')
   select('TV advert', from: 'Where did you first hear of Pension Wise?')
   click_button('Next')
 end


### PR DESCRIPTION
I spotted this typo during testing.