### PR TITLE
Specify node version explicitly

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,8 @@
 {
   "name": "pension_guidance",
+  "engines": {
+    "node": "14.18.1"
+  },
   "dependencies": {
     "bower": "*"
   },


### PR DESCRIPTION
This works around heroku build issues in the staging environment.