### PR TITLE
Make Scottish tax notice more prevalent

### DIFF
--- a/config/locales/calculators/take_cash_in_chunks.en.yml
+++ b/config/locales/calculators/take_cash_in_chunks.en.yml
@@ -48,9 +48,6 @@ en:
             <li>
               This is an estimate — the exact amount of tax you pay depends on your total income for the year and your tax rate.
             </li>
-            <li>
-              If you’re in Scotland you can <a href="https://www.gov.uk/estimate-income-tax" rel="external">get an estimate</a> of how much tax you’ll pay.
-            </li>
 
       form:
         heading: Estimate how much you could get

--- a/config/locales/calculators/take_whole_pot.en.yml
+++ b/config/locales/calculators/take_whole_pot.en.yml
@@ -37,9 +37,6 @@ en:
             <li>
               This is an estimate — the exact amount of tax you pay depends on your total income for the year and your tax rate.
             </li>
-            <li>
-              If you’re in Scotland you can <a href="https://www.gov.uk/estimate-income-tax" rel="external">get an estimate</a> of how much tax you’ll pay.
-            </li>
 
       form:
         heading: Estimate what you’d get after tax

--- a/content/take_cash_in_chunks.en.md
+++ b/content/take_cash_in_chunks.en.md
@@ -20,6 +20,8 @@ Not all providers offer this option. If your current provider doesn’t offer it
 
 ^Find out [if you can book](/en/pension-type-tool) a free Pension Wise appointment.^
 
+^This calculator will not calculate tax accurately for individuals living in Scotland as income tax calculations are different. [Get an estimate](https://www.gov.uk/estimate-income-tax) of how much tax you’ll pay.^
+
 {::calculator id="take-cash-in-chunks" locale="en" /}
 
 %Taking a large sum of cash from your pot can mean you pay a higher amount of tax.%

--- a/content/take_whole_pot.en.md
+++ b/content/take_whole_pot.en.md
@@ -18,6 +18,8 @@ You pay tax when you take money from your pot. This is because when you’re pay
 
 ^Find out [if you can book](/en/pension-type-tool) a free Pension Wise appointment.^
 
+^This calculator will not calculate tax accurately for individuals living in Scotland as income tax calculations are different. [Get an estimate](https://www.gov.uk/estimate-income-tax) of how much tax you’ll pay.^
+
 {::calculator id="take-whole-pot" locale="en" /}
 
 %Taking a large sum of cash from your pot can mean you pay a higher amount of tax.%


### PR DESCRIPTION
This was hidden under the calculate button so in some cases an
individual residing in Scotland could complete the form before noticing
it did not apply to them.