### PR TITLE
Make the cookie control a bit smaller

### DIFF
--- a/app/views/components/_cookie_banner.html.erb
+++ b/app/views/components/_cookie_banner.html.erb
@@ -50,8 +50,8 @@
         toggleColor: '#00823b',
         toggleBackground: '#dee0e2',
         buttonIcon: null,
-        buttonIconWidth: 120,
-        buttonIconHeight: 120,
+        buttonIconWidth: 80,
+        buttonIconHeight: 80,
         removeIcon: false,
         removeAbout: true
       },


### PR DESCRIPTION
It occupies quite a bit of space in the bottom left corner and can be
a bit smaller.