### PR TITLE
Include necessary cookie configuration

### DIFF
--- a/app/views/components/_cookie_banner.html.erb
+++ b/app/views/components/_cookie_banner.html.erb
@@ -15,6 +15,7 @@
       closeOnGlobalChange: true,
       closeStyle: 'button',
       subDomains: true,
+      necessaryCookies: ['smarter_signposted', 'pilot_summaries'],
 
       text: {
         accept: '<%= t('cookie_banner.accept') %>',


### PR DESCRIPTION
These cookies are required to track first party signposting and for
opt-in data collection on the 'explore your options' journey.