### PR TITLE
Fix input overflow issue on Safari

### DIFF
--- a/app/assets/stylesheets/base/_forms.scss
+++ b/app/assets/stylesheets/base/_forms.scss
@@ -13,6 +13,7 @@ input[name="slider"] {
   font-size: 16px;
   border: 1px solid $color-grey-secondary;
   border-radius: 4px;
+  width: 80%;
 
   // outlines
   &:focus {


### PR DESCRIPTION
In Safari at 320px the input element was a bit too wide, and made
things look strange.

![image](https://user-images.githubusercontent.com/363618/160641001-f3af8dee-457d-450b-8d91-40dd7ee67e45.png)
