### PR TITLE
Alter research consent wording

### DIFF
--- a/config/locales/pension_summaries.cy.yml
+++ b/config/locales/pension_summaries.cy.yml
@@ -13,8 +13,8 @@ cy:
       title: Yn gyntaf - ychydig amdanoch chi
       errors:
         heading: Mae'n ddrwg gennyf, digwyddodd un neu fwy o wallau
-        description: Os ydych chi wedi rhoi caniatâd i Ipsos MORI gysylltu â chi yna llenwch eich enw a chyfeiriad e-bost dilys. Os nad ydych am gysylltu â nhw, yna tynnwch eich enw a / neu gyfeiriad e-bost oddi ar y ffurflen.
-      consent_given: Rwy'n rhoi fy nghaniatâd i rannu fy manylion cyswllt â Ipsos MORI at y diben hwn.
+        description: Os gwnaethoch roi caniatâd i gysylltu â ni gan ein partneriaid ymchwil dibynadwy yna llenwch eich enw a chyfeiriad e-bost dilys. Os nad ydych am gael cysylltiad,  dilëwch eich enw a/neu’ch cyfeiriad e-bost o'r ffurflen.
+        consent_given: Rhoddaf fy nghaniatâd i'm manylion cyswllt gael eu rhannu gyda'n partneriaid ymchwil dibynadwy at y diben hwn.
       age:
         legend: Pa un o'r grwpiau oedran hyn ydych chi?
         "Under 50": "Dan 50 oed"
@@ -36,7 +36,7 @@ cy:
       ipsos_statement:
         html: |
           <h2>Helpwch ni i wella ein gwasanaeth</h2>
-          <p>Rydym yn cynnal ymchwil cwsmeriaid drwy ein partner ymchwil annibynnol (Ipsos MORI). Rydym yn gofyn i gynrychiolaeth o gwsmeriaid am eu profiad o ddefnyddio Pension Wise i wella ein gwasanaethau. Bydd unrhyw fanylion a ddarparwch ond yn cael eu defnyddio i’r diben hwn.</p>
+          <p>A yw'n IAWN os ydym yn rhannu eich manylion cyswllt â'n partneriaid ymchwil dibynadwy? Gyda'ch caniatâd, bydd Pension Wise neu ein partneriaid ymchwil, yn cysylltu â chi i ofyn a hoffech roi adborth a gallwch benderfynu wedyn os ydych am gymryd rhan. Mae eich adborth yn ein helpu i wella'r gwasanaeth.</p>
       privacy_notice:
         html: |
           <h2 id="hysbysiad-preifatrwydd">Hysbysiad preifatrwydd</h2>

--- a/config/locales/pension_summaries.en.yml
+++ b/config/locales/pension_summaries.en.yml
@@ -13,8 +13,8 @@ en:
       title: Firstly – a bit about you
       errors:
         heading: Sorry, one or more errors occurred
-        description: If you have given consent to be contacted by Ipsos MORI then please fill out your name and a valid email address. If you do not want to be contacted then please remove your name and/or email address from the form.
-      consent_given: I give my consent for my contact details to be shared with Ipsos MORI for this purpose.
+        description: If you have given consent to be contacted by our trusted research partners then please fill out your name and a valid email address. If you do not want to be contacted then please remove your name and/or email address from the form.
+      consent_given: I give my consent for my contact details to be shared with our trusted research partners for this purpose.
       age:
         legend: Which of these age groups are you in?
         "Under 50": "Under 50"
@@ -40,7 +40,7 @@ en:
       ipsos_statement:
         html: |
           <h2>Help us improve our service</h2>
-          <p>We carry out customer research via our independent research partner (Ipsos MORI). We ask a sample of customers about their experience of using Pension Wise to improve our services. Any details you provide will be used solely for this purpose.</p>
+          <p>Is it OK if we share your contact details with our trusted research partners? With your consent, Pension Wise or our research partners, may contact you to ask if you would like to provide feedback and you can decide then if you want to take part. Your feedback helps us improve the service.</p>
       privacy_notice:
         html: |
           <h2>Privacy notice</h2>

--- a/spec/features/pension_summary_spec.rb
+++ b/spec/features/pension_summary_spec.rb
@@ -171,7 +171,7 @@ def and_i_choose_to_explore_my_pension_options
 end
 
 def and_i_answer_the_questions_about_me
-  check('I give my consent for my contact details to be shared with Ipsos MORI for this purpose')
+  check('I give my consent for my contact details to be shared with our trusted research partners for this purpose.')
   fill_in('Name', with: 'Jim Bob')
   fill_in('Email', with: 'jim@bob.com')
   choose('Male')


### PR DESCRIPTION
This is to remove the specific mention of IPSOS, as this journey will gather user consent for research to be conducted by other trusted partners.