### PR TITLE
Ensure appointment confirmations are displayed

### DIFF
--- a/app/helpers/booking_requests_helper.rb
+++ b/app/helpers/booking_requests_helper.rb
@@ -1,6 +1,6 @@
 module BookingRequestsHelper
-  def confirmation(booking_request)
-    partial = booking_request.realtime? ? 'appointment_confirmation' : 'booking_request_confirmation'
+  def confirmation
+    partial = flash[:reference] ? 'appointment_confirmation' : 'booking_request_confirmation'
 
     render partial: partial
   end

--- a/app/lib/booking_requests/stub_api.rb
+++ b/app/lib/booking_requests/stub_api.rb
@@ -4,9 +4,6 @@ module BookingRequests
       Rails.logger.info(payload)
 
       {
-        'reference' => '1',
-        'proceeded_at' => '2018-11-21 13:00',
-        'location' => 'Hackney'
       }
     end
 

--- a/app/views/booking_requests/completed.html.erb
+++ b/app/views/booking_requests/completed.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:page_title, t('service.title', page_title: 'We’ve received your request')) %>
 
-<%= confirmation(@booking_request) %>
+<%= confirmation %>
 
 <script>
   window.dataLayer = window.dataLayer || [];

--- a/app/views/booking_requests/completed.html.erb
+++ b/app/views/booking_requests/completed.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:page_title, t('service.title', page_title: 'We’ve received your request')) %>
 
-<%= render partial: 'booking_request_confirmation' %>
+<%= confirmation(@booking_request) %>
 
 <script>
   window.dataLayer = window.dataLayer || [];

--- a/features/customer_booking_request.feature
+++ b/features/customer_booking_request.feature
@@ -26,7 +26,7 @@ Scenario: Customer makes a realtime online appointment
   And I pass the basic eligibility requirements
   Then I see my one chosen slot
   When I submit my completed Booking Request
-  Then my Booking Request is confirmed
+  Then my appointment is confirmed
 
 @javascript @booking_locations @time_travel
 Scenario: Customer makes an online Booking Request

--- a/features/customer_booking_request.feature
+++ b/features/customer_booking_request.feature
@@ -28,6 +28,21 @@ Scenario: Customer makes a realtime online appointment
   When I submit my completed Booking Request
   Then my appointment is confirmed
 
+@javascript @booking_locations @time_travel @mixed_availability
+Scenario: Customer makes a realtime online appointment
+  Given a location is enabled for online booking
+  And the date is "2018-11-01"
+  When I browse for the location "Hackney"
+  And I opt to book online
+  Then I see the location name "Hackney"
+  And I can only choose one slot
+  When I choose the first available non-realtime slot
+  And I provide my personal details
+  And I pass the basic eligibility requirements
+  Then I see my one chosen slot
+  When I submit my completed Booking Request
+  Then my Booking Request is confirmed
+
 @javascript @booking_locations @time_travel
 Scenario: Customer makes an online Booking Request
   Given a location is enabled for online booking

--- a/features/step_definitions/customer_booking_request_steps.rb
+++ b/features/step_definitions/customer_booking_request_steps.rb
@@ -10,7 +10,7 @@ Then(/^I can only choose one slot$/) do
   expect(@step_one).to have_slot_options(count: 1)
 end
 
-When(/^I choose the first available realtime slot$/) do
+When(/^I choose the first available (non-)?realtime slot$/) do |_|
   @step_one.wait_for_available_days
   @step_one.available_days.first.click
 

--- a/features/step_definitions/customer_booking_request_steps.rb
+++ b/features/step_definitions/customer_booking_request_steps.rb
@@ -7,6 +7,8 @@ Given(/^no locations are enabled for online booking$/) do
 end
 
 Then(/^I can only choose one slot$/) do
+  @step_one.wait_until_slot_options_visible
+
   expect(@step_one).to have_slot_options(count: 1)
 end
 
@@ -240,6 +242,7 @@ end
 Then(/^my chosen slots persist$/) do
   expect(@step_one).to be_displayed
 
+  @step_one.wait_until_chosen_slots_visible
   expect(@step_one).to have_chosen_slots(count: 3)
 end
 

--- a/features/support/booking_requests.rb
+++ b/features/support/booking_requests.rb
@@ -14,6 +14,32 @@ Around('@no_availability') do |_, block|
   end
 end
 
+Around('@mixed_availability') do |_, block|
+  begin
+    previous_api = BookingRequests.api
+
+    BookingRequests.api = Class.new do
+      def slots(*)
+        [
+          BookingRequests::Slot.new(date: '2018-11-06', start: '0900', end: '1300'),
+          BookingRequests::Slot.new(date: '2018-11-07', start: '0900', end: '1000'),
+          BookingRequests::Slot.new(date: '2018-11-08', start: '0900', end: '1000'),
+          BookingRequests::Slot.new(date: '2018-11-09', start: '0900', end: '1000'),
+          BookingRequests::Slot.new(date: '2018-11-10', start: '0900', end: '1000')
+        ]
+      end
+
+      def create(*)
+        {}
+      end
+    end.new
+
+    block.call
+  ensure
+    BookingRequests.api = previous_api
+  end
+end
+
 Around('@realtime_availability') do |_, block|
   begin
     previous_api = BookingRequests.api


### PR DESCRIPTION
Previously we were checking an incorrect predicate to determine whether the
booking was automatically fulfilled in realtime or not. Also, this was
fragile when a customer returned to the confirmation page by refresh and
the required `flash` data was no longer present. This approach ensures
bookings and appointments are displayed correctly without error.