### PR TITLE
Bump GOVUK frontend gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,10 @@ source 'https://rubygems.org' do # rubocop:disable Metrics/BlockLength
   gem 'foreman'
   gem 'gaffe'
   gem 'govspeak', '~> 3.2'
-  gem 'govuk_elements_rails'
+  gem 'govuk_elements_rails',
+      github: 'guidance-guarantee-programme/govuk_elements_rails',
+      branch: 'missing-symlinks',
+      submodules: true
   gem 'govuk_frontend_toolkit'
   gem 'govuk_template'
   gem 'humanize'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,15 @@
 GIT
+  remote: https://github.com/guidance-guarantee-programme/govuk_elements_rails.git
+  revision: cbcb572b13e50fa363d604f78ae015c0e8fec9c7
+  branch: missing-symlinks
+  submodules: true
+  specs:
+    govuk_elements_rails (3.1.3)
+      govuk_frontend_toolkit (>= 6.0.2)
+      rails (>= 4.1.0)
+      sass (>= 3.2.0)
+
+GIT
   remote: https://github.com/guidance-guarantee-programme/output-templates.git
   revision: 755f165e966585d7fd030ecffcbc6d7801fe4a21
   specs:
@@ -156,14 +167,10 @@ GEM
       kramdown (~> 1.10.0)
       nokogiri (~> 1.5)
       sanitize (~> 2.1.0)
-    govuk_elements_rails (3.0.2)
-      govuk_frontend_toolkit (>= 5.2.0)
-      rails (>= 4.1.0)
+    govuk_frontend_toolkit (9.0.0)
+      railties (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_frontend_toolkit (5.2.0)
-      rails (>= 3.1.0)
-      sass (>= 3.2.0)
-    govuk_template (0.24.1)
+    govuk_template (0.26.0)
       rails (>= 3.1)
     hashdiff (0.3.8)
     hashery (2.1.2)
@@ -210,7 +217,7 @@ GEM
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
-    mimemagic (0.3.3)
+    mimemagic (0.3.4)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.0)
@@ -252,7 +259,7 @@ GEM
       pry (~> 0.10)
     puma (4.3.3)
       nio4r (~> 2.0)
-    rack (2.0.8)
+    rack (2.2.2)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (5.2.4.1)


### PR DESCRIPTION
Bumps various frontend gems to pull in the latest changes for
accessibility and general fixes.

Pins `govuk_elements_rails` to our version that includes a fix for
missing symlinks.