### PR TITLE
This was causing odd layout with lists

### DIFF
--- a/app/assets/stylesheets/money-helper-overrides.scss
+++ b/app/assets/stylesheets/money-helper-overrides.scss
@@ -242,7 +242,6 @@ ol ol li {
 ul li::before {
   content: "•";
   font-size: 1.5rem;
-  top: 1px;
 }
 
 ol {


### PR DESCRIPTION
This was causing odd wrapping and layout of list items in particular
places. The text still appears centred to the bullet after the removal
of this rule.