### PR TITLE
Improve 'unavailability' message

### DIFF
--- a/app/views/employer/locations/show.html.erb
+++ b/app/views/employer/locations/show.html.erb
@@ -23,7 +23,7 @@
         <i class="icon icon-information">
           <span class="visually-hidden">Info</span>
         </i>
-        <strong class="small">This location is fully booked</strong>
+        <strong class="small">Please check back for appointment availability.</strong>
       </div>
     <% end %>
   </div>


### PR DESCRIPTION
This could be misleading when a location is enabled prior to available
slots being added.