### PR TITLE
Prep employer bookings for f2f/phone

### DIFF
--- a/app/views/employer/bookings/_step_3.html.erb
+++ b/app/views/employer/bookings/_step_3.html.erb
@@ -39,7 +39,7 @@
   <div class="form-group <%= 'form-group-error' if @booking.errors.include?(:phone) %>">
     <%= f.label :phone, class: 'form-label-bold' do %>
       Phone number
-      <span class="form-hint">The number you’d like us to call you on. We’ll send an SMS appointment reminder if a mobile number is provided</span>
+      <span class="form-hint">We’ll send an SMS appointment reminder if a mobile number is provided. If you’re booking a telephone appointment, this is the number we will call you on</span>
     <% end %>
 
     <% if @booking.errors.include?(:phone) %>

--- a/app/views/employer/bookings/confirmation.html.erb
+++ b/app/views/employer/bookings/confirmation.html.erb
@@ -8,10 +8,6 @@
         Your reference number is <br>
         <strong class="heading-medium t-booking-reference"><%= @booking_reference %></strong>
       </p>
-      <p>
-        Your Pension Wise appointment will be delivered by telephone. We will
-        call you on the phone number provided.
-      </p>
     </div>
 
     <div class="t-start">

--- a/app/views/employer/locations/index.html.erb
+++ b/app/views/employer/locations/index.html.erb
@@ -18,10 +18,6 @@
       </span>
     </div>
     <div class="l-column-two-thirds">
-      <div class="application-notice help-notice">
-        <p>The ongoing response to coronavirus has affected the delivery of face-to-face appointments. As a result, Pension Wise appointments will be delivered by telephone.</p>
-      </div>
-
       <% @locations_by_letter.each do |letter, locations| %>
         <h2 class="locations-a-z-letter"><%= letter %></h2>
         <ol class="locations-a-z-letter-list">

--- a/app/views/employer/locations/show.html.erb
+++ b/app/views/employer/locations/show.html.erb
@@ -6,13 +6,6 @@
 
 <div class="l-grid-row">
   <div class="l-column-half">
-    <div class="application-notice help-notice">
-      <p>
-        The ongoing response to coronavirus has affected the delivery of
-        face-to-face appointments. Your Pension Wise appointment will
-        be delivered by telephone.
-      </p>
-    </div>
 
     <h2>Address</h2>
     <div class="t-address">


### PR DESCRIPTION
We've hacked in some temporary wording changes to allow both
face-to-face or telephone employer appointments during the coronavirus
crisis.