### PR TITLE
Track smarter signposted referrals

### DIFF
--- a/app/controllers/smarter_signpostings_controller.rb
+++ b/app/controllers/smarter_signpostings_controller.rb
@@ -1,0 +1,23 @@
+class SmarterSignpostingsController < ApplicationController
+  def new
+    smarter_signposted!
+
+    redirect_to new_telephone_appointment_path
+  end
+
+  def destroy
+    remove_smarter_signposted!
+
+    redirect_to new_telephone_appointment_path
+  end
+
+  private
+
+  def remove_smarter_signposted!
+    cookies.permanent[:smarter_signposted] = 'false'
+  end
+
+  def smarter_signposted!
+    cookies.permanent[:smarter_signposted] = 'true'
+  end
+end

--- a/app/controllers/telephone_appointments_controller.rb
+++ b/app/controllers/telephone_appointments_controller.rb
@@ -122,7 +122,7 @@ class TelephoneAppointmentsController < ApplicationController # rubocop:disable 
         :accessibility_requirements,
         :notes,
         :gdpr_consent
-      )
+      ).merge(smarter_signposted: smarter_signposted?)
   end
 
   def set_breadcrumbs
@@ -133,4 +133,9 @@ class TelephoneAppointmentsController < ApplicationController # rubocop:disable 
   def slot_selected?
     telephone_appointment.start_at
   end
+
+  def smarter_signposted?
+    cookies.permanent[:smarter_signposted] == 'true'
+  end
+  helper_method :smarter_signposted?
 end

--- a/app/models/telephone_appointment.rb
+++ b/app/models/telephone_appointment.rb
@@ -20,7 +20,8 @@ class TelephoneAppointment # rubocop:disable ClassLength
     :date_of_birth_day,
     :gdpr_consent,
     :accessibility_requirements,
-    :notes
+    :notes,
+    :smarter_signposted
   )
 
   validates :start_at, presence: true
@@ -79,7 +80,8 @@ class TelephoneAppointment # rubocop:disable ClassLength
       where_you_heard: where_you_heard,
       gdpr_consent: gdpr_consent,
       accessibility_requirements: accessibility_requirements,
-      notes: notes
+      notes: notes,
+      smarter_signposted: smarter_signposted
     }
   end
 

--- a/app/views/telephone_appointments/_smarter_signposted_banner.html.erb
+++ b/app/views/telephone_appointments/_smarter_signposted_banner.html.erb
@@ -1,0 +1,4 @@
+<div class="application-notice info-notice t-smarter-signposted-banner">
+  <p>You are booking a <strong>smarter signposting</strong> appointment</p>
+  <p><%= button_to 'Cancel', smarter_signposting_path, method: :delete, class: 'button t-cancel-smarter-signposting' %></p>
+</div>

--- a/app/views/telephone_appointments/new.html.erb
+++ b/app/views/telephone_appointments/new.html.erb
@@ -2,6 +2,8 @@
   <div class="l-column-full">
     <h1>Book a phone appointment</h1>
 
+    <%= render partial: 'smarter_signposted_banner' if smarter_signposted? %>
+
     <% if @telephone_appointment.errors.any? || (params[:continue] && !slot_selected?) %>
       <div class="error-summary t-errors" role="alert" aria-labelledby="error-summary-heading-example-1" tabindex="-1" data-error-summary>
         <h2 class="heading-medium error-summary-heading" id="error-summary-heading-example-1">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,8 @@ Rails.application.routes.draw do
   scope ':locale', locale: /en|cy/ do
     root 'home#show'
 
+    resource :smarter_signposting, only: %i(new destroy), path: 'smarter'
+
     constraints format: 'html' do
       resources :categories, only: 'show', path: 'browse'
 

--- a/features/pages/new_telephone_appointment.rb
+++ b/features/pages/new_telephone_appointment.rb
@@ -15,6 +15,8 @@ module Pages
     element :where_you_heard, '.t-where-you-heard'
     element :accessibility_requirements, '.t-accessibility-requirements'
     element :additional_info, '.t-additional-info'
+    element :smarter_signposting_banner, '.t-smarter-signposted-banner'
+    element :cancel_smarter_signposting, '.t-cancel-smarter-signposting'
 
     element :dc_pot_confirmed_yes, '.t-dc-pot-confirmed-yes'
     element :dc_pot_confirmed_no, '.t-dc-pot-confirmed-no'

--- a/features/pages/smarter_signposting_referral.rb
+++ b/features/pages/smarter_signposting_referral.rb
@@ -1,0 +1,5 @@
+module Pages
+  class SmarterSignpostingReferral < SitePrism::Page
+    set_url '/smarter/new'
+  end
+end

--- a/features/step_definitions/telephone_booking_request_steps.rb
+++ b/features/step_definitions/telephone_booking_request_steps.rb
@@ -18,10 +18,32 @@ def stub_appointments_api_to_fail
   allow(@appointment_api_fake).to receive(:create).once.and_return(false)
 end
 
+Given(/^the agent makes a smarter signposting referral$/) do
+  @page = Pages::SmarterSignpostingReferral.new
+  @page.load
+end
+
 Given(/^the customer wants to book a phone appointment$/) do
   @page = Pages::NewTelephoneAppointment.new
   @page.load(locale: :en)
   expect(@page).to be_displayed
+end
+
+Then('they are redirected to the telephone booking') do
+  @page = Pages::NewTelephoneAppointment.new
+  expect(@page).to be_displayed
+end
+
+Then('they are shown the signposting banner') do
+  expect(@page).to have_smarter_signposting_banner
+end
+
+When('they cancel the referral') do
+  @page.cancel_smarter_signposting.click
+end
+
+Then('they are not shown the signposting banner') do
+  expect(@page).to have_no_smarter_signposting_banner
 end
 
 When(/^they choose a date after the slots on that day have been taken$/) do

--- a/features/telephone_booking_request.feature
+++ b/features/telephone_booking_request.feature
@@ -3,6 +3,22 @@ Feature: Customer creates a Telephone Booking
   I want to book a telephone appointment
   So I can understand my pension options
 
+Scenario: TPAS agent creates a 'smarter signposting' telephone appointment
+  Given the agent makes a smarter signposting referral
+  Then they are redirected to the telephone booking
+  And they are shown the signposting banner
+  When they are eligible for an appointment
+  Then their appointment is created
+  And they see a confirmation of their appointment
+
+Scenario: TPAS agent cancels a 'smarter signposting' referral
+  Given the agent makes a smarter signposting referral
+  Then they are redirected to the telephone booking
+  And they are shown the signposting banner
+  When they cancel the referral
+  Then they are redirected to the telephone booking
+  And they are not shown the signposting banner
+
 Scenario: Customer without DC pot tries to book a telephone appointment
   Given the customer wants to book a phone appointment
   When they do not have a DC pot

--- a/spec/lib/telephone_appointments_api_spec.rb
+++ b/spec/lib/telephone_appointments_api_spec.rb
@@ -34,7 +34,8 @@ RSpec.describe TelephoneAppointmentsApi do
         date_of_birth_month: '10',
         date_of_birth_day: '23',
         dc_pot_confirmed: 'yes',
-        gdpr_consent: 'yes'
+        gdpr_consent: 'yes',
+        smarter_signposted: 'true'
       )
     end
 

--- a/spec/models/telephone_appointment_spec.rb
+++ b/spec/models/telephone_appointment_spec.rb
@@ -14,7 +14,8 @@ RSpec.describe TelephoneAppointment, type: :model do
       where_you_heard: '1',
       gdpr_consent: 'yes',
       accessibility_requirements: '1',
-      notes: 'meh'
+      notes: 'meh',
+      smarter_signposted: 'true'
     )
   end
 


### PR DESCRIPTION
TPAS agents can book on the customer's behalf and signal a 'smarter
signposted' referral. A simple cookie is tracked through to completion
and passed along to the API when present.