### PR TITLE
Revert nudge contact numbers

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -4,8 +4,6 @@ module ApplicationHelper
   def contact_number(appointment)
     if appointment.due_diligence?
       '0800 015 4906'
-    elsif appointment.embedded?
-      '0800 100 166'
     else
       '0800 138 3944'
     end

--- a/app/views/nudge_appointments/_step_3.html.erb
+++ b/app/views/nudge_appointments/_step_3.html.erb
@@ -262,6 +262,6 @@
   <p><%= link_to('Change date/time', new_nudge_appointment_path) %></p>
 
   <h5 class="slot-picker-header slot-picker-header--need-help t-need-help-banner">Customer needs help? Need printed confirmation letter?</h5>
-  <p>Ask them to phone <strong>0800 100 166</strong> to speak to someone who can help book their free appointment.</p>
+  <p>Ask them to phone <strong>0800 138 3944</strong> to speak to someone who can help book their free appointment.</p>
   <p>Call between 8am to 8pm, Monday to Friday.</p>
 </div>

--- a/app/views/telephone_appointments/nudge.html.erb
+++ b/app/views/telephone_appointments/nudge.html.erb
@@ -15,7 +15,7 @@
       <li>tell you what your next steps are</li>
     </ul>
     <p><a class="button button--primary t-start" href="/en/telephone-appointments/new?nudged=true&embedded=true" role="button">Book your free appointment online</a></p>
-    <p>You can also book by calling <a href="tel:0800100166"><strong>0800 100 166</strong></a> free or, if you are overseas, by calling <a href="tel:+441633745828"><strong>+44 1633 745 828</strong></a>*.</p>
+    <p>You can also book by calling <a href="tel:08001383944"><strong>0800 138 3944</strong></a> free or, if you are overseas, by calling <a href="tel:+441633745828"><strong>+44 1633 745 828</strong></a>*.</p>
     <p>Lines are open Monday to Friday, 8am to 8pm UK time.</p>
     <p>*International call charges may apply.</p>
   </div>


### PR DESCRIPTION
The IVR isn't ready for these yet so we have to temporarily switch back
to the older contact numbers until they are.