### PR TITLE
Don't skip CSRF for feedback

### DIFF
--- a/app/controllers/feedbacks_controller.rb
+++ b/app/controllers/feedbacks_controller.rb
@@ -1,5 +1,4 @@
 class FeedbacksController < ApplicationController
-  skip_before_action :verify_authenticity_token
   layout 'full_width'
 
   def new

--- a/app/views/feedbacks/_feedback_link.html.erb
+++ b/app/views/feedbacks/_feedback_link.html.erb
@@ -1,0 +1,1 @@
+<a href="/en/feedback/new?feedback[feedback_type]=pension_type_tool" target="_blank">Is there anything wrong with this page?</a>

--- a/config/initializers/govspeak.rb
+++ b/config/initializers/govspeak.rb
@@ -32,15 +32,8 @@ Govspeak::Document.extension('multi-choice-questions', regexp) do |partial_name,
   )
 end
 
-Govspeak::Document.extension('feedback', %r(^{::feedback_form /})) do
-  partial = 'feedbacks/feedback_form'
-
-  feedback = FeedbackForm.new(feedback_type: 'pension_type_tool')
-
-  ApplicationController.render(
-    partial: partial,
-    assigns: { feedback: feedback }
-  )
+Govspeak::Document.extension('feedback', %r(^{::feedback_link /})) do
+  ApplicationController.render(partial: 'feedbacks/feedback_link')
 end
 
 Govspeak::Document.extension('webchat', %r(^{::webchat /})) do

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -131,6 +131,15 @@ cy:
         wrong_length: gyda maint anghywir o lythrennau (dylai fod yn %{count} llythyren)
 
       models:
+        feedback_form:
+          attributes:
+            name:
+              blank: enter a name
+            email:
+              invalid: enter a valid email address
+              invalid_email: enter a valid email address
+            message:
+              blank: enter a message
         welsh_language/booking_request:
           attributes:
             date_of_birth:
@@ -254,15 +263,6 @@ cy:
               blank: enter a name
             email_address:
               invalid_email: enter a valid email address
-        feedback_form:
-          attributes:
-            name:
-              blank: enter a name
-            email:
-              invalid: enter a valid email address
-              invalid_email: enter a valid email address
-            message:
-              blank: enter a message
         pension_summary:
           attributes:
             consent_given:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -104,6 +104,15 @@ en:
   activemodel:
     errors:
       models:
+        feedback_form:
+          attributes:
+            name:
+              blank: enter a name
+            email:
+              invalid: enter a valid email address
+              invalid_email: enter a valid email address
+            message:
+              blank: enter a message
         booking_request_form:
           attributes:
             first_name:
@@ -213,15 +222,6 @@ en:
           attributes:
             email_address:
               invalid_email: enter a valid email address
-        feedback_form:
-          attributes:
-            name:
-              blank: enter a name
-            email:
-              invalid: enter a valid email address
-              invalid_email: enter a valid email address
-            message:
-              blank: enter a message
         pension_summary:
           attributes:
             consent_given:

--- a/content/pension_type_tool.cy.md
+++ b/content/pension_type_tool.cy.md
@@ -18,4 +18,4 @@ Os oes gennych bensiwn cyfraniadau wedi’u diffinio (personol neu gweithle) ryd
 
 [Dechrau nawr](/cy/pension-type-tool/question-1){: .button}
 
-{::feedback_form /}
+{::feedback_link /}

--- a/content/pension_type_tool.en.md
+++ b/content/pension_type_tool.en.md
@@ -18,4 +18,4 @@ If you have a defined contribution (personal or workplace) pension you choose ho
 [Start now](/en/pension-type-tool/question-1){: .button .button-start}
 {::webchat /}
 
-{::feedback_form /}
+{::feedback_link /}

--- a/content/pension_type_tool/question_1.cy.md
+++ b/content/pension_type_tool/question_1.cy.md
@@ -14,4 +14,4 @@ tags:
 ## Ydy eich pensiwn wedi cael ei sefydlu gan eich cyflogwr?
 {:/yes-no-dont-know-question}
 
-{::feedback_form /}
+{::feedback_link /}

--- a/content/pension_type_tool/question_1.en.md
+++ b/content/pension_type_tool/question_1.en.md
@@ -15,4 +15,4 @@ tags:
 {:/yes-no-dont-know-question}
 
 {::webchat /}
-{::feedback_form /}
+{::feedback_link /}

--- a/content/pension_type_tool/question_2.cy.md
+++ b/content/pension_type_tool/question_2.cy.md
@@ -22,4 +22,4 @@ tags:
 * unrhyw gyflogwr sector gyhoeddus arall, ee gwasanaethau cymdeithasol
 {:/yes-no-dont-know-question}
 
-{::feedback_form /}
+{::feedback_link /}

--- a/content/pension_type_tool/question_2.en.md
+++ b/content/pension_type_tool/question_2.en.md
@@ -23,4 +23,4 @@ tags:
 {:/yes-no-dont-know-question}
 
 {::webchat /}
-{::feedback_form /}
+{::feedback_link /}

--- a/content/pension_type_tool/question_3.cy.md
+++ b/content/pension_type_tool/question_3.cy.md
@@ -46,4 +46,4 @@ tags:
 ^Efallai bod rhai o’r cwmniau hyn wedi cael enwau gwahanol yn y gorffenol neu wedi uno â chwmniau eraill, ee roedd Aviva yn arfer bod yn Norwich Union.^
 {:/yes-no-dont-know-question}
 
-{::feedback_form /}
+{::feedback_link /}

--- a/content/pension_type_tool/question_3.en.md
+++ b/content/pension_type_tool/question_3.en.md
@@ -47,4 +47,4 @@ tags:
 {:/yes-no-dont-know-question}
 
 {::webchat /}
-{::feedback_form /}
+{::feedback_link /}

--- a/content/pension_type_tool/question_4.cy.md
+++ b/content/pension_type_tool/question_4.cy.md
@@ -16,4 +16,4 @@ tags:
 
 {:/pension-start-year-question}
 
-{::feedback_form /}
+{::feedback_link /}

--- a/content/pension_type_tool/question_4.en.md
+++ b/content/pension_type_tool/question_4.en.md
@@ -17,4 +17,4 @@ tags:
 {:/pension-start-year-question}
 
 {::webchat /}
-{::feedback_form /}
+{::feedback_link /}

--- a/spec/features/feedback_spec.rb
+++ b/spec/features/feedback_spec.rb
@@ -9,25 +9,4 @@ RSpec.feature 'Customer feedback', js: true do
     expect(page).to have_content('Feedback')
     expect(page).to have_content('Message')
   end
-
-  scenario 'can be left on the pension type tool' do
-    begin
-      allow_forgery_protection = FeedbacksController.allow_forgery_protection
-      FeedbacksController.allow_forgery_protection = true
-
-      visit '/pension-type-tool'
-
-      click_on 'Is there anything wrong with this page?'
-
-      fill_in 'Name', with: 'Jim Bob'
-      fill_in 'Email', with: 'jim@bob.com'
-      fill_in 'Message', with: 'Some feedback'
-
-      click_on 'Send feedback'
-
-      expect(page).to have_content('Thank you for your help')
-    ensure
-      FeedbacksController.allow_forgery_protection = allow_forgery_protection
-    end
-  end
 end

--- a/spec/features/questions_spec.rb
+++ b/spec/features/questions_spec.rb
@@ -21,11 +21,6 @@ RSpec.feature 'Questions', type: :feature do
   scenario 'can leave feedback' do
     visit '/pension-type-tool/question-1'
 
-    page.find('.t-feedback-name').set 'Jim Bob'
-    page.find('.t-feedback-email').set 'jim@bob.com'
-    page.find('.t-feedback-message').set 'Jim Bob rulez'
-    page.find('.t-feedback-submit').click
-
-    expect(page).to have_content('Thank you for your help')
+    expect(page).to have_content('Is there anything wrong with this page?')
   end
 end


### PR DESCRIPTION
This was switched off across the board for the pension type tool since this
is a hybrid journey that uses static (therefore cached and needing cookies
stripped for cloudflare) content and cannot serve a CSRF token and the
requisite cookie. It's easier just to turn what was previously the inline
form into a link to the feedback form.

This change has been made to mitigate the anonymous pen testing the site 
has suffered recently.