### PR TITLE
Add webchat link to booking journeys

### DIFF
--- a/app/views/booking_requests/step_two.html.erb
+++ b/app/views/booking_requests/step_two.html.erb
@@ -171,6 +171,7 @@
             <% end %>
           </div>
         </fieldset>
+        <p><%= render partial: 'components/webchat' %></p>
       </div>
 
       <div class="form-group <%= 'form-group-error' if @booking_request.errors.include?(:accessibility_requirements) %>">

--- a/app/views/telephone_appointments/_step_3.html.erb
+++ b/app/views/telephone_appointments/_step_3.html.erb
@@ -149,6 +149,7 @@
         <%= f.label :dc_pot_confirmed, value: 'not-sure' do %>Not sure<% end %>
       </div>
     </fieldset>
+    <p><%= render partial: 'components/webchat' %></p>
   </div>
 
   <div class="form-group <%= 'form-group-error' if @telephone_appointment.errors.include?(:where_you_heard) %>">


### PR DESCRIPTION
Adds the webchat link for pension type information, underneath the DC
pot question.