### PR TITLE
Ensure PSG customers remain in-channel

### DIFF
--- a/app/views/telephone_appointments/_step_3.html.erb
+++ b/app/views/telephone_appointments/_step_3.html.erb
@@ -272,7 +272,7 @@
     <p class="slot-picker-confirmed-date__text"><%= l(@telephone_appointment.start_at, format: :govuk_time) %>, 45 to 60 minutes</p>
   </div>
 
-  <p><%= link_to('Change date/time', new_telephone_appointment_path) %></p>
+  <p><%= link_to('Change date/time', new_telephone_appointment_path(schedule_type: @telephone_appointment.schedule_type), class: 't-change-date-time') %></p>
 
   <% unless @telephone_appointment.due_diligence? %>
     <h5 class="slot-picker-header slot-picker-header--need-help t-need-help-banner">Need help?<% unless @telephone_appointment.embedded? %>Attending appointment on behalf of a family member or friend?<% end %></h5>

--- a/features/pages/new_telephone_appointment.rb
+++ b/features/pages/new_telephone_appointment.rb
@@ -18,6 +18,7 @@ module Pages
     element :smarter_signposting_banner, '.t-smarter-signposted-banner'
     element :cancel_smarter_signposting, '.t-cancel-smarter-signposting'
     element :lloyds_signposting_banner, '.t-lloyds-signposted-banner'
+    element :change_date_time, '.t-change-date-time'
 
     element :dc_pot_confirmed_yes, '.t-dc-pot-confirmed-yes'
     element :dc_pot_confirmed_no, '.t-dc-pot-confirmed-no'

--- a/spec/features/due_diligence_booking_spec.rb
+++ b/spec/features/due_diligence_booking_spec.rb
@@ -26,6 +26,8 @@ RSpec.feature 'Due diligence bookings' do
     expect(@page.hidden_dc_pot_confirmed.value).to eq('not-sure')
     expect(@page.hidden_gdpr_consent.value).to eq('no')
     expect(@page.hidden_where_you_heard.value).to eq('2') # pension provider
+    # ensure links back to rebook are the correct schedule type
+    expect(@page.change_date_time[:href]).to end_with('?schedule_type=due_diligence')
 
     @page.first_name.set('Rick')
     @page.last_name.set('Sanchez')


### PR DESCRIPTION
When opting to change a date and time the customers would end up
out-of-channel and book a regular telephone appointment instead. This
change ensures the correct flag is sent.