### PR TITLE
Create an endpoint for Welsh EYO

### DIFF
--- a/app/domain/pension_summary.rb
+++ b/app/domain/pension_summary.rb
@@ -111,6 +111,26 @@ class PensionSummary < ApplicationRecord
     errors.add(:email, :invalid) unless email_valid?
   end
 
+  def self.generate_welsh_digital!(secondary_options) # rubocop:disable Metrics/MethodLength
+    create!(
+      submitted_at: Time.zone.now,
+      generated_at: Time.zone.now,
+      pilot: false,
+      welsh_digital: true,
+      leave_your_pot_untouched: true,
+      get_a_guaranteed_income: true,
+      get_an_adjustable_income: true,
+      take_cash: true,
+      take_whole: true,
+      mix_your_options: true,
+      how_my_pension_affects_my_benefits: secondary_options[:supplementary_benefits],
+      getting_help_with_debt: secondary_options[:supplementary_debt],
+      taking_my_pension_if_im_ill: secondary_options[:supplementary_ill_health],
+      transferring_my_pension_to_another_provider: secondary_options[:supplementary_pension_transfers],
+      final_salary_career_average: secondary_options[:supplementary_defined_benefit_pensions]
+    )
+  end
+
   def generate(attrs, now: Time.current)
     update(attrs.merge(generated_at: now))
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -60,6 +60,7 @@ Rails.application.routes.draw do
         post 'step-one', action: 'save_primary_options'
         post 'step-two', action: 'save_secondary_options'
         post 'your-experience', action: 'save_feedback'
+        post 'welsh-summary', action: 'save_welsh_summary'
       end
 
       scope 'employers/:employer_id', module: :employer, as: :employer, locale: :en do

--- a/db/migrate/20240528161606_add_welsh_digital_to_pension_summaries.rb
+++ b/db/migrate/20240528161606_add_welsh_digital_to_pension_summaries.rb
@@ -1,0 +1,5 @@
+class AddWelshDigitalToPensionSummaries < ActiveRecord::Migration[6.1]
+  def change
+    add_column :pension_summaries, :welsh_digital, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_05_14_152738) do
+ActiveRecord::Schema.define(version: 2024_05_28_161606) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -45,6 +45,7 @@ ActiveRecord::Schema.define(version: 2024_05_14_152738) do
     t.integer "where_you_heard"
     t.datetime "submitted_at"
     t.boolean "final_salary_career_average", default: false, null: false
+    t.boolean "welsh_digital", default: false, null: false
   end
 
   create_table "pension_summary_step_viewings", force: :cascade do |t|

--- a/spec/requests/welsh_language_explore_your_options_download_spec.rb
+++ b/spec/requests/welsh_language_explore_your_options_download_spec.rb
@@ -1,0 +1,34 @@
+RSpec.describe 'Generating a Welsh language EYO document', type: :request do
+  specify 'Successfully generating the document' do
+    post '/cy/explore-your-options/welsh-summary', params: {
+      appointment_summary: {
+        supplementary_benefits: true,
+        supplementary_debt: true,
+        supplementary_ill_health: true,
+        supplementary_defined_benefit_pensions: true,
+        supplementary_pension_transfers: true
+      }
+    }
+
+    @summary = PensionSummary.last
+    expect(@summary).to have_attributes(
+      welsh_digital: true,
+      leave_your_pot_untouched: true,
+      get_a_guaranteed_income: true,
+      get_an_adjustable_income: true,
+      take_cash: true,
+      take_whole: true,
+      mix_your_options: true,
+      how_my_pension_affects_my_benefits: true,
+      getting_help_with_debt: true,
+      taking_my_pension_if_im_ill: true,
+      transferring_my_pension_to_another_provider: true,
+      final_salary_career_average: true
+    )
+
+    expect(response).to be_redirect
+    expect(response.location).to eq(
+      "http://www.example.com/cy/explore-your-options/download?id=#{@summary.id}"
+    )
+  end
+end


### PR DESCRIPTION
This allows the PW digital tool to generate a summary and download the created PDF document. The resultant summary instance is marked specifically as being created by the Welsh PWD tool to aid BI.