### PR TITLE
Ensure configuration values are integers

### DIFF
--- a/app/lib/telephone_appointments_api.rb
+++ b/app/lib/telephone_appointments_api.rb
@@ -35,15 +35,15 @@ class TelephoneAppointmentsApi
   end
 
   def open_timeout
-    ENV.fetch('TAP_APPOINTMENTS_API_OPEN_TIMEOUT', 2)
+    ENV.fetch('TAP_APPOINTMENTS_API_OPEN_TIMEOUT', 2).to_i
   end
 
   def read_timeout
-    ENV.fetch('TAP_APPOINTMENTS_API_READ_TIMEOUT', 2)
+    ENV.fetch('TAP_APPOINTMENTS_API_READ_TIMEOUT', 2).to_i
   end
 
   def retries
-    ENV.fetch('TAP_APPOINTMENTS_API_RETRIES', 0)
+    ENV.fetch('TAP_APPOINTMENTS_API_RETRIES', 0).to_i
   end
 
   def api_uri


### PR DESCRIPTION
When these values are set they were not converted to integers and were
causing issues further along. This change ensures they are always
converted to integers regardless whether they're defaulted or come from
the configured environment variables.