### PR TITLE
Redirect to locations index for missing

### DIFF
--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -27,7 +27,7 @@ class LocationsController < ApplicationController
   def show
     location = Locations.find(params[:id])
 
-    raise(ActionController::RoutingError, 'Location Not Found') unless location
+    return redirect_to(locations_path(locale: locale), status: :moved_permanently) unless location
 
     booking_location = Locations.find(location.booking_location_id) if location.booking_location_id.present?
 

--- a/spec/controllers/locations_controller_spec.rb
+++ b/spec/controllers/locations_controller_spec.rb
@@ -43,8 +43,13 @@ RSpec.describe LocationsController, type: :controller do
       allow(Locations).to receive(:find).with(valid_id).and_return(location)
     end
 
-    specify 'with an invalid id' do
-      expect { get :show, params: { locale: :en, id: invalid_id } }.to raise_error(ActionController::RoutingError)
+    context 'with an invalid id' do
+      it 'redirects permanently to the locations index' do
+        get :show, params: { locale: :en, id: invalid_id }
+
+        expect(response).to be_redirection
+        expect(response.location).to end_with('/en/locations')
+      end
     end
 
     specify 'with a valid id' do


### PR DESCRIPTION
We now need to redirect to the locations index page instead of issuing a
404 for inactive locations for 'SEO'.