### PR TITLE
Improve wording for realtime

### DIFF
--- a/app/views/booking_requests/step_two.html.erb
+++ b/app/views/booking_requests/step_two.html.erb
@@ -191,7 +191,7 @@
         <%= f.label :additional_info, class: 'form-label-bold' do %>
           Additional information
           <span class="form-hint">
-            eg any times you’re not available, accessibility adjustments
+            eg accessibility adjustments
           </span>
         <% end %>
         <%= f.text_area :additional_info, class: 'form-control form-control-3-4 js-character-limit-input', rows: 5, maxlength: 160, data: { maxlength: 160 } %>


### PR DESCRIPTION
We don't need to ask the customer to specify unavailable times since
they're booking a realtime appointment now.