### PR TITLE
Handle missing employer locations

### DIFF
--- a/app/controllers/employer/locations_controller.rb
+++ b/app/controllers/employer/locations_controller.rb
@@ -4,6 +4,10 @@ module Employer
 
     before_action :set_breadcrumbs
 
+    rescue_from HTTPConnection::ResourceNotFound do
+      render 'errors/not_found', status: :not_found
+    end
+
     def index
       expires_in Rails.application.config.cache_max_age, public: true
 

--- a/spec/cassettes/Error_pages/employer_location_not_found.yml
+++ b/spec/cassettes/Error_pages/employer_location_not_found.yml
@@ -1,0 +1,97 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3008/api/v1/employers/2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - PensionWise/1.0 (birdperson.local; benlovell; 78717) ruby/2.6.5 (114; x86_64-darwin19)
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"76554681bc8a1652837bb5183ab42df1"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 861b4d47-9ccf-43a6-a889-c15886a66767
+      X-Runtime:
+      - '0.525468'
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{"name":"BSI Group","locations":[{"id":703,"name":"Hemel Hempstead","address_line_one":"Kitemark
+        House","address_line_two":"Maylands Avenue","address_line_three":"","town":"Hemel
+        Hempstead","county":"Hertfordshire","postcode":"HP2 4SQ","available":false}]}'
+    http_version: 
+  recorded_at: Wed, 05 Feb 2020 13:47:18 GMT
+- request:
+    method: get
+    uri: http://localhost:3008/api/v1/locations/1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - PensionWise/1.0 (birdperson.local; benlovell; 78717) ruby/2.6.5 (114; x86_64-darwin19)
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - fb435251-899e-4a2a-af0d-f85d4a9f075e
+      X-Runtime:
+      - '0.011751'
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 05 Feb 2020 13:47:18 GMT
+recorded_with: VCR 3.0.3

--- a/spec/features/employer_booking_spec.rb
+++ b/spec/features/employer_booking_spec.rb
@@ -5,17 +5,20 @@ require_relative '../../features/pages/employer_booking_confirmation'
 RSpec.feature 'Tesco Bookings' do
   scenario 'Placing a successful booking', js: true do
     Timecop.travel('2017-09-12 13:00') do
-      given_the_tesco_hq_location_is_configured
-      when_the_customer_attempts_a_booking
-      and_they_choose_an_available_day
-      and_they_choose_an_available_time
-      and_they_fill_in_their_personal_details
-      then_the_booking_is_placed
-      and_they_see_the_confirmation
+      given_the_tesco_hq_location_is_configured do
+        when_the_customer_attempts_a_booking
+        and_they_choose_an_available_day
+        and_they_choose_an_available_time
+        and_they_fill_in_their_personal_details
+        then_the_booking_is_placed
+        and_they_see_the_confirmation
+      end
     end
   end
 
   def given_the_tesco_hq_location_is_configured
+    previous = Employer.api
+
     Employer.api = Class.new do
       def employer(*)
         JSON.parse(IO.read('spec/fixtures/tesco_hq.json'))
@@ -30,6 +33,10 @@ RSpec.feature 'Tesco Bookings' do
         booking.room = 'Room.1'
       end
     end.new
+
+    yield
+  ensure
+    Employer.api = previous
   end
 
   def when_the_customer_attempts_a_booking

--- a/spec/features/employer_locations_spec.rb
+++ b/spec/features/employer_locations_spec.rb
@@ -13,6 +13,8 @@ RSpec.feature 'Employer locations' do
   end
 
   def given_bookable_tesco_locations_exist
+    previous = Employer.api
+
     Employer.api = Class.new do
       def employer(*)
         {
@@ -38,6 +40,8 @@ RSpec.feature 'Employer locations' do
     end.new
 
     yield
+  ensure
+    Employer.api = previous
   end
 
   def when_the_customer_visits_the_tesco_locations_page

--- a/spec/requests/error_pages_spec.rb
+++ b/spec/requests/error_pages_spec.rb
@@ -1,4 +1,11 @@
 RSpec.describe 'Error pages', type: :request do
+  specify 'employer location not found', vcr: true do
+    get '/en/employers/2/locations/1'
+
+    expect(response).to be_not_found
+    expect(response).to render_template(:not_found)
+  end
+
   specify 'location not found' do
     get '/en/locations/c63c56e9-2111-43cc-bb72-c58ad4053bfc/booking-request/step-one'
 


### PR DESCRIPTION
Previously this scenario would display the 'technical error' page. It
should instead be handled as a 404 with the associated 'missing content'
page displayed.