### PR TITLE
Lloyds signposted appointments

### DIFF
--- a/app/controllers/telephone_appointments_controller.rb
+++ b/app/controllers/telephone_appointments_controller.rb
@@ -11,6 +11,7 @@ class TelephoneAppointmentsController < ApplicationController # rubocop:disable 
   helper_method :slot_selected?
 
   def new
+    check_lloyds_cookie!
   end
 
   def create
@@ -77,7 +78,7 @@ class TelephoneAppointmentsController < ApplicationController # rubocop:disable 
   end
 
   def retrieve_slots
-    slots   = TelephoneAppointmentsApi.new.slots
+    slots   = TelephoneAppointmentsApi.new.slots(lloyds_signposted?)
 
     @months = retrieve_months(slots)
     @times  = retrieve_times(slots)
@@ -122,7 +123,10 @@ class TelephoneAppointmentsController < ApplicationController # rubocop:disable 
         :accessibility_requirements,
         :notes,
         :gdpr_consent
-      ).merge(smarter_signposted: smarter_signposted?)
+      ).merge(
+        smarter_signposted: smarter_signposted?,
+        lloyds_signposted: lloyds_signposted?
+      )
   end
 
   def set_breadcrumbs
@@ -134,8 +138,17 @@ class TelephoneAppointmentsController < ApplicationController # rubocop:disable 
     telephone_appointment.start_at
   end
 
+  def check_lloyds_cookie!
+    cookies.permanent[:lloyds_signposted] = 'true' if params[:lloyds]
+  end
+
   def smarter_signposted?
     cookies.permanent[:smarter_signposted] == 'true'
   end
   helper_method :smarter_signposted?
+
+  def lloyds_signposted?
+    cookies.permanent[:lloyds_signposted] == 'true'
+  end
+  helper_method :lloyds_signposted?
 end

--- a/app/lib/telephone_appointments_api.rb
+++ b/app/lib/telephone_appointments_api.rb
@@ -1,4 +1,6 @@
 class TelephoneAppointmentsApi
+  SLOTS_PATH = '/api/v1/bookable_slots'.freeze
+
   def create(telephone_appointment)
     response = connection.post('/api/v1/appointments', telephone_appointment.attributes)
 
@@ -7,8 +9,10 @@ class TelephoneAppointmentsApi
     false
   end
 
-  def slots
-    response = connection.get('/api/v1/bookable_slots')
+  def slots(filter_for_lloyds = nil)
+    path = filter_for_lloyds ? SLOTS_PATH + '?lloyds=true' : SLOTS_PATH
+
+    response = connection.get(path)
     response.body
   end
 

--- a/app/models/telephone_appointment.rb
+++ b/app/models/telephone_appointment.rb
@@ -21,7 +21,8 @@ class TelephoneAppointment # rubocop:disable ClassLength
     :gdpr_consent,
     :accessibility_requirements,
     :notes,
-    :smarter_signposted
+    :smarter_signposted,
+    :lloyds_signposted
   )
 
   validates :start_at, presence: true
@@ -81,7 +82,8 @@ class TelephoneAppointment # rubocop:disable ClassLength
       gdpr_consent: gdpr_consent,
       accessibility_requirements: accessibility_requirements,
       notes: notes,
-      smarter_signposted: smarter_signposted
+      smarter_signposted: smarter_signposted,
+      lloyds_signposted: lloyds_signposted
     }
   end
 

--- a/app/views/components/_cookie_banner.html.erb
+++ b/app/views/components/_cookie_banner.html.erb
@@ -15,7 +15,7 @@
       closeOnGlobalChange: true,
       closeStyle: 'button',
       subDomains: true,
-      necessaryCookies: ['smarter_signposted', 'pilot_summaries'],
+      necessaryCookies: ['smarter_signposted', 'pilot_summaries', 'lloyds_signposted'],
 
       text: {
         accept: '<%= t('cookie_banner.accept') %>',

--- a/app/views/telephone_appointments/new.html.erb
+++ b/app/views/telephone_appointments/new.html.erb
@@ -2,6 +2,12 @@
   <div class="l-column-full">
     <h1>Book a phone appointment</h1>
 
+    <% if lloyds_signposted? %>
+      <div class="application-notice info-notice t-lloyds-signposted-banner">
+        <p>You are booking as an employee of <strong>LBGPTL</strong></p>
+      </div>
+    <% end %>
+
     <%= render partial: 'smarter_signposted_banner' if smarter_signposted? %>
 
     <% if @telephone_appointment.errors.any? || (params[:continue] && !slot_selected?) %>

--- a/features/pages/new_telephone_appointment.rb
+++ b/features/pages/new_telephone_appointment.rb
@@ -1,6 +1,6 @@
 module Pages
   class NewTelephoneAppointment < SitePrism::Page
-    set_url '/{locale}/telephone-appointments/new'
+    set_url '/{locale}/telephone-appointments/new{?query*}'
 
     element :first_name, '.t-first-name'
     element :last_name, '.t-last-name'
@@ -17,6 +17,7 @@ module Pages
     element :additional_info, '.t-additional-info'
     element :smarter_signposting_banner, '.t-smarter-signposted-banner'
     element :cancel_smarter_signposting, '.t-cancel-smarter-signposting'
+    element :lloyds_signposting_banner, '.t-lloyds-signposted-banner'
 
     element :dc_pot_confirmed_yes, '.t-dc-pot-confirmed-yes'
     element :dc_pot_confirmed_no, '.t-dc-pot-confirmed-no'

--- a/features/step_definitions/telephone_booking_request_steps.rb
+++ b/features/step_definitions/telephone_booking_request_steps.rb
@@ -18,6 +18,15 @@ def stub_appointments_api_to_fail
   allow(@appointment_api_fake).to receive(:create).once.and_return(false)
 end
 
+Given('the customer makes a Lloyds signposting referral') do
+  @page = Pages::NewTelephoneAppointment.new
+  @page.load(locale: :en, query: { lloyds: true })
+end
+
+Then('they are show the Lloyds signposting banner') do
+  expect(@page).to be_displayed
+end
+
 Given(/^the agent makes a smarter signposting referral$/) do
   @page = Pages::SmarterSignpostingReferral.new
   @page.load

--- a/features/telephone_booking_request.feature
+++ b/features/telephone_booking_request.feature
@@ -3,6 +3,10 @@ Feature: Customer creates a Telephone Booking
   I want to book a telephone appointment
   So I can understand my pension options
 
+Scenario: Lloyds employee creates a signposted telephone appointment
+  Given the customer makes a Lloyds signposting referral
+  Then they are show the Lloyds signposting banner
+
 Scenario: TPAS agent creates a 'smarter signposting' telephone appointment
   Given the agent makes a smarter signposting referral
   Then they are redirected to the telephone booking

--- a/spec/lib/telephone_appointments_api_spec.rb
+++ b/spec/lib/telephone_appointments_api_spec.rb
@@ -1,13 +1,9 @@
 RSpec.describe TelephoneAppointmentsApi do
-  context 'with valid params' do
+  describe '#slots' do
     before do
       allow(HTTPConnectionFactory).to receive(:build).and_return(connection)
-      allow(connection).to receive(:headers).and_return(headers)
-      allow(connection).to receive(:post)
-    end
-
-    subject do
-      described_class.new
+      allow(connection).to receive(:headers).and_return({})
+      allow(connection).to receive(:get).and_return(double(body: {}))
     end
 
     let(:connection) do
@@ -18,36 +14,71 @@ RSpec.describe TelephoneAppointmentsApi do
       {}
     end
 
-    let(:api_response) do
-      double(headers: { 'Location' => '/appointments/123456' })
+    context 'for Lloyds' do
+      it 'uses the filtered path for slots' do
+        subject.slots(true)
+
+        expect(connection).to have_received(:get).with('/api/v1/bookable_slots?lloyds=true')
+      end
     end
 
-    let(:telephone_appointment) do
-      TelephoneAppointment.new(
-        start_at: Time.zone.now.to_s,
-        first_name: 'First',
-        last_name: 'Last',
-        email: 'email@example.org',
-        phone: '29309203023',
-        memorable_word: 'hello',
-        date_of_birth_year: '1920',
-        date_of_birth_month: '10',
-        date_of_birth_day: '23',
-        dc_pot_confirmed: 'yes',
-        gdpr_consent: 'yes',
-        smarter_signposted: 'true'
-      )
+    context 'for general availability' do
+      it 'uses the unfiltered path for slots' do
+        subject.slots
+
+        expect(connection).to have_received(:get).with('/api/v1/bookable_slots')
+      end
     end
+  end
 
-    it 'posts the telephone appointment' do
-      expect(connection).to receive(:post).with(
-        '/api/v1/appointments',
-        telephone_appointment.attributes
-      ).and_return(api_response)
+  describe '#create' do
+    context 'with valid params' do
+      before do
+        allow(HTTPConnectionFactory).to receive(:build).and_return(connection)
+        allow(connection).to receive(:headers).and_return(headers)
+        allow(connection).to receive(:post)
+      end
 
-      expect(subject.create(telephone_appointment)).to be_truthy
+      let(:connection) do
+        double(:connection)
+      end
 
-      expect(telephone_appointment.id).to eq('123456')
+      let(:headers) do
+        {}
+      end
+
+      let(:api_response) do
+        double(headers: { 'Location' => '/appointments/123456' })
+      end
+
+      let(:telephone_appointment) do
+        TelephoneAppointment.new(
+          start_at: Time.zone.now.to_s,
+          first_name: 'First',
+          last_name: 'Last',
+          email: 'email@example.org',
+          phone: '29309203023',
+          memorable_word: 'hello',
+          date_of_birth_year: '1920',
+          date_of_birth_month: '10',
+          date_of_birth_day: '23',
+          dc_pot_confirmed: 'yes',
+          gdpr_consent: 'yes',
+          smarter_signposted: 'true',
+          lloyds_signposted: 'false'
+        )
+      end
+
+      it 'posts the telephone appointment' do
+        expect(connection).to receive(:post).with(
+          '/api/v1/appointments',
+          telephone_appointment.attributes
+        ).and_return(api_response)
+
+        expect(subject.create(telephone_appointment)).to be_truthy
+
+        expect(telephone_appointment.id).to eq('123456')
+      end
     end
   end
 end


### PR DESCRIPTION
When the customer lands on the Lloyds signposting URL they are cookied
and the flag is passed through to the bookings API upon completion. The
availability calendar is filtered also to the correct providers based on
their enrolment in the Lloyds trial.