### PR TITLE
Make GDPR consent mandatory

### DIFF
--- a/app/forms/booking_request_form.rb
+++ b/app/forms/booking_request_form.rb
@@ -21,6 +21,7 @@ class BookingRequestForm # rubocop:disable ClassLength
     step_two.validates :additional_info, length: { maximum: 160 }, allow_blank: true
     step_two.validates :additional_info, presence: true, if: :accessibility_requirements?
     step_two.validates :where_you_heard, inclusion: { in: WhereYouHeard::OPTIONS.keys }
+    step_two.validates :gdpr_consent, inclusion: { in: %w(yes no) }
   end
 
   def initialize(location_id, opts)

--- a/app/models/telephone_appointment.rb
+++ b/app/models/telephone_appointment.rb
@@ -44,6 +44,7 @@ class TelephoneAppointment # rubocop:disable ClassLength
   validates :notes, presence: true, if: :accessibility_requirements?
   validates :accessibility_requirements, inclusion: { in: %w(0 1) }
   validates :referrer, presence: true, if: :due_diligence?
+  validates :gdpr_consent, inclusion: { in: %w(yes no) }
 
   def due_diligence?
     schedule_type == 'due_diligence'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -261,6 +261,8 @@ en:
               inclusion: select an option
             notes:
               blank: describe the accessibility adjustments you require
+            gdpr_consent:
+              inclusion: select an option
         nudge_appointment:
           attributes:
             first_name:
@@ -315,6 +317,7 @@ en:
         where_you_heard: Where did you first hear of Pension Wise
         notes: Additional information
         referrer: Which pension provider referred you for Pension Safeguarding Guidance
+        gdpr_consent: Customer research consent
       booking_request_form:
         primary_slot: Slot 1
         secondary_slot: Slot 2

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -181,6 +181,8 @@ en:
               inclusion: select an option
             additional_info:
               blank: describe the accessibility adjustments you require
+            gdpr_consent:
+              inclusion: select an option
         bsl/booking_request:
           attributes:
             first_name:
@@ -327,6 +329,7 @@ en:
         opt_in: Terms and conditions
         telephone_number: Phone number
         where_you_heard: Where did you first hear of Pension Wise
+        gdpr_consent: Customer research consent
       appointment_summary:
         appointment_type: Your age
   activerecord:

--- a/spec/forms/booking_request_form_spec.rb
+++ b/spec/forms/booking_request_form_spec.rb
@@ -117,6 +117,11 @@ RSpec.describe BookingRequestForm do
         expect(subject).not_to be_step_two_valid
       end
 
+      it 'requires `gdpr_consent`' do
+        subject.gdpr_consent = nil
+        expect(subject).not_to be_step_two_valid
+      end
+
       context 'when accessibility requirements are specified' do
         it 'requires additional info' do
           subject.accessibility_requirements = '1'

--- a/spec/models/telephone_appointment_spec.rb
+++ b/spec/models/telephone_appointment_spec.rb
@@ -153,6 +153,11 @@ RSpec.describe TelephoneAppointment, type: :model do
       end
     end
 
+    it 'validates inclusion of GDPR consent' do
+      subject.gdpr_consent = nil
+      expect(subject).to be_invalid
+    end
+
     it 'validates presence of start_at' do
       subject.start_at = nil
       expect(subject).to_not be_valid


### PR DESCRIPTION
Ensures this answer is mandatory on both the phone and face-to-face customer
booking journeys.