### PR TITLE
Allow customers to specify a support person

### DIFF
--- a/app/controllers/bsl/bsl_booking_requests_controller.rb
+++ b/app/controllers/bsl/bsl_booking_requests_controller.rb
@@ -47,7 +47,12 @@ module Bsl
           :accessibility_needs,
           :additional_info,
           :where_you_heard,
-          :gdpr_consent
+          :gdpr_consent,
+          :supported,
+          :support_name,
+          :support_relationship,
+          :support_email,
+          :support_phone
         )
     end
 

--- a/app/lib/bsl/mapper.rb
+++ b/app/lib/bsl/mapper.rb
@@ -16,7 +16,12 @@ module Bsl
         accessibility_needs: booking_request.accessibility_needs,
         additional_info: booking_request.additional_info,
         where_you_heard: booking_request.where_you_heard,
-        gdpr_consent: booking_request.gdpr_consent.to_s
+        gdpr_consent: booking_request.gdpr_consent.to_s,
+        support: booking_request.supported,
+        support_name: booking_request.support_name,
+        support_relationship: booking_request.support_relationship,
+        support_email: booking_request.support_email,
+        support_phone: booking_request.support_phone
       }
     end
 

--- a/app/models/bsl/booking_request.rb
+++ b/app/models/bsl/booking_request.rb
@@ -12,7 +12,12 @@ module Bsl
       :accessibility_needs,
       :additional_info,
       :where_you_heard,
-      :gdpr_consent
+      :gdpr_consent,
+      :supported,
+      :support_name,
+      :support_relationship,
+      :support_phone,
+      :support_email
     )
 
     attr_writer :date_of_birth
@@ -29,6 +34,12 @@ module Bsl
     validates :where_you_heard, inclusion: { in: WhereYouHeard::OPTIONS.keys }
     validate :validate_age_eligibility, if: :date_of_birth
 
+    validates :supported, inclusion: { in: %w(yes no) }
+    validates :support_name, presence: true, if: :supported?
+    validates :support_relationship, presence: true, if: :supported?
+    validates :support_email, email: true, if: :supported?
+    validates :support_phone, presence: true, format: /\A([\d+\-\s\+()]+)\z/, if: :supported?
+
     def date_of_birth
       return nil unless /\d{4}-\d{1,2}-\d{1,2}/.match?(@date_of_birth)
 
@@ -40,6 +51,10 @@ module Bsl
     end
 
     private
+
+    def supported?
+      supported == 'yes'
+    end
 
     def validate_age_eligibility
       errors.add(:date_of_birth) if age < 50

--- a/app/views/bsl/bsl_booking_requests/new.html.erb
+++ b/app/views/bsl/bsl_booking_requests/new.html.erb
@@ -189,6 +189,77 @@
         </div>
       </div>
 
+      <div class="form-group <%= 'form-group-error' if @booking_request.errors.include?(:supported) %>" id="supported" tabindex="-1" data-radio-toggle>
+        <fieldset class="inline">
+          <legend class="form-label-bold">Will someone be joining you for support?</legend>
+
+          <% if @booking_request.errors.include?(:supported) %>
+            <span class="error-message"><%= @booking_request.errors[:supported].to_sentence.capitalize %></span>
+          <% end %>
+
+          <div class="multiple-choice" data-target="support-fields">
+            <%= f.radio_button :supported, 'yes', class: 't-supported-yes', data: { target: 'support-fields' } %>
+            <%= f.label :supported, value: 'yes' do %>
+              Yes
+            <% end %>
+          </div>
+
+          <div class="multiple-choice">
+            <%= f.radio_button :supported, 'no', class: 't-supported-no' %>
+            <%= f.label :supported, value: 'no' do %>
+              No
+            <% end %>
+          </div>
+
+        </fieldset>
+      </div>
+
+      <div id="support-fields" class="js-hidden application-notice info-notice">
+        <div class="form-group <%= 'form-group-error' if @booking_request.errors.include?(:support_name) %>">
+          <%= f.label :support_name, class: 'form-label-bold' %>
+          <% if @booking_request.errors.include?(:support_name) %>
+            <span class="error-message"><%= @booking_request.errors[:support_name].to_sentence.capitalize %></span>
+          <% end %>
+          <%= f.text_field :support_name, class: "t-support-name form-control #{'form-control-error' if @booking_request.errors.include?(:support_name)}" %>
+        </div>
+
+        <div class="form-group <%= 'form-group-error' if @booking_request.errors.include?(:support_relationship) %>">
+          <%= f.label :support_relationship, class: 'form-label-bold' %>
+          <% if @booking_request.errors.include?(:support_relationship) %>
+            <span class="error-message"><%= @booking_request.errors[:support_relationship].to_sentence.capitalize %></span>
+          <% end %>
+          <%= f.text_field :support_relationship, class: "t-support-relationship form-control #{'form-control-error' if @booking_request.errors.include?(:support_relationship)}" %>
+        </div>
+
+        <div class="form-group <%= 'form-group-error' if @booking_request.errors.include?(:support_email) %>">
+          <%= f.label :support_email, class: 'form-label-bold' do %>
+            Their email
+            <span class="form-hint">We may need to email them if we’re unable to reach you</span>
+          <% end %>
+
+          <% if @booking_request.errors.include?(:support_email) %>
+            <span class="error-message"><%= @booking_request.errors[:support_email].to_sentence.capitalize %></span>
+          <% end %>
+
+          <div class="email-outer">
+            <%= f.email_field :support_email, class: "t-support-email form-control #{'form-control-error' if @booking_request.errors.include?(:support_email)}" %>
+          </div>
+        </div>
+
+        <div class="form-group <%= 'form-group-error' if @booking_request.errors.include?(:support_phone) %>">
+          <%= f.label :support_phone, class: 'form-label-bold' do %>
+            Their phone number
+            <span class="form-hint">We may need to phone them if we’re unable to reach you</span>
+          <% end %>
+
+          <% if @booking_request.errors.include?(:support_phone) %>
+            <span class="error-message"><%= @booking_request.errors[:support_phone].to_sentence.capitalize %></span>
+          <% end %>
+
+          <%= f.text_field :support_phone, class: "t-support-phone form-control #{'form-control-error' if @booking_request.errors.include?(:support_phone)}" %>
+        </div>
+      </div>
+
       <div class="form-group">
         <%= f.label :additional_info, class: 'form-label-bold' do %>
           Additional information

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -168,6 +168,17 @@ en:
               inclusion: select an option
             additional_info:
               blank: describe the accessibility adjustments you require
+            support:
+              inclusion: select an option
+            support_name:
+              blank: enter a name
+            support_relationship:
+              blank: enter their relationship to you
+            support_email:
+              invalid_email: enter a valid email address
+            support_phone:
+              blank: enter a phone number
+              invalid: enter a valid phone number
         employer/booking:
           attributes:
             first_name:
@@ -214,6 +225,12 @@ en:
               blank: describe the accessibility adjustments you require
 
     attributes:
+      bsl/booking_request:
+        supported: Will someone be joining you for support
+        support_name: Their name
+        support_relationship: Their relationship to you
+        support_email: Their email
+        support_phone: Their phone number
       employer/booking:
         dc_pot_confirmed: Defined contribution pension
         accept_terms_and_conditions: Terms and conditions

--- a/features/pages/bsl_booking_request.rb
+++ b/features/pages/bsl_booking_request.rb
@@ -15,6 +15,14 @@ module Pages
     element :additional_info, '.t-additional-info'
     element :where_you_heard, '.t-where-you-heard'
     element :gdpr_consent_yes, '.t-gdpr-consent-yes', visible: false
+
+    element :supported_yes, '.t-supported-yes', visible: false
+    element :supported_no, '.t-supported-no', visible: false
+    element :support_name, '.t-support-name'
+    element :support_relationship, '.t-support-relationship'
+    element :support_email, '.t-support-email'
+    element :support_phone, '.t-support-phone'
+
     element :submit, '.t-submit'
 
     elements :errors, '.form-group-error'

--- a/spec/cassettes/British_Sign_Language_bookings/Customer_places_a_BSL_booking_request_successfully.yml
+++ b/spec/cassettes/British_Sign_Language_bookings/Customer_places_a_BSL_booking_request_successfully.yml
@@ -7,10 +7,12 @@ http_interactions:
       encoding: UTF-8
       string: '{"first_name":"Ben","last_name":"Smith","email":"ben@example.com","phone":"07715
         930 455","memorable_word":"spoon","date_of_birth":"1960-01-01","defined_contribution_pot_confirmed":"yes","accessibility_needs":"1","additional_info":"Before
-        1PM.","where_you_heard":"7","gdpr_consent":"yes"}'
+        1PM.","where_you_heard":"7","gdpr_consent":"yes","support":"yes","support_name":"Dave
+        David","support_relationship":"Carer","support_email":"dave@example.com","support_phone":"07715
+        930 455"}'
     headers:
       User-Agent:
-      - PensionWise/1.0 (birdperson; benlovell; 65813) ruby/2.6.5 (114; x86_64-darwin19)
+      - PensionWise/1.0 (birdperson; benlovell; 59986) ruby/2.6.5 (114; x86_64-darwin19)
       Accept:
       - application/json
       Content-Type:
@@ -39,14 +41,14 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - 51adf95d-eea7-467f-8351-a87c83c6b72f
+      - 713887e0-f864-4804-b533-57278f128065
       X-Runtime:
-      - '0.169619'
+      - '0.284847'
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: ''
     http_version:
-  recorded_at: Wed, 23 Sep 2020 12:00:25 GMT
+  recorded_at: Thu, 17 Dec 2020 10:27:49 GMT
 recorded_with: VCR 3.0.3

--- a/spec/features/bsl_booking_spec.rb
+++ b/spec/features/bsl_booking_spec.rb
@@ -36,6 +36,14 @@ RSpec.feature 'British Sign Language bookings' do
     @page.additional_info.set('Before 1PM.')
     @page.where_you_heard.select('TV advert')
     @page.gdpr_consent_yes.set(true)
+
+    expect(@page).to have_no_support_name
+    @page.supported_yes.set(true)
+    @page.wait_until_support_name_visible
+    @page.support_name.set('Dave David')
+    @page.support_relationship.set('Carer')
+    @page.support_email.set('dave@example.com')
+    @page.support_phone.set('07715 930 455')
   end
 
   def and_they_submit_their_booking_request

--- a/spec/models/bsl/booking_request_spec.rb
+++ b/spec/models/bsl/booking_request_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe Bsl::BookingRequest do
       'defined_contribution_pot_confirmed' => 'yes',
       'date_of_birth' => '1950-01-01',
       'additional_info' => '',
-      'where_you_heard' => '1'
+      'where_you_heard' => '1',
+      'supported' => 'no'
     }
   end
 
@@ -26,5 +27,43 @@ RSpec.describe Bsl::BookingRequest do
 
     subject.date_of_birth = ''
     expect(subject).to be_invalid
+  end
+
+  context 'when supported' do
+    let(:supported_attributes) do
+      {
+        'supported' => 'yes',
+        'support_name' => 'Dave Jones',
+        'support_relationship' => 'Friend',
+        'support_email' => 'dave@example.com',
+        'support_phone' => '07715 999 345'
+      }
+    end
+
+    subject { described_class.new(attributes.merge(supported_attributes)) }
+
+    it 'requires the supporter name' do
+      subject.support_name = nil
+
+      expect(subject).to be_invalid
+    end
+
+    it 'requires the supporter relationship' do
+      subject.support_relationship = nil
+
+      expect(subject).to be_invalid
+    end
+
+    it 'requires the supporter email' do
+      subject.support_email = nil
+
+      expect(subject).to be_invalid
+    end
+
+    it 'requires the supporter phone' do
+      subject.support_phone = nil
+
+      expect(subject).to be_invalid
+    end
   end
 end


### PR DESCRIPTION
Allows BSL customers to nominate a person for support during their
appointment and the booking process.