### PR TITLE
Add an explicit accessibility option for phone

### DIFF
--- a/app/controllers/telephone_appointments_controller.rb
+++ b/app/controllers/telephone_appointments_controller.rb
@@ -106,7 +106,9 @@ class TelephoneAppointmentsController < ApplicationController
         :date_of_birth_year,
         :date_of_birth_month,
         :date_of_birth_day,
-        :gdpr_consent
+        :gdpr_consent,
+        :accessibility_requirements,
+        :notes
       )
   end
 

--- a/app/models/telephone_appointment.rb
+++ b/app/models/telephone_appointment.rb
@@ -18,7 +18,9 @@ class TelephoneAppointment
     :date_of_birth_year,
     :date_of_birth_month,
     :date_of_birth_day,
-    :gdpr_consent
+    :gdpr_consent,
+    :accessibility_requirements,
+    :notes
   )
 
   validates :start_at, presence: true
@@ -30,6 +32,8 @@ class TelephoneAppointment
   validates :date_of_birth, presence: true
   validates :dc_pot_confirmed, inclusion: { in: %w(yes no not-sure) }
   validates :where_you_heard, inclusion: { in: WhereYouHeard::OPTIONS.keys }
+  validates :notes, length: { maximum: 160 }, allow_blank: true
+  validates :accessibility_requirements, inclusion: { in: %w(0 1) }
 
   def advance!
     self.step += 1
@@ -60,7 +64,9 @@ class TelephoneAppointment
       date_of_birth: date_of_birth,
       dc_pot_confirmed: dc_pot_confirmed == 'yes',
       where_you_heard: where_you_heard,
-      gdpr_consent: gdpr_consent
+      gdpr_consent: gdpr_consent,
+      accessibility_requirements: accessibility_requirements,
+      notes: notes
     }
   end
 

--- a/app/views/telephone_appointments/_hidden_fields.html.erb
+++ b/app/views/telephone_appointments/_hidden_fields.html.erb
@@ -10,3 +10,6 @@
 <%= f.hidden_field :selected_date, id: "#{id_prefix}_selected_date" %>
 <%= f.hidden_field :where_you_heard, id: "#{id_prefix}_where_you_heard" %>
 <%= f.hidden_field :gdpr_consent, id: "#{id_prefix}_gdpr_consent" %>
+<%= f.hidden_field :accessibility_requirements, id: "#{id_prefix}_accessibility_requirements" %>
+<%= f.hidden_field :notes, id: "#{id_prefix}_notes" %>
+<%= f.hidden_field :gdpr_consent, id: "#{id_prefix}_gdpr_consent" %>

--- a/app/views/telephone_appointments/_step_3.html.erb
+++ b/app/views/telephone_appointments/_step_3.html.erb
@@ -152,6 +152,29 @@
     <p><%= render partial: 'components/webchat' %></p>
   </div>
 
+  <div class="form-group <%= 'form-group-error' if @telephone_appointment.errors.include?(:accessibility_requirements) %>">
+    <div class="multiple-choice">
+      <%= f.check_box :accessibility_requirements, class: 't-accessibility-requirements' %>
+      <%= f.label :accessibility_requirements do %>
+        <% if @telephone_appointment.errors.include?(:accessibility_requirements) %>
+          <span class="error-message"><%= @telephone_appointment.errors[:accessibility_requirements].to_sentence.capitalize %></span>
+        <% end %>
+        I require help or an adjustment to help me access my appointment
+        <span class="form-hint" id="accessibility-hint">We may contact you for details of your specific needs</span>
+      <% end %>
+    </div>
+  </div>
+
+  <div class="form-group" data-character-limit>
+    <%= f.label :notes, class: 'form-label-bold' do %>
+      Additional information
+      <span class="form-hint">
+        eg accessibility adjustments
+      </span>
+    <% end %>
+    <%= f.text_area :notes, class: 't-additional-info form-control form-control-3-4 js-character-limit-input', rows: 5, maxlength: 160, data: { maxlength: 160 } %>
+  </div>
+
   <div class="form-group <%= 'form-group-error' if @telephone_appointment.errors.include?(:where_you_heard) %>">
     <%= f.label :where_you_heard, 'Where did you first hear of Pension Wise?', class: 'form-label-bold' %>
     <% if @telephone_appointment.errors.include?(:where_you_heard) %>

--- a/features/pages/new_telephone_appointment.rb
+++ b/features/pages/new_telephone_appointment.rb
@@ -13,6 +13,8 @@ module Pages
     element :memorable_word, '.t-memorable-word'
     element :choose_other_time_message, '.t-choose-other-time-message'
     element :where_you_heard, '.t-where-you-heard'
+    element :accessibility_requirements, '.t-accessibility-requirements'
+    element :additional_info, '.t-additional-info'
 
     element :dc_pot_confirmed_yes, '.t-dc-pot-confirmed-yes'
     element :dc_pot_confirmed_no, '.t-dc-pot-confirmed-no'

--- a/features/step_definitions/telephone_booking_request_steps.rb
+++ b/features/step_definitions/telephone_booking_request_steps.rb
@@ -94,6 +94,7 @@ Given(/^they do not have a DC pot$/) do
   @page.dc_pot_confirmed_no.set(true)
   @page.where_you_heard.select('Other')
   @page.gdpr_consent_yes.set(true)
+  @page.accessibility_requirements.set(true)
 
   @page.submit.click
 end
@@ -117,6 +118,7 @@ Given(/^they are below the minimum age$/) do
   @page.dc_pot_confirmed_yes.set(true)
   @page.where_you_heard.select('Other')
   @page.gdpr_consent_yes.set(true)
+  @page.accessibility_requirements.set(true)
 
   @page.submit.click
 end
@@ -137,6 +139,7 @@ Given(/^they are eligible for an appointment$/) do
   @page.dc_pot_confirmed_yes.set(true)
   @page.gdpr_consent_yes.set(true)
   @page.where_you_heard.select('Other')
+  @page.accessibility_requirements.set(true)
 
   @page.submit.click
 end
@@ -151,6 +154,7 @@ Then(/^their appointment is created$/) do
   expect(@created_telephone_appointment.date_of_birth).to eq DateTime.new(1920, 10, 23).in_time_zone
   expect(@created_telephone_appointment.gdpr_consent).to eq 'yes'
   expect(@created_telephone_appointment.where_you_heard).to eq '17'
+  expect(@created_telephone_appointment.accessibility_requirements).to eq '1'
 end
 
 Then(/^they see a confirmation of their appointment$/) do
@@ -176,6 +180,7 @@ When(/^the slot becomes unavailable while they are filling in their details$/) d
   @page.dc_pot_confirmed_yes.set(true)
   @page.where_you_heard.select('Other')
   @page.gdpr_consent_yes.set(true)
+  @page.accessibility_requirements.set(true)
 
   @page.submit.click
 end

--- a/spec/models/telephone_appointment_spec.rb
+++ b/spec/models/telephone_appointment_spec.rb
@@ -12,7 +12,9 @@ RSpec.describe TelephoneAppointment, type: :model do
       date_of_birth_day: '01',
       dc_pot_confirmed: 'yes',
       where_you_heard: '1',
-      gdpr_consent: 'yes'
+      gdpr_consent: 'yes',
+      accessibility_requirements: '1',
+      notes: 'meh'
     )
   end
 


### PR DESCRIPTION
Gives customers the ability to explicitly specify accessibility
requirements when placing an appointment.