### PR TITLE
Separate further signposting for web/print

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: https://github.com/guidance-guarantee-programme/output-templates.git
-  revision: 630ff0a222c1c2eaa55ee4539b015cefe4c58e51
+  revision: 8d5a6a7d808aa2059526bd9a1b05fea70e0dfe0a
   specs:
-    output-templates (4.9.5)
+    output-templates (4.9.6)
       actionview
       sass
 

--- a/app/controllers/pension_summaries_controller.rb
+++ b/app/controllers/pension_summaries_controller.rb
@@ -88,14 +88,16 @@ class PensionSummariesController < ApplicationController
   end
 
   def print
-    @intro = get_guide('print-introduction')
+    @intro  = get_guide('print-introduction')
+    @outro  = get_guide('trusted-sources', prefixed: false)
     @guides = @summary.selected_steps.collect { |s| get_guide(s) }
 
     render 'pension_summaries/print', layout: false
   end
 
   def download
-    @intro = get_guide('print-introduction')
+    @intro  = get_guide('print-introduction')
+    @outro  = get_guide('trusted-sources', prefixed: false)
     @guides = @summary.selected_steps.collect { |s| get_guide(s) }
 
     render pdf: 'your pension summary from Pension Wise',
@@ -108,8 +110,10 @@ class PensionSummariesController < ApplicationController
 
   private
 
-  def get_guide(slug)
-    GuideDecorator.cached_for(GuideRepository.new.find("pension_summary/#{slug}"))
+  def get_guide(slug, prefixed: true)
+    path = prefixed ? "pension_summary/#{slug}" : slug
+
+    GuideDecorator.cached_for(GuideRepository.new.find(path))
   end
 
   def about_you_params

--- a/app/views/pension_summaries/print.html.erb
+++ b/app/views/pension_summaries/print.html.erb
@@ -121,6 +121,36 @@
         padding-right: 60px;
       }
     }
+
+    table {
+      margin: 1em 0 2em;
+      border-collapse: collapse;
+    }
+
+    th {
+      font-weight: bold;
+      margin: .4em .5em .4em 0;
+      text-align: left;
+    }
+
+    th, td {
+      vertical-align: top;
+    }
+
+    td {
+      border-top: 1px solid grey;
+    }
+
+    .options-table th {
+      font-weight: bold;
+      width: 33%;
+    }
+
+    .options-table td {
+      padding-top: .9em;
+      padding-bottom: .9em;
+      width: 33%;
+    }
   </style>
 </head>
 <body>
@@ -137,6 +167,8 @@
       <div class="page-break"></div>
     <% end %>
   <% end %>
+
+  <%= @outro.content %>
 </body>
 <script>
   window.print();

--- a/content/pension_summary/final.cy.md
+++ b/content/pension_summary/final.cy.md
@@ -1,3 +1,4 @@
+{:.not-printed}
 # Arweiniad pellach diduedd am ddim
 
 {:.not-printed}
@@ -7,44 +8,9 @@ Os hoffech gael mwy o wybodaeth am eich opsiynau, gallwch drefnu apwyntiad Pensi
 {:.not-printed}
 [Trefnu apwyntiad am ddim](/appointments){: .button #phone-button style="font-size: 0.9em; padding-left: 2em; padding-right: 2em;"}
 
+{:.not-printed}
+
 ## Help gyda blwydd-daliadau, dyled, a dod o hyd i ymgynghorydd ariannol:
 
-$C
-### Y Gwasanaeth Cynghori Ariannol
-[moneyadviceservice.org.uk](https://moneyadviceservice.org.uk)<br>
-Ffôn: 0800 138 7777<br>
-O’r tu allan i’r DU: +44 144 382 7658
-$C
-
-## Help gyda budd-daliadau a dyled:
-
-$C
-### Cyngor Ar Bopeth
-[citizensadvice.org.uk](https://citizensadvice.org.uk)<br>
-Ffôn:<br>
-Lloegr: 03444 111 444<br>
-Yr Alban: 0808 800 9060
-$C
-
-$C
-### Cyngor Ar Bopeth Gogledd Iwerddon
-[citizensadvice.co.uk](https://citizensadvice.org.uk)
-$C
-
-## Help gyda sgamiau, Pensiwn y Wladwriaeth a phensiynau cyflog terfynol a chyfraniadau wedi’u diffinio:
-
-$C
-### Y Gwasanaeth Cynghori ar Bensiynau
-[pensionsadvisoryservice.org.uk](https://pensionsadvisoryservice.org.uk)<br>
-Ffôn: 0800 011 3797<br>
-O’r tu allan i’r DU: +44 207 9325780
-$C
-
-## Dod o hyd i bensiwn a gollwyd:
-
-$C
-### Y Gwasanaeth Olrhain Pensiynau
-[www.gov.uk/dod-o-hyd-i-fanylion-cyswllt-pensiwn](https://www.gov.uk/dod-o-hyd-i-fanylion-cyswllt-pensiwn)<br>
-Ffôn: 0345 6002 537<br>
-O’r tu allan i’r DU: +44 191 215 4491
-$C
+{:.not-printed}
+[Trusted sources of additional information](/cy/trusted-sources)

--- a/content/pension_summary/final.en.md
+++ b/content/pension_summary/final.en.md
@@ -1,3 +1,4 @@
+{:.not-printed}
 # Further free and impartial guidance
 
 {:.not-printed}
@@ -7,44 +8,9 @@ If you’d like more information on your options, you can book a Pension Wise ap
 {:.not-printed}
 [Book a free appointment](/appointments){: .button #phone-button style="font-size: 0.9em; padding-left: 2em; padding-right: 2em;"}
 
-## Help with annuities, debt and finding a financial adviser:
+{:.not-printed}
 
-$C
-### The Money Advice Service
-[moneyadviceservice.org.uk](https://moneyadviceservice.org.uk)<br>
-Phone: 0800 138 7777<br>
-From outside the UK: +44 144 382 7658
-$C
+## Help with annuities, debt and finding additional information
 
-## Help with benefits and debt:
-
-$C
-### Citizens Advice
-[citizensadvice.org.uk](https://citizensadvice.org.uk)<br>
-Phone:<br>
-England: 03444 111 444<br>
-Scotland: 0808 800 9060
-$C
-
-$C
-### Northern Ireland Citizens Advice
-[citizensadvice.co.uk](https://citizensadvice.org.uk)
-$C
-
-## Help with scams, State Pension, final salary and defined contribution pensions:
-
-$C
-### The Pensions Advisory Service
-[pensionsadvisoryservice.org.uk](https://pensionsadvisoryservice.org.uk)<br>
-Phone: 0800 011 3797<br>
-From outside the UK: +44 207 9325780
-$C
-
-## Find a lost pension:
-
-$C
-### The Pensions Tracing Service
-[gov.uk/find-pension-contact-details](https://www.gov.uk/find-pension-contact-details)<br>
-Phone: 0800 731 0193<br>
-From outside the UK: +44 191 215 4491
-$C
+{:.not-printed}
+[Trusted sources of additional information](/en/trusted-sources)

--- a/content/trusted_sources.cy.md
+++ b/content/trusted_sources.cy.md
@@ -1,135 +1,135 @@
-# Trusted sources of additional information
+# Ffynonhellau dibynadwy o wybodaeth ychwanegol
 
-Pension Wise consider these organisations to be trusted sources of additional information:
+Mae Pension Wise yn ystyried y sefydliadau hyn i fod yn ffynonhellau dibynadwy o wybodaeth ychwanegol:
 
 <table class="options-table">
   <thead>
     <tr>
-      <th scope="col">Organisation</th>
-      <th scope="col">Query</th>
+      <th scope="col">Sefydliad</th>
+      <th scope="col">Ymholiad</th>
     </tr>
   </thead>
   <tbody>
     <tr>
       <td>
-        <strong>The Pensions Advisory Service</strong><br>
+        <strong>Y Gwasanaeth Cynghori ar Bensiynau</strong><br>
         <a href="https://pensionsadvisoryservice.org.uk">pensionsadvisoryservice.org.uk</a><br>
-        Phone: 0800 011 3797
+        Ffôn: 0800 011 3797
       </td>
       <td>
-        For general pension queries and complaints, including help avoiding pension scams and saving into a pension scheme
+        Ar gyfer ymholiadau pensiwn cyffredinol a chwynion, yn cynnwys help i osgoi sgamiau pensiwn a chynilo i gynllun pensiwn
       </td>
     </tr>
     <tr>
       <td>
-        <strong>Citizens Advice</strong><br>
-        England & Wales<br>
+        <strong>Cyngor Ar Bopeth</strong><br>
+        Cymru a Lloegr<br>
         <a href="https://www.citizensadvice.org.uk">www.citizensadvice.org.uk</a><br>
-        Phone:<br>
-        03444 111 444 (England)<br>
-        03444 77 20 20 (Wales)<br><br>
+        Ffôn:<br>
+        03444 111 444 (Lloegr)<br>
+        03444 77 20 20 (Cymru)<br><br>
 
-        Scotland<br>
+        Yr Alban<br>
         <a href="https://www.cas.org.uk">www.cas.org.uk</a><br>
-        Contact local bureau
+        Cystlltwch â changen lleol
       </td>
       <td>
         <ul>
-          <li>Debt</li>
-          <li>Social Care</li>
-          <li>State Benefits</li>
-          <li>Employment rights</li>
-          <li>Consumer rights</li>
-          <li>Relationships</li>
-          <li>Housing</li>
-          <li>Discrimination</li>
-          <li>Tax</li>
+          <li>Dyled</li>
+          <li>Gofal Cymdeithasol</li>
+          <li>Budd-daliadau’r Wladwriaeth</li>
+          <li>Hawliau cyflogaeth</li>
+          <li>Hawliau defnyddwyr</li>
+          <li>Perthnasau</li>
+          <li>Tai</li>
+          <li>Gwahaniaethu</li>
+          <li>Treth</li>
         </ul>
       </td>
     </tr>
     <tr>
       <td>
-        <strong>Money Advice Service</strong><br>
-        <a href="https://www.moneyadviceservice.org.uk">www.moneyadviceservice.org.uk</a><br>
-        Phone: 0800 138 7777
+        <strong>Y Gwasanaeth Cynghori Ariannol</strong><br>
+        <a href="https://www.moneyadviceservice.org.uk/cy">www.moneyadviceservice.org.uk/cy</a><br>
+        Ffôn: 0800 138 0555
       </td>
       <td>
         <ul>
-        <li>Annuity Comparison Tool <a href="https://comparison.moneyadviceservice.org.uk">comparison.moneyadviceservice.org.uk</a></li>
-        <li>Retirement adviser directory <a href="https://directory.moneyadviceservice.org.uk">directory.moneyadviceservice.org.uk</a></li>
-        <li>Understand and compare Income Drawdown <a href="https://www.moneyadviceservice.org.uk/en/retirement-income-options/income-drawdown">www.moneyadviceservice.org.uk/en/retirement-income-options/income-drawdown</a></li>
-        <li>Debt and borrowing</li>
-        <li>Budgeting and managing money</li>
-        <li>Saving and investing</li>
-        <li>Pensions and retirement</li>
-        <li>Work and redundancy</li>
-        <li>Benefits</li>
-        <li>Births, deaths and family</li>
-        <li>Insurance</li>
-        <li>Homes and mortgages</li>
-        <li>Care and disability</li>
+        <li>Offeryn Cymharu Blwydd-dal <a href=" https://comparison.moneyadviceservice.org.uk/cy/tools/annuities">comparison.moneyadviceservice.org.uk/cy/tools/annuities</a></li>
+        <li>Cyfeirlyfr cynghori ar ymddeoliad <a href=" https://directory.moneyadviceservice.org.uk/cy">directory.moneyadviceservice.org.uk/cy</a></li>
+        <li>Deall a chymharu Tynnu Incwm i Lawr <a href=" https://www.moneyadviceservice.org.uk/cy/opsiynau-incwm-ymddeoliad/income-drawdown">www.moneyadviceservice.org.uk/cy/opsiynau-incwm-ymddeoliad/income-drawdown</a></li>
+        <li>Dyled a benthyca</li>
+        <li>Cyllidebu a rheoli arian</li>
+        <li>Cynilo a buddsoddi</li>
+        <li>Pensiynau ac ymddeoliad</li>
+        <li>Gwaith a diswyddo</li>
+        <li>Budd-daliadau</li>
+        <li>Genedigaethau, marwolaethau a theulu</li>
+        <li>Yswiriant</li>
+        <li>Cartrefi a morgesis</li>
+        <li>Gofal ac anabledd</li>
         </ul>
       </td>
     </tr>
     <tr>
       <td>
-        <strong>Pension Ombudsman</strong><br>
+        <strong>Ombwdsmon Pensiynau</strong><br>
         <a href="https://www.pensions-ombudsman.org.uk">www.pensions-ombudsman.org.uk</a><br>
-        Phone: 0800 917 4487
+        Ffôn: 0800 917 4487
       </td>
       <td>
-        Complaints about the maladministration of pensions
+        Cwynion am gamweinyddu pensiynau
       </td>
     </tr>
     <tr>
       <td>
-        <strong>Financial Ombudsman</strong><br>
+        <strong>Ombwdsmon Ariannol</strong><br>
         <a href="https://www.financial-ombudsman.org.uk">www.financial-ombudsman.org.uk</a><br>
-        Phone: 0800 023 4567
+        Ffôn: 0800 023 4567
       </td>
       <td>
-        Complaints about the sales and marketing of pensions
+        Cwynion am werthu a marchnata pensiynau
       </td>
     </tr>
     <tr>
       <td>
         <strong>Action Fraud</strong><br>
         <a href="https://www.actionfraud.police.uk">www.actionfraud.police.uk</a><br>
-        Phone: 0300 123 2040
+        Ffôn: 0300 123 2040
       </td>
       <td>
-        For information on scams or to report a scam
+        Am wybodaeth ar sgamiau neu i roi gwybod am sgam
       </td>
     </tr>
     <tr>
       <td>
-        <strong>HM Revenue and Customs</strong><br>
+        <strong>Cyllid a Thollau EM</strong><br>
         <a href="https://www.gov.uk/contact-hmrc">www.gov.uk/contact-hmrc</a><br>
-        Phone: 0300 200 3300
+        Ffôn: 0300 200 3300
       </td>
       <td>
         <ul>
-          <li>Self Assessment</li>
-          <li>Tax credits</li>
-          <li>Child Benefit</li>
-          <li>Income Tax</li>
-          <li>National Insurance</li>
-          <li>Tax for employers</li>
-          <li>VAT</li>
+          <li>Hunanasesiad</li>
+          <li>Credydau Treth</li>
+          <li>Budd-dal Plant</li>
+          <li>Treth Incwm</li>
+          <li>Yswiriant Gwladol</li>
+          <li>Treth i gyflogwyr </li>
+          <li>TAW</li>
         </ul>
       </td>
     </tr>
     <tr>
       <td>
-        <strong>Financial Conduct Authority (FCA)</strong><br>
+        <strong>Awdurdod Ymddygiad Ariannol (FCA)</strong><br>
         <a href="https://www.fca.org.uk">www.fca.org.uk</a><br>
-        Phone: 0800 111 6768
+        Ffôn: 0800 111 6768
       </td>
       <td>
         <ul>
-          <li>Check the FCA register to see if a firm or adviser is regulated <a href="https://www.fca.org.uk/register">www.fca.org.uk/register</a></li>
-          <li>Check list of unauthorised schemes and individuals to avoid <a href="https://www.fca.org.uk/scamsmart/warning-list/search">www.fca.org.uk/scamsmart/warning-list/search</a></li>
-          <li>Useful information on scams</li>
+          <li>Edrychwch ar gofrestr yr FCA i weld os yw busnes neu ymgynghorydd wedi’u rheoleiddio <a href="https://www.fca.org.uk/register">www.fca.org.uk/register</a></li>
+          <li>Edrychwch ar restr o gynlluniau sydd heb eu hawrdudodi ac unigolion i’w hosgoi <a href="https://www.fca.org.uk/scamsmart/warning-list/search">www.fca.org.uk/scamsmart/warning-list/search</a></li>
+          <li>Gwybodaeth ddefnyddiol ar sgamiau</li>
         </ul>
       </td>
     </tr>
@@ -137,24 +137,24 @@ Pension Wise consider these organisations to be trusted sources of additional in
       <td>
         <strong>GOV.UK</strong><br>
         <a href="https://www.gov.uk">www.gov.uk</a><br>
-        <a href="https://www.gov.uk/check-state-pension">www.gov.uk/check-state-pension</a><br>
-        <a href="https://www.gov.uk/find-pension-contact-details">www.gov.uk/find-pension-contact-details</a><br>
+        <a href="https://www.gov.uk/gwirio-eich-pensiwn-y-wladwriaeth">www.gov.uk/gwirio-eich-pensiwn-y-wladwriaeth</a><br>
+        <a href="https://www.gov.uk/dod-o-hyd-i-fanylion-cyswllt-pensiwn">www.gov.uk/dod-o-hyd-i-fanylion-cyswllt-pensiwn</a><br>
         <a href="https://www.gov.uk/state-pension-age">www.gov.uk/state-pension-age</a><br>
-        Phone:<br>
-        0800 731 0175 (Future Pension Centre)<br>
-        0800 731 0193 (Pension Tracing Service)
+        Ffôn:<br>
+        0800 731 0175 (Canolfan Pensiwn y Dyfodol)<br>
+        0800 731 0193 (Gwasanaeth Olrhain Pensiwn)
       </td>
       <td>
         <ul>
-          <li>Working, jobs and pensions eg State Pension, Tracing a pension</li>
-          <li>Tax credits</li>
-          <li>Births, deaths, marriages</li>
-          <li>Divorce</li>
-          <li>Lasting Power of Attorney</li>
-          <li>Employment & Self-employment</li>
-          <li>Disabled people</li>
-          <li>Housing and local services</li>
-          <li>Money and tax</li>
+          <li>Gwaith, swyddi a phensiynau ee Pensiwn y Wladwriaeth, Olrhain pensiwn </li>
+          <li>Credydau Treth</li>
+          <li>Genedigaethau, marwolaethau, priodasau </li>
+          <li>Ysgariad</li>
+          <li>Pwer Atwrnai Parhaus</li>
+          <li>Cyflogseth a Hunangyflogaeth</li>
+          <li>Pobl anabl</li>
+          <li>Tai a gwasanaethau lleol</li>
+          <li>Arian a threth</li>
         </ul>
       </td>
     </tr>
@@ -162,40 +162,40 @@ Pension Wise consider these organisations to be trusted sources of additional in
       <td>
         <strong>MIND</strong><br>
         <a href="https://www.mind.org.uk">www.mind.org.uk</a><br>
-        Phone: 0300 123 3393
+        Ffôn: 0300 123 3393
       </td>
       <td>
         <ul>
-          <li>Types of mental health problems</li>
-          <li>Where to get help</li>
-          <li>Medication and alternative treatments</li>
-          <li>Advocacy</li>
+          <li>Mathau o broblemau iechyd meddwl</li>
+          <li>Ble i gael help</li>
+          <li>Meddyginiaeth a thriniaethau amgen</li>
+          <li>Eiriolaeth</li>
         </ul>
       </td>
     </tr>
     <tr>
       <td>
-        <strong>Samaritans</strong><br>
+        <strong>Samariaid</strong><br>
         <a href="https://www.samaritans.org">www.samaritans.org</a><br>
-        Phone: 116 123<br>
-        Email: <a href="mailto:jo@samaritans.org">jo@samaritans.org</a>
+        Ffôn: 116 123<br>
+        E-bost: <a href="mailto:jo@samaritans.org">jo@samaritans.org</a>
       </td>
       <td>
-        Samaritans offer a safe place for people to talk any time they like, in their own way – about whatever’s getting to them. They don’t have to be suicidal
+        Mae’r Samariaid yn cynnig man diogel i bobl seared unrhyw bryd maent eisiau, yn eu ffordd eu hunain – am beth bynnag sy’n eu peoni. Ni does yn rhaid iddynt fod yn teimlo fel lladd eu hunain
       </td>
     </tr>
     <tr>
       <td>
-        <strong>Alzheimers Society</strong><br>
+        <strong>Cymdeithas Alzheimers</strong><br>
         <a href="https://www.alzheimers.org.uk">www.alzheimers.org.uk</a><br>
-        Phone: 0330 333 0804
+        Ffôn: 0330 333 0804
       </td>
       <td>
         <ul>
-          <li>Daily living</li>
-          <li>Help with Care</li>
-          <li>Staying Independent</li>
-          <li>Legal and Financial</li>
+          <li>Bywyd bob dydd</li>
+          <li>Help gyda Gofal</li>
+          <li>Aros yn Annibynnol Independent</li>
+          <li>Cyfreithiol ac Ariannol </li>
         </ul>
       </td>
     </tr>

--- a/content/trusted_sources.cy.md
+++ b/content/trusted_sources.cy.md
@@ -1,0 +1,203 @@
+# Trusted sources of additional information
+
+Pension Wise consider these organisations to be trusted sources of additional information:
+
+<table class="options-table">
+  <thead>
+    <tr>
+      <th scope="col">Organisation</th>
+      <th scope="col">Query</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <strong>The Pensions Advisory Service</strong><br>
+        <a href="https://pensionsadvisoryservice.org.uk">pensionsadvisoryservice.org.uk</a><br>
+        Phone: 0800 011 3797
+      </td>
+      <td>
+        For general pension queries and complaints, including help avoiding pension scams and saving into a pension scheme
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <strong>Citizens Advice</strong><br>
+        England & Wales<br>
+        <a href="https://www.citizensadvice.org.uk">www.citizensadvice.org.uk</a><br>
+        Phone:<br>
+        03444 111 444 (England)<br>
+        03444 77 20 20 (Wales)<br><br>
+
+        Scotland<br>
+        <a href="https://www.cas.org.uk">www.cas.org.uk</a><br>
+        Contact local bureau
+      </td>
+      <td>
+        <ul>
+          <li>Debt</li>
+          <li>Social Care</li>
+          <li>State Benefits</li>
+          <li>Employment rights</li>
+          <li>Consumer rights</li>
+          <li>Relationships</li>
+          <li>Housing</li>
+          <li>Discrimination</li>
+          <li>Tax</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <strong>Money Advice Service</strong><br>
+        <a href="https://www.moneyadviceservice.org.uk">www.moneyadviceservice.org.uk</a><br>
+        Phone: 0800 138 7777
+      </td>
+      <td>
+        <ul>
+        <li>Annuity Comparison Tool <a href="https://comparison.moneyadviceservice.org.uk">comparison.moneyadviceservice.org.uk</a></li>
+        <li>Retirement adviser directory <a href="https://directory.moneyadviceservice.org.uk">directory.moneyadviceservice.org.uk</a></li>
+        <li>Understand and compare Income Drawdown <a href="https://www.moneyadviceservice.org.uk/en/retirement-income-options/income-drawdown">www.moneyadviceservice.org.uk/en/retirement-income-options/income-drawdown</a></li>
+        <li>Debt and borrowing</li>
+        <li>Budgeting and managing money</li>
+        <li>Saving and investing</li>
+        <li>Pensions and retirement</li>
+        <li>Work and redundancy</li>
+        <li>Benefits</li>
+        <li>Births, deaths and family</li>
+        <li>Insurance</li>
+        <li>Homes and mortgages</li>
+        <li>Care and disability</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <strong>Pension Ombudsman</strong><br>
+        <a href="https://www.pensions-ombudsman.org.uk">www.pensions-ombudsman.org.uk</a><br>
+        Phone: 0800 917 4487
+      </td>
+      <td>
+        Complaints about the maladministration of pensions
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <strong>Financial Ombudsman</strong><br>
+        <a href="https://www.financial-ombudsman.org.uk">www.financial-ombudsman.org.uk</a><br>
+        Phone: 0800 023 4567
+      </td>
+      <td>
+        Complaints about the sales and marketing of pensions
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <strong>Action Fraud</strong><br>
+        <a href="https://www.actionfraud.police.uk">www.actionfraud.police.uk</a><br>
+        Phone: 0300 123 2040
+      </td>
+      <td>
+        For information on scams or to report a scam
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <strong>HM Revenue and Customs</strong><br>
+        <a href="https://www.gov.uk/contact-hmrc">www.gov.uk/contact-hmrc</a><br>
+        Phone: 0300 200 3300
+      </td>
+      <td>
+        <ul>
+          <li>Self Assessment</li>
+          <li>Tax credits</li>
+          <li>Child Benefit</li>
+          <li>Income Tax</li>
+          <li>National Insurance</li>
+          <li>Tax for employers</li>
+          <li>VAT</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <strong>Financial Conduct Authority (FCA)</strong><br>
+        <a href="https://www.fca.org.uk">www.fca.org.uk</a><br>
+        Phone: 0800 111 6768
+      </td>
+      <td>
+        <ul>
+          <li>Check the FCA register to see if a firm or adviser is regulated <a href="https://www.fca.org.uk/register">www.fca.org.uk/register</a></li>
+          <li>Check list of unauthorised schemes and individuals to avoid <a href="https://www.fca.org.uk/scamsmart/warning-list/search">www.fca.org.uk/scamsmart/warning-list/search</a></li>
+          <li>Useful information on scams</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <strong>GOV.UK</strong><br>
+        <a href="https://www.gov.uk">www.gov.uk</a><br>
+        <a href="https://www.gov.uk/check-state-pension">www.gov.uk/check-state-pension</a><br>
+        <a href="https://www.gov.uk/find-pension-contact-details">www.gov.uk/find-pension-contact-details</a><br>
+        <a href="https://www.gov.uk/state-pension-age">www.gov.uk/state-pension-age</a><br>
+        Phone:<br>
+        0800 731 0175 (Future Pension Centre)<br>
+        0800 731 0193 (Pension Tracing Service)
+      </td>
+      <td>
+        <ul>
+          <li>Working, jobs and pensions eg State Pension, Tracing a pension</li>
+          <li>Tax credits</li>
+          <li>Births, deaths, marriages</li>
+          <li>Divorce</li>
+          <li>Lasting Power of Attorney</li>
+          <li>Employment & Self-employment</li>
+          <li>Disabled people</li>
+          <li>Housing and local services</li>
+          <li>Money and tax</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <strong>MIND</strong><br>
+        <a href="https://www.mind.org.uk">www.mind.org.uk</a><br>
+        Phone: 0300 123 3393
+      </td>
+      <td>
+        <ul>
+          <li>Types of mental health problems</li>
+          <li>Where to get help</li>
+          <li>Medication and alternative treatments</li>
+          <li>Advocacy</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <strong>Samaritans</strong><br>
+        <a href="https://www.samaritans.org">www.samaritans.org</a><br>
+        Phone: 116 123<br>
+        Email: <a href="mailto:jo@samaritans.org">jo@samaritans.org</a>
+      </td>
+      <td>
+        Samaritans offer a safe place for people to talk any time they like, in their own way – about whatever’s getting to them. They don’t have to be suicidal
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <strong>Alzheimers Society</strong><br>
+        <a href="https://www.alzheimers.org.uk">www.alzheimers.org.uk</a><br>
+        Phone: 0330 333 0804
+      </td>
+      <td>
+        <ul>
+          <li>Daily living</li>
+          <li>Help with Care</li>
+          <li>Staying Independent</li>
+          <li>Legal and Financial</li>
+        </ul>
+      </td>
+    </tr>
+  </tbody>
+</table>

--- a/content/trusted_sources.en.md
+++ b/content/trusted_sources.en.md
@@ -1,0 +1,203 @@
+# Trusted sources of additional information
+
+Pension Wise consider these organisations to be trusted sources of additional information:
+
+<table class="options-table">
+  <thead>
+    <tr>
+      <th scope="col">Organisation</th>
+      <th scope="col">Query</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <strong>The Pensions Advisory Service</strong><br>
+        <a href="https://pensionsadvisoryservice.org.uk">pensionsadvisoryservice.org.uk</a><br>
+        Phone: 0800 011 3797
+      </td>
+      <td>
+        For general pension queries and complaints, including help avoiding pension scams and saving into a pension scheme
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <strong>Citizens Advice</strong><br>
+        England & Wales<br>
+        <a href="https://www.citizensadvice.org.uk">www.citizensadvice.org.uk</a><br>
+        Phone:<br>
+        03444 111 444 (England)<br>
+        03444 77 20 20 (Wales)<br><br>
+
+        Scotland<br>
+        <a href="https://www.cas.org.uk">www.cas.org.uk</a><br>
+        Contact local bureau
+      </td>
+      <td>
+        <ul>
+          <li>Debt</li>
+          <li>Social Care</li>
+          <li>State Benefits</li>
+          <li>Employment rights</li>
+          <li>Consumer rights</li>
+          <li>Relationships</li>
+          <li>Housing</li>
+          <li>Discrimination</li>
+          <li>Tax</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <strong>Money Advice Service</strong><br>
+        <a href="https://www.moneyadviceservice.org.uk">www.moneyadviceservice.org.uk</a><br>
+        Phone: 0800 138 7777
+      </td>
+      <td>
+        <ul>
+        <li>Annuity Comparison Tool <a href="https://comparison.moneyadviceservice.org.uk">comparison.moneyadviceservice.org.uk</a></li>
+        <li>Retirement adviser directory <a href="https://directory.moneyadviceservice.org.uk">directory.moneyadviceservice.org.uk</a></li>
+        <li>Understand and compare Income Drawdown <a href="https://www.moneyadviceservice.org.uk/en/retirement-income-options/income-drawdown">www.moneyadviceservice.org.uk/en/retirement-income-options/income-drawdown</a></li>
+        <li>Debt and borrowing</li>
+        <li>Budgeting and managing money</li>
+        <li>Saving and investing</li>
+        <li>Pensions and retirement</li>
+        <li>Work and redundancy</li>
+        <li>Benefits</li>
+        <li>Births, deaths and family</li>
+        <li>Insurance</li>
+        <li>Homes and mortgages</li>
+        <li>Care and disability</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <strong>Pension Ombudsman</strong><br>
+        <a href="https://www.pensions-ombudsman.org.uk">www.pensions-ombudsman.org.uk</a><br>
+        Phone: 0800 917 4487
+      </td>
+      <td>
+        Complaints about the maladministration of pensions
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <strong>Financial Ombudsman</strong><br>
+        <a href="https://www.financial-ombudsman.org.uk">www.financial-ombudsman.org.uk</a><br>
+        Phone: 0800 023 4567
+      </td>
+      <td>
+        Complaints about the sales and marketing of pensions
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <strong>Action Fraud</strong><br>
+        <a href="https://www.actionfraud.police.uk">www.actionfraud.police.uk</a><br>
+        Phone: 0300 123 2040
+      </td>
+      <td>
+        For information on scams or to report a scam
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <strong>HM Revenue and Customs</strong><br>
+        <a href="https://www.gov.uk/contact-hmrc">www.gov.uk/contact-hmrc</a><br>
+        Phone: 0300 200 3300
+      </td>
+      <td>
+        <ul>
+          <li>Self Assessment</li>
+          <li>Tax credits</li>
+          <li>Child Benefit</li>
+          <li>Income Tax</li>
+          <li>National Insurance</li>
+          <li>Tax for employers</li>
+          <li>VAT</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <strong>Financial Conduct Authority (FCA)</strong><br>
+        <a href="https://www.fca.org.uk">www.fca.org.uk</a><br>
+        Phone: 0800 111 6768
+      </td>
+      <td>
+        <ul>
+          <li>Check the FCA register to see if a firm or adviser is regulated <a href="https://www.fca.org.uk/register">www.fca.org.uk/register</a></li>
+          <li>Check list of unauthorised schemes and individuals to avoid <a href="https://www.fca.org.uk/scamsmart/warning-list/search">www.fca.org.uk/scamsmart/warning-list/search</a></li>
+          <li>Useful information on scams</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <strong>GOV.UK</strong><br>
+        <a href="https://www.gov.uk">www.gov.uk</a><br>
+        <a href="https://www.gov.uk/check-state-pension">www.gov.uk/check-state-pension</a><br>
+        <a href="https://www.gov.uk/find-pension-contact-details">www.gov.uk/find-pension-contact-details</a><br>
+        <a href="https://www.gov.uk/state-pension-age">www.gov.uk/state-pension-age</a><br>
+        Phone:<br>
+        0800 731 0175 (Future Pension Centre)<br>
+        0800 731 0193 (Pension Tracing Service)
+      </td>
+      <td>
+        <ul>
+          <li>Working, jobs and pensions eg State Pension, Tracing a pension</li>
+          <li>Tax credits</li>
+          <li>Births, deaths, marriages</li>
+          <li>Divorce</li>
+          <li>Lasting Power of Attorney</li>
+          <li>Employment & Self-employment</li>
+          <li>Disabled people</li>
+          <li>Housing and local services</li>
+          <li>Money and tax</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <strong>MIND</strong><br>
+        <a href="https://www.mind.org.uk">www.mind.org.uk</a><br>
+        Phone: 0300 123 3393
+      </td>
+      <td>
+        <ul>
+          <li>Types of mental health problems</li>
+          <li>Where to get help</li>
+          <li>Medication and alternative treatments</li>
+          <li>Advocacy</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <strong>Samaritans</strong><br>
+        <a href="https://www.samaritans.org">www.samaritans.org</a><br>
+        Phone: 116 123<br>
+        Email: <a href="mailto:jo@samaritans.org">jo@samaritans.org</a>
+      </td>
+      <td>
+        Samaritans offer a safe place for people to talk any time they like, in their own way – about whatever’s getting to them. They don’t have to be suicidal
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <strong>Alzheimers Society</strong><br>
+        <a href="https://www.alzheimers.org.uk">www.alzheimers.org.uk</a><br>
+        Phone: 0330 333 0804
+      </td>
+      <td>
+        <ul>
+          <li>Daily living</li>
+          <li>Help with Care</li>
+          <li>Staying Independent</li>
+          <li>Legal and Financial</li>
+        </ul>
+      </td>
+    </tr>
+  </tbody>
+</table>


### PR DESCRIPTION
The printed/download version will show in full while the web version
will link to the newly introduced 'Trusted sources' page. This was
deemed necessary otherwise the final pension summary step is overloaded
with the full trusted sources content.