### PR TITLE
Improve wording for submit button

### DIFF
--- a/app/views/booking_requests/step_two.html.erb
+++ b/app/views/booking_requests/step_two.html.erb
@@ -232,7 +232,7 @@
       </div>
 
       <div class="form-group">
-        <%= f.submit 'Submit booking request', class: 'button t-submit', data: { disable_with: 'Please wait...' } %>
+        <%= f.submit 'Book appointment', class: 'button t-submit', data: { disable_with: 'Please wait...' } %>
       </div>
 
       <div role="note" aria-label="Information" class="application-notice info-notice">


### PR DESCRIPTION
This should not refer to booking requests now all locations are realtime
enabled and result in actual appointments.