### PR TITLE
Improve right-hand panel information

### DIFF
--- a/app/views/nudge_appointments/_step_3.html.erb
+++ b/app/views/nudge_appointments/_step_3.html.erb
@@ -261,7 +261,7 @@
 
   <p><%= link_to('Change date/time', new_nudge_appointment_path) %></p>
 
-  <h5 class="slot-picker-header slot-picker-header--need-help t-need-help-banner">Customer needs help? Need printed confirmation letter?</h5>
+  <h5 class="slot-picker-header slot-picker-header--need-help t-need-help-banner">If the customer is attending on behalf of family/friend or needs postal confirmation, a Welsh language appointment or British Sign Language interpreter</h5>
   <p>Ask them to phone <strong>0800 100 166</strong> to speak to someone who can help book their free appointment.</p>
   <p>Call between 8am to 8pm, Monday to Friday.</p>
 </div>


### PR DESCRIPTION
Agents have expressed some confusion about when they ought to signpost
the customer off for a third-party or other type of booking.