### PR TITLE
Automatically redact EYO records

### DIFF
--- a/app/domain/pension_summary.rb
+++ b/app/domain/pension_summary.rb
@@ -183,5 +183,11 @@ class PensionSummary < ApplicationRecord
   def email_valid?
     email.to_s =~ EMAIL_REGEX
   end
+
+  def self.for_redaction
+    where
+      .not(name: 'redacted')
+      .where('created_at < ?', 2.years.ago.beginning_of_day)
+  end
 end
 # rubocop:enable Metrics/ClassLength

--- a/lib/tasks/redact.rake
+++ b/lib/tasks/redact.rake
@@ -1,0 +1,15 @@
+namespace :redact do
+  desc 'Redact Pension Summaries older than 2 years'
+  task pension_summaries: :environment do
+    # rubocop:disable Rails/SkipsModelValidations
+    PensionSummary.for_redaction.update_all(
+      gender: 'redacted',
+      name: 'redacted',
+      age: 'redacted',
+      email: 'redacted',
+      country: 'redacted',
+      comments: 'redacted'
+    )
+    # rubocop:enable Rails/SkipsModelValidations
+  end
+end

--- a/spec/factories/pension_summaries.rb
+++ b/spec/factories/pension_summaries.rb
@@ -3,6 +3,12 @@ FactoryBot.define do
     trait :generated do
       generated_at { Time.current }
     end
+
+    trait :with_consent do
+      name { 'Bob' }
+      email { 'bob@example.com' }
+      consent_given { true }
+    end
   end
 
   factory :pension_summary_step_viewing, class: 'PensionSummary::StepViewing' do

--- a/spec/models/pension_summary_spec.rb
+++ b/spec/models/pension_summary_spec.rb
@@ -2,6 +2,17 @@
 RSpec.describe PensionSummary, type: :model do
   subject { FactoryBot.build(:pension_summary) }
 
+  describe '.for_redaction' do
+    it 'returns unredacted records older than 2 years' do
+      included = FactoryBot.create(:pension_summary, :with_consent, created_at: 3.years.ago)
+      # excluded as redacted, newer than 2 years
+      FactoryBot.create(:pension_summary, :with_consent, name: 'redacted', created_at: 3.years.ago)
+      FactoryBot.create(:pension_summary, :with_consent)
+
+      expect(described_class.for_redaction).to match_array([included])
+    end
+  end
+
   describe 'schema' do
     it { is_expected.to have_db_column(:id).of_type(:uuid).with_options(primary: true) }
 


### PR DESCRIPTION
These will be redacted two years after their initial creation.