### PR TITLE
Validate against digits in name fields

### DIFF
--- a/app/models/telephone_appointment.rb
+++ b/app/models/telephone_appointment.rb
@@ -25,8 +25,8 @@ class TelephoneAppointment # rubocop:disable ClassLength
   )
 
   validates :start_at, presence: true
-  validates :first_name, presence: true
-  validates :last_name, presence: true
+  validates :first_name, presence: true, format: { without: /\d+/ }
+  validates :last_name, presence: true, format: { without: /\d+/ }
   validates :email, email: true
   validate  :validate_phone
   validates :memorable_word, presence: true

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -191,8 +191,10 @@ en:
           attributes:
             first_name:
               blank: enter a name
+              invalid: must not contain numerical digits
             last_name:
               blank: enter a name
+              invalid: must not contain numerical digits
             email:
               invalid_email: enter a valid email address
             phone:

--- a/spec/models/telephone_appointment_spec.rb
+++ b/spec/models/telephone_appointment_spec.rb
@@ -123,8 +123,18 @@ RSpec.describe TelephoneAppointment, type: :model do
       expect(subject).to_not be_valid
     end
 
+    it 'validates first name does not contain digits' do
+      subject.first_name = '07731 292 999'
+      expect(subject).to_not be_valid
+    end
+
     it 'validates presence of last_name' do
       subject.last_name = nil
+      expect(subject).to_not be_valid
+    end
+
+    it 'validates last name does not contain digits' do
+      subject.last_name = 'Ben 303030'
       expect(subject).to_not be_valid
     end
 


### PR DESCRIPTION
It appears some bookings are coming through with the mobile number
autofilled into these fields. This will ensure the customer is alerted
when this happens.