### PR TITLE
Blanket `noindex` across the full site

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,8 @@ before_script:
 - "(cd .downloads; [ -d prince-9.0r5-linux-amd64-static ] || curl -s https://www.princexml.com/download/prince-9.0r5-linux-amd64-static.tar.gz | tar xzf -)"
 - echo $PWD | ./.downloads/prince-9.0r5-linux-amd64-static/install.sh
 - npm install
-- npx @puppeteer/browsers install chromedriver@119.0.6045.105 --path $PWD/bin
-- export PATH=$PWD/bin/chromedriver/linux-119.0.6045.105/chromedriver-linux64:$PATH
+- npx @puppeteer/browsers install chromedriver@121.0.6167.85 --path $PWD/bin
+- export PATH=$PWD/bin/chromedriver/linux-121.0.6167.85/chromedriver-linux64:$PATH
 - bundle exec rake db:create db:migrate RAILS_ENV=test
 notifications:
   slack:

--- a/app/decorators/cached_guide_decorator.rb
+++ b/app/decorators/cached_guide_decorator.rb
@@ -9,7 +9,7 @@ class CachedGuideDecorator < SimpleDelegator
     self.expires_in = expires_in
   end
 
-  %i[title content canonical noindex?].each do |method|
+  %i[title content canonical].each do |method|
     define_method(method) do
       cache_key = [object.id, object.locale, method].join('-')
       cache.fetch(cache_key, expires_in: expires_in) { super() }

--- a/app/decorators/guide_decorator.rb
+++ b/app/decorators/guide_decorator.rb
@@ -31,10 +31,6 @@ class GuideDecorator < SimpleDelegator
 
   delegate :canonical, to: :metadata
 
-  def noindex?
-    metadata.noindex == true
-  end
-
   def self.for(guide)
     case guide.content_type
     when :govspeak then GovspeakGuideDecorator.new(guide)

--- a/app/views/appointment_summaries/new.html.erb
+++ b/app/views/appointment_summaries/new.html.erb
@@ -1,7 +1,6 @@
 <% content_for(:page_title, t('service.title', page_title: 'How to view your appointment summary')) %>
 <% content_for(:meta_description, 'Choose the information you want in the summary of your Pension Wise appointment') %>
 <% content_for(:canonical, "https://www.moneyhelper.org.uk/en/pensions-and-retirement/pension-wise/view-your-appointment-summary") %>
-<% content_for(:noindex, true) %>
 <% content_for(:page_name, 'Appointment Summary') %>
 
 <%= form_for @appointment_summary, url: appointment_summaries_path, html: { class: 't-appointment-summary-generator' } do |f| %>

--- a/app/views/bsl/bsl_booking_requests/new.html.erb
+++ b/app/views/bsl/bsl_booking_requests/new.html.erb
@@ -1,6 +1,5 @@
 <% content_for(:page_title, t('service.title', page_title: 'British Sign Language Bookings')) %>
 <% content_for(:canonical, "https://www.moneyhelper.org.uk/#{locale}/pensions-and-retirement/pension-wise/book-a-free-pension-wise-appointment/request-a-free-british-sign-language-appointment") %>
-<% content_for(:noindex, true) %>
 <% content_for(:page_name, 'BSL Booking Request') %>
 
 <div class="l-grid-row">

--- a/app/views/contact/new.html.erb
+++ b/app/views/contact/new.html.erb
@@ -1,5 +1,4 @@
 <% content_for(:canonical, "https://www.moneyhelper.org.uk/#{locale}/contact-us/complaints-about-pension-wise") %>
-<% content_for(:noindex, true) %>
 
 <div class="l-column-full">
   <% if params[:sent] %>

--- a/app/views/guides/show.html.erb
+++ b/app/views/guides/show.html.erb
@@ -4,9 +4,6 @@
 <% if @guide.canonical.present? %>
   <% content_for(:canonical, @guide.canonical) %>
 <% end %>
-<% if @guide.noindex? %>
-  <% content_for(:noindex, @guide.noindex?) %>
-<% end %>
 
 <div class="l-column-full">
 <%= render 'option' if @guide.option? %>

--- a/app/views/layouts/govuk_template.html.erb
+++ b/app/views/layouts/govuk_template.html.erb
@@ -27,9 +27,7 @@
     <% if content_for?(:canonical) %>
       <link rel="canonical" href="<%= yield(:canonical) %>" />
     <% end %>
-    <% if content_for?(:noindex) || Rails.env.staging? %>
-      <meta name="robots" content="noindex,nofollow">
-    <% end %>
+    <meta name="robots" content="noindex,nofollow">
 
     <%# the colour used for theme-color is the standard palette $black from
         https://github.com/alphagov/govuk_frontend_toolkit/blob/master/stylesheets/colours/_palette.scss %>

--- a/app/views/locations/show.html.erb
+++ b/app/views/locations/show.html.erb
@@ -1,7 +1,6 @@
 <% content_for(:page_title, t('service.title', page_title: @location.name)) %>
 <% content_for(:meta_description, "Find out the address, booking hours and how to book a Pension Wise appointment at #{@location.name} Citizens Advice") %>
 <% content_for(:canonical, 'https://www.moneyhelper.org.uk/en/pensions-and-retirement/pension-wise/book-a-free-pension-wise-appointment') %>
-<% content_for(:noindex, true) %>
 <% content_for(:page_name, 'F2F Location Details') %>
 <% content_for(:tool_step, '2') %>
 

--- a/app/views/pension_summaries/about_you.html.erb
+++ b/app/views/pension_summaries/about_you.html.erb
@@ -1,6 +1,5 @@
 <% content_for(:page_title, t('service.title', page_title: t('.title'))) %>
 <% content_for(:canonical, "https://www.moneyhelper.org.uk/#{locale}/pensions-and-retirement/pension-wise/explore-your-pension-options") %>
-<% content_for(:noindex, true) %>
 
 <div class="l-column-two-thirds">
   <%= @guide.content %>

--- a/app/views/pension_summaries/step_one.html.erb
+++ b/app/views/pension_summaries/step_one.html.erb
@@ -1,6 +1,5 @@
 <% content_for(:page_title, t('service.title', page_title: t('.title'))) %>
 <% content_for(:canonical, "https://www.moneyhelper.org.uk/#{locale}/pensions-and-retirement/pension-wise/explore-your-pension-options") %>
-<% content_for(:noindex, true) %>
 
 <div class="l-column-two-thirds">
   <%= @guide.content %>

--- a/app/views/telephone_appointments/new.html.erb
+++ b/app/views/telephone_appointments/new.html.erb
@@ -1,5 +1,4 @@
 <% content_for(:canonical, canonical_url) %>
-<% content_for(:noindex, true) %>
 <% content_for(:page_name, 'Telephone Booking') %>
 
 <div class="l-column-full">

--- a/app/views/welsh_language/booking_requests/new.html.erb
+++ b/app/views/welsh_language/booking_requests/new.html.erb
@@ -1,6 +1,5 @@
 <% content_for(:page_title, t('service.title', page_title: 'Gofynnwch am apwyntiad Pension Wise am ddim')) %>
 <% content_for(:canonical, "https://www.moneyhelper.org.uk/cy/pensions-and-retirement/pension-wise/book-a-free-pension-wise-appointment") %>
-<% content_for(:noindex, true) %>
 <% content_for(:page_name, 'Welsh Language Booking Request') %>
 <% content_for(:tool_step, '2') %>
 

--- a/content/adjustable_income.cy.md
+++ b/content/adjustable_income.cy.md
@@ -3,7 +3,6 @@ label: Cael incwm addasadwy
 description: Gallwch ddewis cymryd incwm neu gyfandaliadau o’ch cronfa bensiwn, trwy ddefnyddio trefniant tynnu allan hyblyg. Trefnwch apwyntiad Pension Wise heddiw.
 tags:
   - embeddable
-noindex: true
 canonical: https://www.moneyhelper.org.uk/cy/pensions-and-retirement/taking-your-pension/what-is-flexible-retirement-income-pension-drawdown
 ---
 

--- a/content/adjustable_income.en.md
+++ b/content/adjustable_income.en.md
@@ -3,7 +3,6 @@ label: Get an adjustable income
 description: You can choose to take an income or lump sums from your pension pot, by using a flexi-access drawdown arrangement. Book a Pension Wise appointment today.
 tags:
   - embeddable
-noindex: true
 canonical: https://www.moneyhelper.org.uk/en/pensions-and-retirement/taking-your-pension/what-is-flexible-retirement-income-pension-drawdown
 ---
 

--- a/content/guaranteed_income.cy.md
+++ b/content/guaranteed_income.cy.md
@@ -3,7 +3,6 @@ label: Cael incwm gwarantedig (blwydd-dal)
 description: Darganfyddwch sut i ddefnyddio'ch cronfa bensiwn i brynu incwm gwarantedig. Trefnwch apwyntiad Pension Wise heddiw.
 tags:
   - embeddable
-noindex: true
 canonical: https://www.moneyhelper.org.uk/cy/pensions-and-retirement/taking-your-pension/guaranteed-retirement-income-annuities-explained
 ---
 

--- a/content/guaranteed_income.en.md
+++ b/content/guaranteed_income.en.md
@@ -3,7 +3,6 @@ label: Get a guaranteed income (annuity)
 description: Find out how to use your pension pot to buy a guaranteed income. Book a Pension Wise appointment today.
 tags:
   - embeddable
-noindex: true
 canonical: https://www.moneyhelper.org.uk/en/pensions-and-retirement/taking-your-pension/guaranteed-retirement-income-annuities-explained
 ---
 

--- a/content/leave_pot_untouched.cy.md
+++ b/content/leave_pot_untouched.cy.md
@@ -3,7 +3,6 @@ label: Gadael y cyfan o’ch cronfa heb ei gyffwrdd
 description: Gallwch chi benderfynu pryd i gymryd arian allan o’ch cronfa bensiwn.
 tags:
   - embeddable
-noindex: true
 canonical: https://www.moneyhelper.org.uk/cy/pensions-and-retirement/taking-your-pension/retiring-later-or-delaying-taking-your-pension-pot
 ---
 

--- a/content/leave_pot_untouched.en.md
+++ b/content/leave_pot_untouched.en.md
@@ -3,7 +3,6 @@ label: Leave your pot untouched
 description: You can decide when you take money from your pension pot.
 tags:
   - embeddable
-noindex: true
 canonical: https://www.moneyhelper.org.uk/en/pensions-and-retirement/taking-your-pension/retiring-later-or-delaying-taking-your-pension-pot
 ---
 

--- a/content/pension_type_tool/question_1.cy.md
+++ b/content/pension_type_tool/question_1.cy.md
@@ -7,7 +7,6 @@ answers:
 tags:
   - appointments
   - embeddable
-noindex: true
 canonical:  https://www.moneyhelper.org.uk/cy/pensions-and-retirement/pension-wise/find-out-your-pension-type
 ---
 

--- a/content/pension_type_tool/question_1.en.md
+++ b/content/pension_type_tool/question_1.en.md
@@ -7,7 +7,6 @@ answers:
 tags:
   - appointments
   - embeddable
-noindex: true
 canonical:  https://www.moneyhelper.org.uk/en/pensions-and-retirement/pension-wise/find-out-your-pension-type
 ---
 

--- a/content/take_cash_in_chunks.cy.md
+++ b/content/take_cash_in_chunks.cy.md
@@ -3,7 +3,6 @@ label: Cymryd arian allan fesul tipyn
 description: Gallwch gymryd symiau llai o arian allan o’ch cronfa bensiwn hyd nes ei fod yn rhedeg allan. Darganfyddwch fwy am yr opsiwn hwn a chysylltu a Pension Wise heddiw.
 tags:
   - embeddable
-noindex: true
 canonical: https://www.moneyhelper.org.uk/cy/pensions-and-retirement/taking-your-pension/taking-your-pension-as-a-number-of-lump-sums
 ---
 

--- a/content/take_cash_in_chunks.en.md
+++ b/content/take_cash_in_chunks.en.md
@@ -3,7 +3,6 @@ label: Take cash in chunks
 description: You can take smaller chunks of cash from your pension pot until it runs out. Learn more about this option and contact Pension Wise today.
 tags:
   - embeddable
-noindex: true
 canonical: https://www.moneyhelper.org.uk/en/pensions-and-retirement/taking-your-pension/taking-your-pension-as-a-number-of-lump-sums
 ---
 

--- a/content/take_whole_pot.cy.md
+++ b/content/take_whole_pot.cy.md
@@ -3,7 +3,6 @@ label: Cymryd eich cronfa bensiwn cyfan
 description: Defnyddiwch ein cyfrifiannell i amcangyfrif faint o dreth y byddwch yn ei dalu os byddwch yn cymryd arian allan o'ch cronfa bensiwn. Trefnwch apwyntiad Pension Wise heddiw.
 tags:
   - embeddable
-noindex: true
 canonical: https://www.moneyhelper.org.uk/cy/pensions-and-retirement/taking-your-pension/taking-your-whole-pension-in-one-go
 ---
 

--- a/content/take_whole_pot.en.md
+++ b/content/take_whole_pot.en.md
@@ -3,7 +3,6 @@ label: Take your whole pot
 description: Use our calculator to estimate how much tax you'll pay if you cash in your pension pot. Book a Pension Wise appointment today.
 tags:
   - embeddable
-noindex: true
 canonical: https://www.moneyhelper.org.uk/en/pensions-and-retirement/taking-your-pension/taking-your-whole-pension-in-one-go
 ---
 


### PR DESCRIPTION
This was a mixture of configuration previously and had proved ineffective in some places. We know we can and should `noindex` the whole site regardless, since the only context that content is displayed in is via Money Helper embeds.