### PR TITLE
Don't fudge a prefix for employers

### DIFF
--- a/app/controllers/employer/locations_controller.rb
+++ b/app/controllers/employer/locations_controller.rb
@@ -7,7 +7,7 @@ module Employer
     def index
       expires_in Rails.application.config.cache_max_age, public: true
 
-      @locations_by_letter = locations.group_by(&:name_index)
+      @locations_by_letter = locations.group_by(&:name)
       @locations_total     = locations.count
     end
 

--- a/app/lib/employer/location.rb
+++ b/app/lib/employer/location.rb
@@ -1,9 +1,5 @@
 module Employer
   class Location < OpenStruct
-    def name_index
-      name.to_s.sub(/^Tesco /i, '').first
-    end
-
     def address
       [
         address_line_one,


### PR DESCRIPTION
Previous to the employer planner changes we had to trim the 'Tesco'
identifier from a location. We now refer to this information via the
associated 'employer' so this is no longer necessary.