### PR TITLE
Disable auto scroll in some smaller tools

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -4,6 +4,7 @@
 //= stub govuk/selection-buttons
 //= require click-tracker.js
 //= require calculators.js
+//= require auto-scroller.js
 //= require feedback.js
 //= require disable-button.js
 

--- a/app/assets/javascripts/auto-scroller.js
+++ b/app/assets/javascripts/auto-scroller.js
@@ -1,0 +1,34 @@
+(function() {
+  'use strict';
+
+  var autoScroller = {
+    start: function() {
+      if (!window.parent) {
+        return;
+      }
+
+      if (!window.parent.postMessage) {
+        return;
+      }
+
+      $(function() {
+        // this only works because the parent in AEM receives the message
+        // and has code to act on it
+
+        var disableScrollToTopMeta = document.querySelector(
+          'meta[name="disable_scroll_to_top"]'
+        );
+        var isScrollToTopDisabled = !!(
+          disableScrollToTopMeta && disableScrollToTopMeta.content === 'true'
+        );
+
+        if (!isScrollToTopDisabled) {
+          window.parent.postMessage({ scrollToTop: true }, '*');
+        }
+      });
+    }
+  };
+
+  window.PWPG = window.PWPG || {};
+  window.PWPG.autoScroller = autoScroller;
+})(jQuery);

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -14,4 +14,8 @@ module ApplicationHelper
       concat link_to(guide.label, guide.url, class: 't-guide-link')
     end
   end
+
+  def disable_scroll_to_top
+    '<meta name="disable_scroll_to_top" content="true"/>'.html_safe
+  end
 end

--- a/app/views/calculators/adjustable_income/_form.html.erb
+++ b/app/views/calculators/adjustable_income/_form.html.erb
@@ -3,6 +3,8 @@
   errors = form&.errors || {}
 %>
 
+<%= disable_scroll_to_top %>
+
 <h2 id="calculator" class="calculator-heading"><%= t('.heading') %></h2>
 
 <%= render 'calculators/error_summary',

--- a/app/views/calculators/guaranteed_income/_form.html.erb
+++ b/app/views/calculators/guaranteed_income/_form.html.erb
@@ -3,6 +3,8 @@
   errors = form&.errors || {}
 %>
 
+<%= disable_scroll_to_top %>
+
 <h2 id="calculator" class="calculator-heading"><%= t('.heading') %></h2>
 
 <%= render 'calculators/error_summary',

--- a/app/views/calculators/leave_pot_untouched/_form.html.erb
+++ b/app/views/calculators/leave_pot_untouched/_form.html.erb
@@ -3,6 +3,8 @@
   errors = form&.errors || {}
 %>
 
+<%= disable_scroll_to_top %>
+
 <h2 id="calculator" class="calculator-heading"><%= t('.heading') %></h2>
 
 <%= render 'calculators/error_summary',

--- a/app/views/calculators/take_cash_in_chunks/_form.html.erb
+++ b/app/views/calculators/take_cash_in_chunks/_form.html.erb
@@ -3,6 +3,8 @@
   errors = form&.errors || {}
 %>
 
+<%= disable_scroll_to_top %>
+
 <h2 id="calculator" class="calculator-heading"><%= t('.heading') %></h2>
 
 <%= render 'calculators/error_summary',

--- a/app/views/calculators/take_whole_pot/_form.html.erb
+++ b/app/views/calculators/take_whole_pot/_form.html.erb
@@ -3,6 +3,8 @@
   errors = form&.errors || {}
 %>
 
+<%= disable_scroll_to_top %>
+
 <h2 id="calculator" class="calculator-heading"><%= t('.heading') %></h2>
 
 <%= render 'calculators/error_summary',

--- a/app/views/layouts/full_width_widget.html.erb
+++ b/app/views/layouts/full_width_widget.html.erb
@@ -75,7 +75,10 @@
       document.addEventListener("DOMContentLoaded", function(event) {
         // this only works because the parent in AEM receives the message
         // and has code to act on it
-        if (window.parent && window.parent.postMessage) {
+        const disableScrollToTopMeta = document.querySelector("meta[name='disable_scroll_to_top']")
+        const isScrollToTopDisabled = !!(disableScrollToTopMeta && disableScrollToTopMeta.content === 'true')
+
+        if (window.parent && window.parent.postMessage && !isScrollToTopDisabled) {
           window.parent.postMessage({scrollToTop: true}, '*');
         }
       });

--- a/app/views/layouts/full_width_widget.html.erb
+++ b/app/views/layouts/full_width_widget.html.erb
@@ -69,19 +69,10 @@
 
   <% unless Rails.env.development? %>
     <%= javascript_include_tag 'iframe-resizer' %>
+    <%= javascript_include_tag 'auto-scroller' %>
     <script>
       window.PWPG.iframeResizer.start();
-
-      document.addEventListener("DOMContentLoaded", function(event) {
-        // this only works because the parent in AEM receives the message
-        // and has code to act on it
-        const disableScrollToTopMeta = document.querySelector("meta[name='disable_scroll_to_top']")
-        const isScrollToTopDisabled = !!(disableScrollToTopMeta && disableScrollToTopMeta.content === 'true')
-
-        if (window.parent && window.parent.postMessage && !isScrollToTopDisabled) {
-          window.parent.postMessage({scrollToTop: true}, '*');
-        }
-      });
+      window.PWPG.autoScroller.start();
     </script>
   <% end %>
 <% end %>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -35,4 +35,5 @@ Rails.application.config.assets.precompile += %w( apple-touch-icon-120x120.png
                                                   accessible.media.player/custom/css/player-theme.css
                                                   video-player.js
                                                   guider-image.jpg
-                                                  iframe-resizer.js )
+                                                  iframe-resizer.js
+                                                  auto-scroller.js )

--- a/spec/javascripts/autoScrollerSpec.js
+++ b/spec/javascripts/autoScrollerSpec.js
@@ -1,0 +1,31 @@
+//= require jasmine-jquery
+
+jasmine.getFixtures().fixturesPath = '../../spec/javascripts/fixtures';
+
+describe('auto scroller', function() {
+  'use strict';
+
+  beforeEach(function() {
+    window.parent = {
+      postMessage: function() {}
+    };
+
+    spyOn(window.parent, 'postMessage');
+  });
+
+  it('is defined', function() {
+    expect(PWPG.autoScroller).toBeDefined();
+  });
+
+  it('auto-scrolls on load', function() {
+    loadFixtures('auto-scroller.html');
+
+    expect(window.parent.postMessage).toHaveBeenCalledWith({ scrollToTop: true }, '*');
+  });
+
+  it('does not auto-scroll when it is disabled', function() {
+    loadFixtures('auto-scroller-disabled.html');
+
+    expect(window.parent.postMessage).not.toHaveBeenCalled();
+  });
+});

--- a/spec/javascripts/fixtures/auto-scroller-disabled.html
+++ b/spec/javascripts/fixtures/auto-scroller-disabled.html
@@ -1,0 +1,5 @@
+<meta name="disable_scroll_to_top" content="true"/>
+
+<script>
+  PWPG.autoScroller.start();
+</script>

--- a/spec/javascripts/fixtures/auto-scroller.html
+++ b/spec/javascripts/fixtures/auto-scroller.html
@@ -1,0 +1,3 @@
+<script>
+  PWPG.autoScroller.start();
+</script>


### PR DESCRIPTION
Some tools are embedded part way down on pages, which means that automatically scrolling to the top of the page on `DOMContentLoaded` is a bad idea for the user.

This PR disables this behaviour in some tools that are used in this way.

- [x] This has been tested in `test` under Chrome and Firefox