### PR TITLE
Coronavirus changes for employer bookings

### DIFF
--- a/app/views/employer/bookings/_step_3.html.erb
+++ b/app/views/employer/bookings/_step_3.html.erb
@@ -39,7 +39,7 @@
   <div class="form-group <%= 'form-group-error' if @booking.errors.include?(:phone) %>">
     <%= f.label :phone, class: 'form-label-bold' do %>
       Phone number
-      <span class="form-hint">We’ll send an SMS appointment reminder if a mobile number is provided</span>
+      <span class="form-hint">The number you’d like us to call you on. We’ll send an SMS appointment reminder if a mobile number is provided</span>
     <% end %>
 
     <% if @booking.errors.include?(:phone) %>
@@ -52,7 +52,7 @@
   <div class="form-group <%= 'form-group-error' if @booking.errors.include?(:memorable_word) %>">
     <%= f.label :memorable_word, class: 'form-label-bold' do %>
       Your memorable word
-      <span class="form-hint">Our pension specialist will repeat this word if they need to call, so you know it’s us</span>
+      <span class="form-hint">Our pension specialist will repeat this word when they call so you know it’s us</span>
     <% end %>
 
     <% if @booking.errors.include?(:memorable_word) %>

--- a/app/views/employer/bookings/confirmation.html.erb
+++ b/app/views/employer/bookings/confirmation.html.erb
@@ -18,8 +18,7 @@
     <div class="t-location">
       <p>
       <strong>Location</strong>
-      <br><%= @booking_room %>
-      <%= simple_format(@location.address) %>
+      <br>Phone appointment
       </p>
     </div>
 

--- a/app/views/employer/locations/index.html.erb
+++ b/app/views/employer/locations/index.html.erb
@@ -18,6 +18,10 @@
       </span>
     </div>
     <div class="l-column-two-thirds">
+      <div class="application-notice help-notice">
+        <p>The ongoing response to coronavirus has affected the delivery of face-to-face appointments. As a result, Pension Wise appointments will be delivered by telephone.</p>
+      </div>
+
       <% @locations_by_letter.each do |letter, locations| %>
         <h2 class="locations-a-z-letter"><%= letter %></h2>
         <ol class="locations-a-z-letter-list">

--- a/app/views/employer/locations/show.html.erb
+++ b/app/views/employer/locations/show.html.erb
@@ -7,6 +7,9 @@
 <div class="l-grid-row">
   <div class="l-column-half">
     <h2>Address</h2>
+    <div class="application-notice help-notice">
+      <p>The ongoing response to coronavirus has affected the delivery of face-to-face appointments. As a result, Pension Wise appointments will be delivered by telephone.</p>
+    </div>
     <div class="t-address">
       <%= simple_format(@location.address) %>
     </div>

--- a/spec/features/employer_booking_spec.rb
+++ b/spec/features/employer_booking_spec.rb
@@ -79,7 +79,6 @@ RSpec.feature 'Tesco Bookings' do
     expect(@page.booking_reference).to have_text('123456')
     expect(@page.start).to have_text('13 September 2017')
     expect(@page.start).to have_text('9:10am')
-    expect(@page).to have_text('Room.1')
-    expect(@page).to have_location
+    expect(@page.location).to have_text('Phone appointment')
   end
 end


### PR DESCRIPTION
Employer appointments are facilitated via the telephone channel
temporarily due to the ongoing coronavirus crises.