### PR TITLE
Disable full confirmation for bookings temporarily

### DIFF
--- a/app/views/booking_requests/completed.html.erb
+++ b/app/views/booking_requests/completed.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:page_title, t('service.title', page_title: 'We’ve received your request')) %>
 
-<%= confirmation(@booking_request) %>
+<%= render partial: 'booking_request_confirmation' %>
 
 <script>
   window.dataLayer = window.dataLayer || [];

--- a/features/customer_booking_request.feature
+++ b/features/customer_booking_request.feature
@@ -26,7 +26,7 @@ Scenario: Customer makes a realtime online appointment
   And I pass the basic eligibility requirements
   Then I see my one chosen slot
   When I submit my completed Booking Request
-  Then my appointment is confirmed
+  Then my Booking Request is confirmed
 
 @javascript @booking_locations @time_travel
 Scenario: Customer makes an online Booking Request


### PR DESCRIPTION
We've seen issues with confirmations and higher than usual numbers of
duplicate bookings which appear to be related. I'll disable this
confirmation while we investigate a fix.