### PR TITLE
Use geo points for map pin placement

### DIFF
--- a/app/decorators/location_decorator.rb
+++ b/app/decorators/location_decorator.rb
@@ -5,6 +5,10 @@ class LocationDecorator < SimpleDelegator
     self._booking_location = booking_location
   end
 
+  def coordinates
+    lat_lng.join(',')
+  end
+
   def address_encoded
     @address_encoded ||= ERB::Util.url_encode(address.gsub("\n", ', ').squish)
   end

--- a/app/views/locations/show.html.erb
+++ b/app/views/locations/show.html.erb
@@ -35,12 +35,12 @@
   <div class="l-column-half">
     <h2 style="margin-top: 0;">Find us here:</h2>
 
-    <a href="https://maps.google.com/maps?q=<%= @location.address_encoded %>" target="_blank">
+    <a href="https://maps.google.com/maps?q=<%= @location.coordinates %>" target="_blank">
       <img
         height="450"
         alt="map showing the location of <%= @location.name %> (link opens external website in new window)"
         style="border:0; position: relative; width:100%;"
-        src="https://maps.googleapis.com/maps/api/staticmap?markers=<%= @location.address_encoded %>&center=<%= @location.address_encoded %>&size=440x330&zoom=15&scale=2&key=<%= ENV['GOOGLE_MAP_API_KEY'] %>" />
+        src="https://maps.googleapis.com/maps/api/staticmap?markers=<%= @location.coordinates %>&center=<%= @location.coordinates %>&size=440x330&zoom=15&scale=2&key=<%= ENV['GOOGLE_MAP_API_KEY'] %>" />
     </a>
   </div>
 </div>


### PR DESCRIPTION
Using the address components instead does not allow us to accurately
place pins when we've manually supplied geo coordinates. This can occur
when geocoding returns coordinates that do not directly correspond to
the actual, expected location when presented on a map.