### PR TITLE
Resolve invalid formats error

### DIFF
--- a/app/controllers/pension_summaries_controller.rb
+++ b/app/controllers/pension_summaries_controller.rb
@@ -102,7 +102,7 @@ class PensionSummariesController < ApplicationController
     render pdf: 'your pension summary from Pension Wise',
            template: 'pension_summaries/print',
            handlers: %w(erb),
-           formats: %w(html),
+           formats: %i(html),
            layout: false,
            disposition: 'inline'
   end

--- a/spec/features/pension_summary_spec.rb
+++ b/spec/features/pension_summary_spec.rb
@@ -10,6 +10,8 @@ RSpec.feature 'The pension summary', type: :feature do
       and_i_select_all_pension_options
       and_i_select_all_extra_options
       then_i_view_a_summary_with_all_pages
+      when_i_download_my_summary
+      then_i_see_a_summary_pdf
     end
 
     scenario 'Viewing the pilot pension summary' do
@@ -115,6 +117,14 @@ RSpec.feature 'The pension summary', type: :feature do
       end
     end
   end
+end
+
+def when_i_download_my_summary
+  click_link('Download')
+end
+
+def then_i_see_a_summary_pdf
+  expect(page.status_code).to eq(200)
 end
 
 def given_the_pilot_summaries_cookie_is_set_to_false


### PR DESCRIPTION
This was not previously covered by tests and was causing a production
error to occur despite the download actually working.