### PR TITLE
Display location with coordinates in searches

### DIFF
--- a/app/decorators/location_search_result_decorator.rb
+++ b/app/decorators/location_search_result_decorator.rb
@@ -1,6 +1,6 @@
 class LocationSearchResultDecorator < SimpleDelegator
-  def address_encoded
-    @address_encoded ||= ERB::Util.url_encode(address.gsub("\n", ', ').squish)
+  def coordinates
+    lat_lng.join(',')
   end
 
   def distance

--- a/app/views/locations/search.html.erb
+++ b/app/views/locations/search.html.erb
@@ -24,12 +24,12 @@
         </div>
 
         <div class="l-column-third">
-          <a href="https://maps.google.com/maps?q=<%= location.address_encoded %>" target="_blank">
+          <a href="https://maps.google.com/maps?q=<%= location.coordinates %>" target="_blank">
             <img
               height="300"
               alt="map showing the location of <%= location.name %> (link opens external website in new window)"
               style="border:0; position: relative;"
-              src="https://maps.googleapis.com/maps/api/staticmap?markers=<%= location.address_encoded %>&center=<%= location.address_encoded %>&size=300x300&scale=2&zoom=15&key=<%= ENV['GOOGLE_MAP_API_KEY'] %>" />
+              src="https://maps.googleapis.com/maps/api/staticmap?markers=<%= location.coordinates %>&center=<%= location.coordinates %>&size=300x300&scale=2&zoom=15&key=<%= ENV['GOOGLE_MAP_API_KEY'] %>" />
           </a>
         </div>
       </div>

--- a/spec/decorators/location_search_result_decorator_spec.rb
+++ b/spec/decorators/location_search_result_decorator_spec.rb
@@ -1,15 +1,12 @@
 RSpec.describe LocationSearchResultDecorator do
-  let(:address) { "Street\nTown\nPostcode" }
   let(:distance) { 1.0489736864844752 }
-  let(:search_result) { double(address: address, distance: distance) }
+  let(:search_result) { double(distance: distance, lat_lng: [123, 456]) }
 
   subject(:decorator) { described_class.new(search_result) }
 
-  specify { expect(decorator.address_encoded).to eq('Street%2C%20Town%2C%20Postcode') }
   specify { expect(decorator.distance).to eq('1.05') }
 
-  context 'when address contains special characters' do
-    let(:address) { "Road & Street\nTown\nPostcode" }
-    specify { expect(decorator.address_encoded).to eq('Road%20%26%20Street%2C%20Town%2C%20Postcode') }
+  it 'returns coordinates' do
+    expect(decorator.coordinates).to eq('123,456')
   end
 end


### PR DESCRIPTION
The actual location details page was using coordinates but the search
results page was still using the encoded address to display a location
pin on a map. This change brings them up to parity.