### PR TITLE
Rename adobe data layer event

### DIFF
--- a/app/views/layouts/govuk_template.html.erb
+++ b/app/views/layouts/govuk_template.html.erb
@@ -52,7 +52,7 @@
     <script type="text/javascript">
       window.adobeDataLayer ||= [];
       adobeDataLayer.push({
-        "event": "pageLoad",
+        "event": "pageLoadRuby",
         "page": {
           "pageName": "<%= j(content_for(:page_name)) %>",
           "pageTitle": "<%= j(content_for(:page_title)) %>",


### PR DESCRIPTION
This is per a request from the data team to help differentiate the tools.