### PR TITLE
Add additional campaign landing pages

### DIFF
--- a/app/controllers/marketing_controller.rb
+++ b/app/controllers/marketing_controller.rb
@@ -8,6 +8,7 @@ class MarketingController < ApplicationController
   end
   alias facebook landing
   alias about landing
+  alias campaign landing
 
   def footer?
     false

--- a/app/helpers/marketing_helper.rb
+++ b/app/helpers/marketing_helper.rb
@@ -43,6 +43,19 @@ module MarketingHelper
     end
   end
 
+  def campaign_phone_number
+    case params[:platform]
+    when 'facebook'
+      '0800 138 1586'
+    when 'google'
+      '0800 138 8293'
+    when 'linkedin'
+      '0800 138 1582'
+    else
+      '0800 138 3375'
+    end
+  end
+
   private
 
   def campaign_date_override?

--- a/app/views/marketing/index.html.erb
+++ b/app/views/marketing/index.html.erb
@@ -38,7 +38,7 @@
                 <p>Pension Wise is free and impartial – we don’t recommend products or companies and won’t tell you how to invest your money.</p>
                 <p class="marketing-book">
                   <%= link_to 'Book now', guide_path('appointments'), class: :button %>
-                  <span class="marketing-promo__call">or phone <span class="marketing-promo__number">0800 138 3375</span></span>
+                  <span class="marketing-promo__call">or phone <span class="marketing-promo__number"><%= campaign_phone_number %></span></span>
                 </p>
               </div>
               <div class="youtube-video">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,10 @@ Rails.application.routes.draw do
       get 'facebook-landing', to: 'marketing#facebook'
       get 'about', to: 'marketing#about'
 
+      constraints platform: /linkedin|google|facebook/, campaign: /apples|dogs|paint|peppers/ do
+        get ':platform-:campaign', to: 'marketing#campaign', as: :marketing_campaign
+      end
+
       scope 'explore-your-options', controller: 'pension_summaries', as: :explore_your_options do
         root action: 'start'
 

--- a/spec/helpers/marketing_helper_spec.rb
+++ b/spec/helpers/marketing_helper_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe MarketingHelper, type: :helper do
-  describe '#banner_image' do
+  describe '#current_campaign' do
     subject { helper.current_campaign(today) }
 
     shared_examples_for 'landing page aliases' do
@@ -117,6 +117,66 @@ RSpec.describe MarketingHelper, type: :helper do
         end
 
         include_examples 'landing page aliases'
+      end
+    end
+
+    %w(apples dogs paint peppers).each do |param|
+      context "when the :campaign param is set to '#{param}'" do
+        before do
+          helper.params[:campaign] = param
+        end
+
+        it 'returns the correct campaign' do
+          expect(helper.current_campaign).to eq(param)
+        end
+      end
+    end
+  end
+
+  describe '#campaign_phone_number' do
+    context 'when there is no :platform param set' do
+      it 'defaults to 0800 138 3375' do
+        expect(helper.campaign_phone_number).to eq('0800 138 3375')
+      end
+    end
+
+    context 'when :platform is set to facebook' do
+      before do
+        helper.params[:platform] = 'facebook'
+      end
+
+      it 'returns 0800 138 1586' do
+        expect(helper.campaign_phone_number).to eq('0800 138 1586')
+      end
+    end
+
+    context 'when :platform is set to google' do
+      before do
+        helper.params[:platform] = 'google'
+      end
+
+      it 'returns 0800 138 1586' do
+        expect(helper.campaign_phone_number).to eq('0800 138 8293')
+      end
+    end
+
+    context 'when :platform is set to linkedin' do
+      before do
+        helper.params[:platform] = 'linkedin'
+      end
+
+      it 'returns 0800 138 1582' do
+        expect(helper.campaign_phone_number).to eq('0800 138 1582')
+      end
+    end
+
+    context 'when :platform is set to an unknown value' do
+      before do
+        helper.params[:platform] = 'unknown'
+      end
+
+      it 'returns 0800 138 3375' do
+        expect(helper.campaign_phone_number).to eq('0800 138 3375')
       end
     end
   end


### PR DESCRIPTION
These are platform and campaign specific so that there's no need to use a schedule and different campaigns can run at the same time.