### PR TITLE
Make the outline rounded in Safari

### DIFF
--- a/app/assets/stylesheets/base/_forms.scss
+++ b/app/assets/stylesheets/base/_forms.scss
@@ -16,9 +16,11 @@ input[name="slider"] {
 
   // outlines
   &:focus {
-    border: 2px solid $color-violet-primary;
-    outline: 4px solid $color-yellow-secondary;
     background-color: $color-white-supporting;
+    border: 4px solid #8200D1;
+    border-radius: 4px;
+    box-shadow: 0 0 0 4px #F0F05A;
+    outline: none;
   }
 
   &.form-control-error {

--- a/app/assets/stylesheets/base/_forms.scss
+++ b/app/assets/stylesheets/base/_forms.scss
@@ -17,9 +17,9 @@ input[name="slider"] {
   // outlines
   &:focus {
     background-color: $color-white-supporting;
-    border: 4px solid #8200D1;
+    border: 4px solid $color-violet-primary;
     border-radius: 4px;
-    box-shadow: 0 0 0 4px #F0F05A;
+    box-shadow: 0 0 0 4px $color-yellow-secondary;
     outline: none;
   }
 

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "jquery": "~1.11.2",
     "jquery-ui": "~1.11.2",
     "bootstrap": "~3.3.6",
-    "accessible.media.player": "git://github.com/alphagov/Accessible-Media-Player.git#master",
+    "accessible.media.player": "https://github.com/alphagov/Accessible-Media-Player.git",
     "handlebars": "~4.0.5"
   },
   "resolutions": {


### PR DESCRIPTION
Safari doesn't support rounding an outline with `border-radius`. This replaces the outline on inputs with
a shadow.

[Original ticket](https://dev.azure.com.mcas.ms/moneyandpensionsservice/Digital%20Experience%20Platform%20-%20AEM/_boards/board/t/Team%201%20(Core%20Capability)/Stories/?workitem=4254)

## Chrome (latest)

![image](https://user-images.githubusercontent.com/363618/158598746-48c23855-9667-46a2-ac01-0ee119166aa8.png)


## Safari 15

![image](https://user-images.githubusercontent.com/363618/158598512-d068277d-706e-4cb8-9820-229830e8cd2c.png)

## Firefox (latest)

![image](https://user-images.githubusercontent.com/363618/158598688-641d55c6-f090-475f-bcc1-def09cba909c.png)

