### PR TITLE
Ensure targets are added to links

### DIFF
--- a/content/pension_type_tool/defined_contribution.cy.md
+++ b/content/pension_type_tool/defined_contribution.cy.md
@@ -17,6 +17,6 @@ Gallwch drefnu apwyntiad Pension Wise am ddim i siarad am eich opsiynau ar gyfer
 
 [Trefnu apwyntaid am ddim]({::money_helper_url path="pensions-and-retirement/pension-wise/book-a-free-pension-wise-appointment" locale="cy"/}){: .button .button--primary target="_parent"}
 
-^Gallwch hefyd [wirio pensiwn arall]({::money_helper_url path="pensions-and-retirement/pension-wise/find-out-your-pension-type" locale="cy"/}){: target="_parent"} neu [edrych drwy eich opsiynau pensiwn]({::money_helper_url path="pensions-and-retirement/pension-wise/explore-your-pension-options" locale="cy"/}){: target="_parent"}.^
+Gallwch hefyd [wirio pensiwn arall]({::money_helper_url path="pensions-and-retirement/pension-wise/find-out-your-pension-type" locale="cy"/}){: target="_parent"} neu [edrych drwy eich opsiynau pensiwn]({::money_helper_url path="pensions-and-retirement/pension-wise/explore-your-pension-options" locale="cy"/}){: target="_parent"}.
 
 [Rhowch eich adborth i ni](http://research.pensionwise.gov.uk/s/PTTfeedback/)

--- a/content/pension_type_tool/defined_contribution.en.md
+++ b/content/pension_type_tool/defined_contribution.en.md
@@ -17,6 +17,6 @@ You can book a free Pension Wise appointment to talk about your options for taki
 
 [Book a free appointment]({::money_helper_url path="pensions-and-retirement/pension-wise/book-a-free-pension-wise-appointment" locale="en"/}){: .button .button--primary target="_parent"}
 
-^You can also [check another pension]({::money_helper_url path="pensions-and-retirement/pension-wise/find-out-your-pension-type" locale="en"/}){: target="_parent"} or [explore your pension options]({::money_helper_url path="pensions-and-retirement/pension-wise/explore-your-pension-options" locale="en"/}){: target="_parent"}.^
+You can also [check another pension]({::money_helper_url path="pensions-and-retirement/pension-wise/find-out-your-pension-type" locale="en"/}){: target="_parent"} or [explore your pension options]({::money_helper_url path="pensions-and-retirement/pension-wise/explore-your-pension-options" locale="en"/}){: target="_parent"}.
 
 {::webchat /}

--- a/content/pension_type_tool/might_defined_contribution.cy.md
+++ b/content/pension_type_tool/might_defined_contribution.cy.md
@@ -17,4 +17,4 @@ Gallwch drefnu apwyntiad Pension Wise am ddim i siarad am eich opsiynau ar gyfer
 
 [Trefnu apwyntaid am ddim]({::money_helper_url path="pensions-and-retirement/pension-wise/book-a-free-pension-wise-appointment" locale="cy"/}){: .button .button--primary target="_parent"}
 
-^Gallwch hefyd [wirio pensiwn arall]({::money_helper_url path="pensions-and-retirement/pension-wise/find-out-your-pension-type" locale="cy"/}){: target="_parent"} neu [edrych drwy eich opsiynau pensiwn]({::money_helper_url path="pensions-and-retirement/pension-wise/explore-your-pension-options" locale="cy"/}){: target="_parent"}.^
+Gallwch hefyd [wirio pensiwn arall]({::money_helper_url path="pensions-and-retirement/pension-wise/find-out-your-pension-type" locale="cy"/}){: target="_parent"} neu [edrych drwy eich opsiynau pensiwn]({::money_helper_url path="pensions-and-retirement/pension-wise/explore-your-pension-options" locale="cy"/}){: target="_parent"}.

--- a/content/pension_type_tool/might_defined_contribution.en.md
+++ b/content/pension_type_tool/might_defined_contribution.en.md
@@ -17,6 +17,6 @@ You can book a free Pension Wise appointment to talk about your options for taki
 
 [Book a free appointment]({::money_helper_url path="pensions-and-retirement/pension-wise/book-a-free-pension-wise-appointment" locale="en"/}){: .button .button--primary target="_parent"}
 
-^You can also [check another pension]({::money_helper_url path="pensions-and-retirement/pension-wise/find-out-your-pension-type" locale="en"/}){: target="_parent"} or [explore your pension options]({::money_helper_url path="pensions-and-retirement/pension-wise/explore-your-pension-options" locale="en"/}){: target="_parent"}.^
+You can also [check another pension]({::money_helper_url path="pensions-and-retirement/pension-wise/find-out-your-pension-type" locale="en"/}){: target="_parent"} or [explore your pension options]({::money_helper_url path="pensions-and-retirement/pension-wise/explore-your-pension-options" locale="en"/}){: target="_parent"}.
 
 {::webchat /}

--- a/content/pension_type_tool/most_cases_defined_benefit.cy.md
+++ b/content/pension_type_tool/most_cases_defined_benefit.cy.md
@@ -13,4 +13,4 @@ Dim ond ar bensiynau cyfraniadau wed’u diffinio y mae Pension Wise yn rhoi arw
 
 Gweler ein canllaw ar [opsiynau buddsoddi pensiwn]({::money_helper_url path="pensions-and-retirement/building-your-retirement-pot/pension-investment-options-an-overview" locale="cy"/}){: target="_parent"} a [Phensiwn y Wladwriaeth]({::money_helper_url path="pensions-and-retirement/state-pension.html" locale="cy"/}){: target="_parent"}.
 
-^Os oes gennych fwy nag un pensiwn, efallai bod gennych bensiwn cyfraniadau wedi’u diffinio hefyd – [gwirio pensiwn arall]({::money_helper_url path="pensions-and-retirement/pension-wise/find-out-your-pension-type" locale="cy"/}){: target="_parent"}.^
+Os oes gennych fwy nag un pensiwn, efallai bod gennych bensiwn cyfraniadau wedi’u diffinio hefyd – [gwirio pensiwn arall]({::money_helper_url path="pensions-and-retirement/pension-wise/find-out-your-pension-type" locale="cy"/}){: target="_parent"}.

--- a/content/pension_type_tool/most_cases_defined_benefit.en.md
+++ b/content/pension_type_tool/most_cases_defined_benefit.en.md
@@ -13,6 +13,6 @@ Pension Wise only gives guidance on defined contribution pensions.
 
 See our guidance on [pension investment options]({::money_helper_url path="pensions-and-retirement/building-your-retirement-pot/pension-investment-options-an-overview" locale="en"/}){: target="_parent"} and the [State Pension]({::money_helper_url path="pensions-and-retirement/state-pension.html" locale="en"/}){: target="_parent"}.
 
-^If you have more than one pension, you may also have a defined contribution pension – [check another pension]({::money_helper_url path="pensions-and-retirement/pension-wise/find-out-your-pension-type" locale="en"/}){: target="_parent"}.^
+If you have more than one pension, you may also have a defined contribution pension – [check another pension]({::money_helper_url path="pensions-and-retirement/pension-wise/find-out-your-pension-type" locale="en"/}){:target="_parent"}.
 
 {::webchat /}

--- a/content/pension_type_tool/most_cases_defined_contribution.cy.md
+++ b/content/pension_type_tool/most_cases_defined_contribution.cy.md
@@ -17,4 +17,4 @@ Gallwch drefnu apwyntiad Pension Wise am ddim i siarad am eich opsiynau ar gyfer
 
 [Trefnu apwyntaid am ddim]({::money_helper_url path="pensions-and-retirement/pension-wise/book-a-free-pension-wise-appointment" locale="cy"/}){: .button .button--primary target="_parent"}
 
-^Gallwch hefyd [wirio pensiwn arall]({::money_helper_url path="pensions-and-retirement/pension-wise/find-out-your-pension-type" locale="cy"/}){: target="_parent"} neu [edrych drwy eich opsiynau pensiwn]({::money_helper_url path="pensions-and-retirement/pension-wise/explore-your-pension-options" locale="cy"/}){: target="_parent"}.^
+Gallwch hefyd [wirio pensiwn arall]({::money_helper_url path="pensions-and-retirement/pension-wise/find-out-your-pension-type" locale="cy"/}){: target="_parent"} neu [edrych drwy eich opsiynau pensiwn]({::money_helper_url path="pensions-and-retirement/pension-wise/explore-your-pension-options" locale="cy"/}){: target="_parent"}.

--- a/content/pension_type_tool/most_cases_defined_contribution.en.md
+++ b/content/pension_type_tool/most_cases_defined_contribution.en.md
@@ -17,6 +17,6 @@ You can book a free Pension Wise appointment to talk about your options for taki
 
 [Book a free appointment]({::money_helper_url path="pensions-and-retirement/pension-wise/book-a-free-pension-wise-appointment" locale="en"/}){: .button .button--primary target="_parent"}
 
-^You can also [check another pension]({::money_helper_url path="pensions-and-retirement/pension-wise/find-out-your-pension-type" locale="en"/}){: target="_parent"} or [explore your pension options]({::money_helper_url path="pensions-and-retirement/pension-wise/explore-your-pension-options" locale="en"/}){: target="_parent"}.^
+You can also [check another pension]({::money_helper_url path="pensions-and-retirement/pension-wise/find-out-your-pension-type" locale="en"/}){: target="_parent"} or [explore your pension options]({::money_helper_url path="pensions-and-retirement/pension-wise/explore-your-pension-options" locale="en"/}){: target="_parent"}.
 
 {::webchat /}


### PR DESCRIPTION
When they're embedded in the callout markup the inline attributes are
dropped from the links. This is the most simple fix for now.