### PR TITLE
Disable mailgun validations at will

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -16,6 +16,8 @@ module ApplicationHelper
   end
 
   def email_validation_data_attributes
+    return '' if ENV['DISABLE_MAILGUN_VALIDATION']
+
     {
       'email-validation': true,
       api_key: ENV.fetch('MAILGUN_VALIDATION_KEY') { 'pubkey-b37c931b1fcef90bf2d83b7cdfd6df39' },


### PR DESCRIPTION
Due to the fact we sometimes hit the limit for mailgun validation API
requests and their inability to allow us to purchase more, since the
service was provisioned via heroku - we needed a way to quickly disable
customer-facing validations if necessary.

The presence of the `DISABLE_MAILGUN_VALIDATION` environment variable
will disable customer validations. Unsetting the variable will switch
them back on.