### PR TITLE
Add customer cancellation journey

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 sudo: false
 distro: focal
 language: ruby
+addons:
+  chrome: stable
 services:
   - postgresql
 cache:

--- a/app/assets/stylesheets/components/_govuk-box-highlight.scss
+++ b/app/assets/stylesheets/components/_govuk-box-highlight.scss
@@ -10,6 +10,10 @@
   p .heading-medium {
     margin: 15px 0 0;
   }
+
+  &.failure {
+    border: 4px solid $error-red;
+  }
 }
 
 .govuk-box-highlight__header {

--- a/app/assets/stylesheets/money-helper-overrides.scss
+++ b/app/assets/stylesheets/money-helper-overrides.scss
@@ -163,6 +163,33 @@ a {
     }
   }
 
+  &.button--secondary {
+    color: $color-magenta-primary !important;
+    background-color: $color-white-supporting !important;
+    box-shadow: 0 3px 0 rgba(0, 11, 59, 0.25);
+    border: 1px solid $color-magenta-primary;
+
+    &:hover {
+      box-shadow: 0 1px 0 rgba(0, 11, 59, 0.25);
+      color: $color-magenta-dark-primary !important;
+      background-color: $color-light-grey-supporting !important;
+    }
+
+    &:focus {
+      box-shadow: 0 1px 0 rgba(0, 11, 59, 0.25);
+      background-color: $color-yellow-secondary !important;
+      color: $color-dark-blue-secondary !important;
+    }
+
+    &:active,
+    &:active:focus {
+      background-color: $color-light-grey-supporting !important;
+      border: 3px solid $color-violet-primary;
+      color: $color-dark-blue-secondary !important;
+      box-shadow: 0 1px 0 $color-white-supporting, inset 0 5px 2px rgba(0, 11, 59, 0.25);
+    }
+  }
+
   &:disabled {
     background-color: transparent !important;
     border: 1px solid $color-grey;

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -50,4 +50,8 @@ class ApplicationController < ActionController::Base
     # is assumed to not be translated.
     default_locale?
   end
+
+  def verifier
+    Rails.application.message_verifier(:rebooked_from)
+  end
 end

--- a/app/controllers/cancels_controller.rb
+++ b/app/controllers/cancels_controller.rb
@@ -35,7 +35,8 @@ class CancelsController < ApplicationController
         :reference,
         :date_of_birth_year,
         :date_of_birth_month,
-        :date_of_birth_day
+        :date_of_birth_day,
+        :reason
       )
   end
 end

--- a/app/controllers/cancels_controller.rb
+++ b/app/controllers/cancels_controller.rb
@@ -9,7 +9,7 @@ class CancelsController < ApplicationController
   def create
     if @cancellation.valid?
       if TelephoneAppointmentsApi.new.cancel(@cancellation.to_attributes)
-        redirect_to success_cancel_path(rebooked_from: @cancellation.reference)
+        redirect_to success_cancel_path(rebooked_from: verifier.generate(@cancellation.reference))
       else
         redirect_to failure_cancel_path
       end

--- a/app/controllers/cancels_controller.rb
+++ b/app/controllers/cancels_controller.rb
@@ -1,0 +1,41 @@
+class CancelsController < ApplicationController
+  include Embeddable
+
+  before_action :cancellation, only: %i[new create]
+
+  def new
+  end
+
+  def create
+    if @cancellation.valid?
+      if TelephoneAppointmentsApi.new.cancel(@cancellation.to_attributes)
+        redirect_to success_cancel_path(rebooked_from: @cancellation.reference)
+      else
+        redirect_to failure_cancel_path
+      end
+    else
+      render :new
+    end
+  end
+
+  def success
+    @rebooked_from_id = params[:rebooked_from]
+  end
+
+  private
+
+  def cancellation
+    @cancellation ||= TelephoneCancellation.new(cancellation_params)
+  end
+
+  def cancellation_params
+    params
+      .fetch(:telephone_cancellation, {})
+      .permit(
+        :reference,
+        :date_of_birth_year,
+        :date_of_birth_month,
+        :date_of_birth_day
+      )
+  end
+end

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,0 +1,8 @@
+class ErrorsController < ApplicationController
+  include Gaffe::Errors
+  include Embeddable
+
+  def show
+    render "errors/#{@rescue_response}", status: @status_code
+  end
+end

--- a/app/controllers/telephone_appointments_controller.rb
+++ b/app/controllers/telephone_appointments_controller.rb
@@ -97,7 +97,7 @@ class TelephoneAppointmentsController < ApplicationController # rubocop:disable 
   end
 
   def assign_rebook_after_cancellation
-    cookies[:rebooked_from_id] = params[:rebooked_from]
+    cookies[:rebooked_from_id] = verifier.verify(params[:rebooked_from]) if params[:rebooked_from]
   end
 
   def slots_cache_key

--- a/app/lib/telephone_appointments_api.rb
+++ b/app/lib/telephone_appointments_api.rb
@@ -1,6 +1,13 @@
 class TelephoneAppointmentsApi
   SLOTS_PATH = '/api/v1/bookable_slots'.freeze
 
+  def cancel(attributes)
+    response = connection.post("/api/v1/appointments/#{attributes[:reference]}/cancel", attributes)
+    response.success?
+  rescue HTTPConnection::UnprocessableEntity
+    false
+  end
+
   def create(telephone_appointment)
     response = connection.post('/api/v1/appointments', telephone_appointment.attributes)
 

--- a/app/models/telephone_appointment.rb
+++ b/app/models/telephone_appointment.rb
@@ -24,7 +24,8 @@ class TelephoneAppointment # rubocop:disable Metrics/ClassLength
     :smarter_signposted,
     :lloyds_signposted,
     :schedule_type,
-    :referrer
+    :referrer,
+    :rebooked_from_id
   )
 
   attr_writer(
@@ -112,7 +113,8 @@ class TelephoneAppointment # rubocop:disable Metrics/ClassLength
       smarter_signposted: smarter_signposted,
       lloyds_signposted: lloyds_signposted,
       schedule_type: schedule_type,
-      referrer: referrer
+      referrer: referrer,
+      rebooked_from_id: rebooked_from_id
     }
   end
 

--- a/app/models/telephone_cancellation.rb
+++ b/app/models/telephone_cancellation.rb
@@ -3,12 +3,14 @@ class TelephoneCancellation
 
   CANCELLATION_REASONS = {
     '32' => 'Inconvenient time',
-    '33' => 'Changed mind',
-    '34' => 'Not prepared enough',
-    '35' => 'Booked multiple appointments',
-    '36' => 'Appointment no longer required',
-    '37' => 'Booked wrong type of appointment',
-    '38' => 'Other'
+    '33' => 'Wait time until appointment',
+    '34' => 'Changed mind',
+    '35' => 'Not prepared enough',
+    '36' => 'Booked multiple appointments',
+    '37' => 'Appointment no longer required',
+    '38' => 'Received guidance from alternative source',
+    '39' => 'Booked wrong type of appointment',
+    '40' => 'Other'
   }.freeze
 
   attr_accessor :reference, :date_of_birth_year, :date_of_birth_month, :date_of_birth_day, :reason

--- a/app/models/telephone_cancellation.rb
+++ b/app/models/telephone_cancellation.rb
@@ -1,0 +1,27 @@
+class TelephoneCancellation
+  include ActiveModel::Model
+
+  attr_accessor :reference, :date_of_birth_year, :date_of_birth_month, :date_of_birth_day
+
+  validates :reference, format: /\A\d+\z/
+  validates :date_of_birth, presence: true
+
+  def date_of_birth
+    parts = [date_of_birth_year, date_of_birth_month, date_of_birth_day]
+
+    return unless parts.all?(&:present?)
+
+    parts.map!(&:to_i)
+
+    Date.new(*parts)
+  rescue Date::Error
+    nil
+  end
+
+  def to_attributes
+    {
+      reference: reference,
+      date_of_birth: date_of_birth.to_s
+    }
+  end
+end

--- a/app/models/telephone_cancellation.rb
+++ b/app/models/telephone_cancellation.rb
@@ -1,10 +1,21 @@
 class TelephoneCancellation
   include ActiveModel::Model
 
-  attr_accessor :reference, :date_of_birth_year, :date_of_birth_month, :date_of_birth_day
+  CANCELLATION_REASONS = {
+    '32' => 'Inconvenient time',
+    '33' => 'Changed mind',
+    '34' => 'Not prepared enough',
+    '35' => 'Booked multiple appointments',
+    '36' => 'Appointment no longer required',
+    '37' => 'Booked wrong type of appointment',
+    '38' => 'Other'
+  }.freeze
+
+  attr_accessor :reference, :date_of_birth_year, :date_of_birth_month, :date_of_birth_day, :reason
 
   validates :reference, format: /\A\d+\z/
   validates :date_of_birth, presence: true
+  validates :reason, inclusion: { in: CANCELLATION_REASONS.keys }
 
   def date_of_birth
     parts = [date_of_birth_year, date_of_birth_month, date_of_birth_day]
@@ -21,7 +32,8 @@ class TelephoneCancellation
   def to_attributes
     {
       reference: reference,
-      date_of_birth: date_of_birth.to_s
+      date_of_birth: date_of_birth.to_s,
+      secondary_status: reason
     }
   end
 end

--- a/app/views/cancels/failure.html.erb
+++ b/app/views/cancels/failure.html.erb
@@ -9,7 +9,7 @@
         <a href="https://www.moneyhelper.org.uk/en/pensions-and-retirement/pension-wise" class="button button--primary" target="_blank">Continue to MoneyHelper</a>
       </p>
 
-      <p>If you’re having problems, you can call <strong>0800 138 3944</strong> or email <a href="mailto:booking.pensionwise@moneyhelper.org.uk" target="_blank">booking.pensionwise@moneyhelper.org.uk</a> to cancel your appointment.</p>
+      <p>If you’re having problems, you can call <strong>0800 138 3944</strong> to cancel your appointment.</p>
 
       <p>Please provide your booking reference number (you’ll find this in your confirmation email).</p>
     </div>

--- a/app/views/cancels/failure.html.erb
+++ b/app/views/cancels/failure.html.erb
@@ -1,7 +1,7 @@
 <div class="l-grid-row">
   <div class="l-column-full">
     <div class="govuk-box-highlight failure">
-      <h1 class="bold-large govuk-box-highlight__header">We were unable to cancel your appointment</h1>
+      <h1 class="bold-large">We were unable to cancel your appointment</h1>
       <p>Some of the details you entered don’t match our records. Go back to enter them again.</p>
 
       <p>

--- a/app/views/cancels/failure.html.erb
+++ b/app/views/cancels/failure.html.erb
@@ -1,0 +1,17 @@
+<div class="l-grid-row">
+  <div class="l-column-full">
+    <div class="govuk-box-highlight failure">
+      <h1 class="bold-large govuk-box-highlight__header">We were unable to cancel your appointment</h1>
+      <p>Some of the details you entered don’t match our records. Go back to enter them again.</p>
+
+      <p>
+        <%= link_to 'Return to previous page', new_cancel_path, class: 'button button--secondary' %>
+        <a href="https://www.moneyhelper.org.uk/en/pensions-and-retirement/pension-wise" class="button button--primary" target="_blank">Continue to MoneyHelper</a>
+      </p>
+
+      <p>If you’re having problems, you can call <strong>0800 138 3944</strong> or email <a href="mailto:booking.pensionwise@moneyhelper.org.uk" target="_blank">booking.pensionwise@moneyhelper.org.uk</a> to cancel your appointment.</p>
+
+      <p>Please provide your booking reference number (you’ll find this in your confirmation email).</p>
+    </div>
+  </div>
+</div>

--- a/app/views/cancels/new.html.erb
+++ b/app/views/cancels/new.html.erb
@@ -102,6 +102,20 @@
       </fieldset>
     </div>
 
+    <div class="form-group <%= 'form-group-error' if @cancellation.errors.include?(:reason) %>">
+      <%= f.label :reason, class: 'form-label-bold' do %>
+        Why are you cancelling your Pension Wise appointment?
+        <% if @cancellation.errors.include?(:reason) %>
+          <span class="error-message" id="error"><span class="visually-hidden">Error: </span><%= @cancellation.errors[:reason].to_sentence.capitalize %></span>
+        <% end %>
+      <% end %>
+      <%= f.select :reason,
+            options_for_select(TelephoneCancellation::CANCELLATION_REASONS.invert.to_a, @cancellation.reason),
+            { include_blank: true},
+            { aria: { describedby: 'error' }, class: "t-reason form-control #{'form-control-error' if @cancellation.errors.include?(:reason)}" }
+      %>
+    </div>
+
     <div class="form-group">
       <%= f.submit 'Cancel appointment', class: 'button button--primary t-submit', data: { disable_with: 'Please wait...' } %>
     </div>

--- a/app/views/cancels/new.html.erb
+++ b/app/views/cancels/new.html.erb
@@ -1,0 +1,109 @@
+<div class="l-column-full">
+  <% if @cancellation.errors.any? %>
+    <div class="error-summary t-errors" role="alert" aria-labelledby="error-summary-heading-example-1" tabindex="-1" data-error-summary>
+      <h2 class="heading-medium error-summary-heading" id="error-summary-heading-example-1">
+        Unable to submit the form
+      </h2>
+
+      <p>Check the following:</p>
+
+      <ul class="error-summary-list">
+        <% @cancellation.errors.each do |error| %>
+          <li><%= link_to "#{TelephoneCancellation.human_attribute_name error.attribute} – #{error.message}", "#cancellation_#{error.attribute}" %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <h2 class="slot-picker-header">Cancel your Pension Wise appointment</h2>
+  <p>Enter your booking reference and date of birth to cancel your appointment.</p>
+
+  <%= form_for @cancellation, url: cancel_path do |f| %>
+    <div class="form-group <%= 'form-group-error' if @cancellation.errors.include?(:reference) %>">
+      <%= f.label :reference, class: 'form-label-bold' %>
+      <% if @cancellation.errors.include?(:reference) %>
+        <span class="error-message" id="reference_error"><span class="visually-hidden">Error: </span><%= @cancellation.errors[:reference].to_sentence.capitalize %></span>
+      <% end %>
+      <%= f.text_field :reference, aria: { required: true, describedby: 'reference_error' }, class: "t-booking-reference form-control #{'form-control-error' if @cancellation.errors.include?(:reference)}" %>
+    </div>
+
+    <div class="form-group <%= 'form-group-error' if @cancellation.errors.include?(:date_of_birth) %>">
+      <fieldset>
+        <legend>
+          <span class="form-label-bold">
+            Date of birth
+          </span>
+        </legend>
+        <div class="form-date" id="cancellation_date_of_birth" tabindex="-1">
+          <div class="form-group form-group-day">
+            <label aria-label="Date of birth, day e.g. 25" class="form-label" for="cancellation_date_of_birth_day">
+              <span class="visually-hidden">Date of birth, day e.g. 25</span>
+              <span aria-hidden="true">Day</span>
+            </label>
+            <%=
+              f.number_field(
+                'date_of_birth_day',
+                id: "#{f.object_name}_date_of_birth_day",
+                use_label: false,
+                value: f.object.date_of_birth.try(:day),
+                placeholder: 'DD',
+                class: "f-dob__input form-control js-dob-day t-date-of-birth-day #{'form-control-error' if @cancellation.errors.include?(:date_of_birth)}",
+                pattern: '[0-9]*',
+                min: 1,
+                max: 31,
+                aria: { required: true, describedby: 'date_of_birth_error' }
+              )
+            %>
+          </div>
+          <div class="form-group form-group-month">
+            <label aria-label="Date of birth, month e.g. 12" class="form-label" for="<%= f.object_name %>_date_of_birth_month">
+              <span class="visually-hidden">Date of birth, month e.g. 12</span>
+              <span aria-hidden="true">Month</span>
+            </label>
+            <%=
+              f.number_field(
+                'date_of_birth_month',
+                id: "#{f.object_name}_date_of_birth_month",
+                use_label: false,
+                value: f.object.date_of_birth.try(:month),
+                placeholder: 'MM',
+                class: "form-dob__input form-control js-dob-month t-date-of-birth-month #{'form-control-error' if @cancellation.errors.include?(:date_of_birth)}",
+                pattern: '[0-9]*',
+                min: 1,
+                max: 12,
+                aria: { required: true, describedby: 'date_of_birth_error' }
+              )
+            %>
+          </div>
+          <div class="form-group form-group-year">
+            <label aria-label="Date of birth, year e.g. 1950" class="form-label" for="<%= f.object_name %>_date_of_birth_year">
+              <span class="visually-hidden">Date of birth, year e.g. 1950</span>
+              <span aria-hidden="true">Year</span>
+            </label>
+            <%=
+              f.number_field(
+                'date_of_birth_year',
+                id: "#{f.object_name}_date_of_birth_year",
+                use_label: false,
+                value: f.object.date_of_birth.try(:year),
+                placeholder: 'YYYY',
+                class: "form-dob__input form-control form-dob__input--year js-dob-year t-date-of-birth-year #{'form-control-error' if @cancellation.errors.include?(:date_of_birth)}",
+                pattern: '[0-9]*',
+                min: 100.years.ago.year,
+                max: Date.today.year,
+                aria: { required: true, describedby: 'date_of_birth_error' }
+              )
+            %>
+          </div>
+        </div>
+        <% if @cancellation.errors.include?(:date_of_birth) %>
+          <span class="error-message" id="date_of_birth_error"><span class="visually-hidden">Error: </span><%= @cancellation.errors[:date_of_birth].to_sentence.capitalize %></span>
+        <% end %>
+      </fieldset>
+    </div>
+
+    <div class="form-group">
+      <%= f.submit 'Cancel appointment', class: 'button button--primary t-submit', data: { disable_with: 'Please wait...' } %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/cancels/new.html.erb
+++ b/app/views/cancels/new.html.erb
@@ -20,7 +20,10 @@
 
   <%= form_for @cancellation, url: cancel_path do |f| %>
     <div class="form-group <%= 'form-group-error' if @cancellation.errors.include?(:reference) %>">
-      <%= f.label :reference, class: 'form-label-bold' %>
+      <%= f.label :reference, class: 'form-label-bold' do %>
+        Your booking reference
+        <span class="form-hint">You’ll find this in your confirmation email</span>
+      <% end %>
       <% if @cancellation.errors.include?(:reference) %>
         <span class="error-message" id="reference_error"><span class="visually-hidden">Error: </span><%= @cancellation.errors[:reference].to_sentence.capitalize %></span>
       <% end %>

--- a/app/views/cancels/success.html.erb
+++ b/app/views/cancels/success.html.erb
@@ -3,7 +3,7 @@
     <div class="govuk-box-highlight">
       <h1 class="bold-large govuk-box-highlight__header">Your Pension Wise appointment has been cancelled</h1>
       <p>We'll send an email to confirm your appointment has been cancelled. If you gave us your mobile phone number, we'll also send you an SMS confirmation.</p>
-      <p>To book a new appointment, <a class="t-rebook-link" href="/en/telephone-appointments/new?rebooked_from=<%= @rebooked_from_id %>">visit the MoneyHelper website</a></p>
+      <p>Over 90% of people who have a Pension Wise appointment feel informed about their pension options and well prepared to talk about them with their pension provider. To re-book your appointment, <a class="t-rebook-link" href="/en/telephone-appointments/new?rebooked_from=<%= @rebooked_from_id %>">visit the MoneyHelper website</a></p>
       <p>You can also start a <a href="https://test-pwtriage.moneyhelper.org.uk/en/pension-wise-triage" target="_blank">self-guided appointment online</a> whenever you’re ready.</p>
     </div>
   </div>

--- a/app/views/cancels/success.html.erb
+++ b/app/views/cancels/success.html.erb
@@ -1,0 +1,10 @@
+<div class="l-grid-row">
+  <div class="l-column-full">
+    <div class="govuk-box-highlight">
+      <h1 class="bold-large govuk-box-highlight__header">Your Pension Wise appointment has been cancelled</h1>
+      <p>We'll send an email to confirm your appointment has been cancelled. If you gave us your mobile phone number, we'll also send you an SMS confirmation.</p>
+      <p>To book a new appointment, <a class="t-rebook-link" href="/en/telephone-appointments/new?rebooked_from=<%= @rebooked_from_id %>">visit the MoneyHelper website</a></p>
+      <p>You can also start a <a href="https://test-pwtriage.moneyhelper.org.uk/en/pension-wise-triage" target="_blank">self-guided appointment online</a> whenever you’re ready.</p>
+    </div>
+  </div>
+</div>

--- a/app/views/cancels/success.html.erb
+++ b/app/views/cancels/success.html.erb
@@ -1,9 +1,11 @@
 <div class="l-grid-row">
   <div class="l-column-full">
     <div class="govuk-box-highlight">
-      <h1 class="bold-large govuk-box-highlight__header">Your Pension Wise appointment has been cancelled</h1>
+      <h1 class="bold-large">Your Pension Wise appointment has been cancelled</h1>
       <p>We'll send an email to confirm your appointment has been cancelled. If you gave us your mobile phone number, we'll also send you an SMS confirmation.</p>
-      <p>Over 90% of people who have a Pension Wise appointment feel informed about their pension options and well prepared to talk about them with their pension provider. To re-book your appointment, <a class="t-rebook-link" href="/en/telephone-appointments/new?rebooked_from=<%= @rebooked_from_id %>">visit the MoneyHelper website</a></p>
+
+      <h2 class="bold-medium">Rebook your appointment?</h2>
+      <p>Over 90% of people who have a Pension Wise appointment feel informed about their pension options and well prepared to talk about them with their pension provider. To rebook your appointment, <a class="t-rebook-link" href="/en/telephone-appointments/new?rebooked_from=<%= @rebooked_from_id %>">visit the MoneyHelper website</a></p>
       <p>You can also start a <a href="https://test-pwtriage.moneyhelper.org.uk/en/pension-wise-triage" target="_blank">self-guided appointment online</a> whenever you’re ready.</p>
     </div>
   </div>

--- a/app/views/cancels/success.html.erb
+++ b/app/views/cancels/success.html.erb
@@ -6,7 +6,6 @@
 
       <h2 class="bold-medium">Rebook your appointment?</h2>
       <p>Over 90% of people who have a Pension Wise appointment feel informed about their pension options and well prepared to talk about them with their pension provider. To rebook your appointment, <a class="t-rebook-link" href="/en/telephone-appointments/new?rebooked_from=<%= @rebooked_from_id %>">visit the MoneyHelper website</a></p>
-      <p>You can also start a <a href="https://test-pwtriage.moneyhelper.org.uk/en/pension-wise-triage" target="_blank">self-guided appointment online</a> whenever you’re ready.</p>
     </div>
   </div>
 </div>

--- a/app/views/errors/internal_server_error.html.erb
+++ b/app/views/errors/internal_server_error.html.erb
@@ -1,5 +1,6 @@
 <% content_for(:page_title, t('service.title', page_title: 'Sorry, we are experiencing technical difficulties (500 error)')) %>
 
-<h1>Sorry, we're having some technical problems</h1>
-
-<p>Please try again in a few moments.</p>
+<div class="l-column-full">
+  <h1>Sorry, we're having some technical problems</h1>
+  <p>Please try again in a few moments.</p>
+</div>

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -1,7 +1,3 @@
 <% content_for(:page_title, t('service.title', page_title: 'Page not found (404 error)')) %>
 
 <h1>Page not found</h1>
-
-<p>Please check that you entered the correct web address.</p>
-
-<p>Or, you can <%= link_to 'browse from the homepage', root_path %> to find the information you need.</p>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -10,7 +10,7 @@ Rails.application.configure do
   config.eager_load = false
 
   # Show full error reports and disable caching.
-  config.consider_all_requests_local = true
+  config.consider_all_requests_local = false
   config.action_controller.perform_caching = false
 
   # Print deprecation notices to the Rails logger.

--- a/config/initializers/gaffe.rb
+++ b/config/initializers/gaffe.rb
@@ -1,1 +1,5 @@
+Gaffe.configure do |config|
+  config.errors_controller = 'ErrorsController'
+end
+
 Gaffe.enable!

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -238,6 +238,12 @@ en:
               inclusion: select an option
             accept_terms_and_conditions:
               inclusion: please accept
+        telephone_cancellation:
+          attributes:
+            reference:
+              invalid: provide your booking reference with only digits
+            date_of_birth:
+              blank: enter a valid date of birth
         telephone_appointment:
           attributes:
             first_name:
@@ -317,6 +323,8 @@ en:
       employer/booking:
         dc_pot_confirmed: Defined contribution pension
         accept_terms_and_conditions: Terms and conditions
+      telephone_cancellation:
+        reference: Your booking reference
       telephone_appointment:
         dc_pot_confirmed: Defined contribution pension
         accept_terms_and_conditions: Terms and conditions

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -244,6 +244,8 @@ en:
               invalid: provide your booking reference with only digits
             date_of_birth:
               blank: enter a valid date of birth
+            reason:
+              inclusion: please choose a cancellation reason
         telephone_appointment:
           attributes:
             first_name:
@@ -325,6 +327,7 @@ en:
         accept_terms_and_conditions: Terms and conditions
       telephone_cancellation:
         reference: Your booking reference
+        reason: Why are you cancelling your Pension Wise appointment?
       telephone_appointment:
         dc_pot_confirmed: Defined contribution pension
         accept_terms_and_conditions: Terms and conditions

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -99,6 +99,13 @@ Rails.application.routes.draw do
 
       resources :telephone_appointments, only: %i[new create], path: 'telephone-appointments' do
         collection do
+          resource :cancel, only: %i[new create] do
+            get :success
+            get :failure
+          end
+        end
+
+        collection do
           get :nudge
           get :ineligible
           get :confirmation

--- a/features/pages/telephone_appointment_cancellation.rb
+++ b/features/pages/telephone_appointment_cancellation.rb
@@ -1,0 +1,12 @@
+module Pages
+  class TelephoneAppointmentCancellation < SitePrism::Page
+    set_url '/en/telephone-appointments/cancel/new'
+
+    element :errors, '.t-errors'
+    element :booking_reference, '.t-booking-reference'
+    element :date_of_birth_day, '.t-date-of-birth-day'
+    element :date_of_birth_month, '.t-date-of-birth-month'
+    element :date_of_birth_year, '.t-date-of-birth-year'
+    element :submit, '.t-submit'
+  end
+end

--- a/features/pages/telephone_appointment_cancellation.rb
+++ b/features/pages/telephone_appointment_cancellation.rb
@@ -7,6 +7,7 @@ module Pages
     element :date_of_birth_day, '.t-date-of-birth-day'
     element :date_of_birth_month, '.t-date-of-birth-month'
     element :date_of_birth_year, '.t-date-of-birth-year'
+    element :reason, '.t-reason'
     element :submit, '.t-submit'
   end
 end

--- a/features/pages/telephone_appointment_cancellation_failure.rb
+++ b/features/pages/telephone_appointment_cancellation_failure.rb
@@ -1,0 +1,5 @@
+module Pages
+  class TelephoneAppointmentCancellationFailure < SitePrism::Page
+    set_url '/en/telephone-appointments/cancel/failure'
+  end
+end

--- a/features/pages/telephone_appointment_cancellation_success.rb
+++ b/features/pages/telephone_appointment_cancellation_success.rb
@@ -1,0 +1,7 @@
+module Pages
+  class TelephoneAppointmentCancellationSuccess < SitePrism::Page
+    set_url '/en/telephone-appointments/cancel/success'
+
+    element :rebook_link, '.t-rebook-link'
+  end
+end

--- a/spec/cassettes/Telephone_appointment_cancellations/Failing_to_cancel_the_appointment.yml
+++ b/spec/cassettes/Telephone_appointment_cancellations/Failing_to_cancel_the_appointment.yml
@@ -1,0 +1,52 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://localhost:3000/api/v1/appointments/181432/cancel
+    body:
+      encoding: UTF-8
+      string: '{"reference":"181432","date_of_birth":"1972-02-02"}'
+    headers:
+      User-Agent:
+      - PensionWise/1.0 (birdperson2; benlovell; 45629) ruby/3.2.2 (53; arm64-darwin22)
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 422
+      message: Unprocessable Content
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-cache
+      Set-Cookie:
+      - _telephone_appointment_planner_session=JZqSTqhNsJoXsjbSg4yCNm%2FxY8IaqDS9CuFcs%2BBc7rUW4wyZbE0efyJExyJz5eaFiS9JC76w72EJKdwF4zxZU05l5ghVbmG%2FkeE9mvsRMyLnpI3etjwYqayI8TTSfYINpVWXoFyrZrONsx0a6Rj%2FfuxNWnHgq%2B4nUCwyX0zUdksdlKfdkzc4Wy9XI2rNNAdqfltQXkM%2BjYjk18BhwN4%3D--%2BjTTNUTQHU0oezaf--vbgLFt2FTZszP7S5MEq%2BFQ%3D%3D;
+        path=/; HttpOnly; SameSite=Lax
+      X-Request-Id:
+      - 936cbb2e-584a-4af6-9dae-31f972769927
+      X-Runtime:
+      - '0.019694'
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Wed, 19 Jun 2024 20:23:34 GMT
+recorded_with: VCR 6.2.0

--- a/spec/cassettes/Telephone_appointment_cancellations/Failing_to_cancel_the_appointment.yml
+++ b/spec/cassettes/Telephone_appointment_cancellations/Failing_to_cancel_the_appointment.yml
@@ -2,13 +2,13 @@
 http_interactions:
 - request:
     method: post
-    uri: http://localhost:3000/api/v1/appointments/181432/cancel
+    uri: http://localhost:3000/api/v1/appointments/181437/cancel
     body:
       encoding: UTF-8
-      string: '{"reference":"181432","date_of_birth":"1972-02-02"}'
+      string: '{"reference":"181437","date_of_birth":"1950-01-01","secondary_status":"28"}'
     headers:
       User-Agent:
-      - PensionWise/1.0 (birdperson2; benlovell; 45629) ruby/3.2.2 (53; arm64-darwin22)
+      - PensionWise/1.0 (birdperson2; benlovell; 22569) ruby/3.2.2 (53; arm64-darwin22)
       Accept:
       - application/json
       Content-Type:
@@ -37,16 +37,16 @@ http_interactions:
       Cache-Control:
       - no-cache
       Set-Cookie:
-      - _telephone_appointment_planner_session=JZqSTqhNsJoXsjbSg4yCNm%2FxY8IaqDS9CuFcs%2BBc7rUW4wyZbE0efyJExyJz5eaFiS9JC76w72EJKdwF4zxZU05l5ghVbmG%2FkeE9mvsRMyLnpI3etjwYqayI8TTSfYINpVWXoFyrZrONsx0a6Rj%2FfuxNWnHgq%2B4nUCwyX0zUdksdlKfdkzc4Wy9XI2rNNAdqfltQXkM%2BjYjk18BhwN4%3D--%2BjTTNUTQHU0oezaf--vbgLFt2FTZszP7S5MEq%2BFQ%3D%3D;
+      - _telephone_appointment_planner_session=rLFKyNjj8Zm9cReKbMHiHIpnmx2IIvz3SAhEdmZlz5QYcdkKrJ0DTCBJnHCfDVyYhvLj4vNUKwJC%2FuATtOD5BlOlugi5b6UgzB0%2F9JFL1X%2FdH3d6%2FCDCaEOss2mt4Fhrl%2FVeAg1fs2nFs4PaUg1agY7RkD8mjXlKWdrWR1XoHorQD9u4T0gtOoycQAnWJDQFGRVkLa7RKunChaKcFPo%3D--DXYH7abPFwBCKGih--jWseQd23e12xM9Sham%2Fz8w%3D%3D;
         path=/; HttpOnly; SameSite=Lax
       X-Request-Id:
-      - 936cbb2e-584a-4af6-9dae-31f972769927
+      - 2cb7f97e-ca91-4b53-a6d4-114bd72602fd
       X-Runtime:
-      - '0.019694'
+      - '0.053803'
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: ''
-  recorded_at: Wed, 19 Jun 2024 20:23:34 GMT
+  recorded_at: Fri, 21 Jun 2024 13:16:51 GMT
 recorded_with: VCR 6.2.0

--- a/spec/cassettes/Telephone_appointment_cancellations/Successfully_cancelling_the_appointment.yml
+++ b/spec/cassettes/Telephone_appointment_cancellations/Successfully_cancelling_the_appointment.yml
@@ -2,13 +2,13 @@
 http_interactions:
 - request:
     method: post
-    uri: http://localhost:3000/api/v1/appointments/181432/cancel
+    uri: http://localhost:3000/api/v1/appointments/181437/cancel
     body:
       encoding: UTF-8
-      string: '{"reference":"181432","date_of_birth":"1972-02-02"}'
+      string: '{"reference":"181437","date_of_birth":"1950-01-01","secondary_status":"28"}'
     headers:
       User-Agent:
-      - PensionWise/1.0 (birdperson2; benlovell; 43338) ruby/3.2.2 (53; arm64-darwin22)
+      - PensionWise/1.0 (birdperson2; benlovell; 22569) ruby/3.2.2 (53; arm64-darwin22)
       Accept:
       - application/json
       Content-Type:
@@ -37,16 +37,16 @@ http_interactions:
       Cache-Control:
       - no-cache
       Set-Cookie:
-      - _telephone_appointment_planner_session=1RW1I2SCLqht%2FNfeOlNDcF8uY8r9nHKK29IO%2FleWVMFYWHn7k44lrcaogB6uuewmj2QgXXRfTf86AOxccqhjuKCo%2BHjCYdSHJLyNGsAFi3b5Z2ge6T5EOcmVoEWD1kEmQ0VtTWZSQ4g02pJH4poyAjUtE8qY%2BwpcaK7tcVfSn95kybdfiq%2FaACwm7vumKmmziFaurqcMBR%2Bun1MtyTk%3D--8in5Wtd5KWQX1vxR--%2F%2BzJp6IAvAfVcIqSdzEEcQ%3D%3D;
+      - _telephone_appointment_planner_session=xinEc58EMFwpXZKrfIt1TgofgRlrUXfPO1j%2BhBm%2BpglpxzjheaBD72MH3%2BwSLOffta7pOKI3O9qHnXB5NIdbRqajrnesjnDR4VfFPTnMqoaiy9S5piX%2BrERkO6EtX1eqU7ZpSF3I4JP6w42H2DsOgHrnHTo4a49yD8%2FKuTAEuIVBuUkj8HjutFmLRE8EkMI%2BQAFfb4bck%2FokJItgYm0%3D--TD5L2meTG%2FoWNVSU--msUw8VlrR1%2B4n6uc2xPSdA%3D%3D;
         path=/; HttpOnly; SameSite=Lax
       X-Request-Id:
-      - 19bd1a96-fc2e-41d5-87f9-aaa06f8164ef
+      - c7db1364-0d02-48d6-8fc3-5fbd044cb8c9
       X-Runtime:
-      - '0.048463'
+      - '0.044538'
       Content-Length:
       - '0'
     body:
       encoding: UTF-8
       string: ''
-  recorded_at: Wed, 19 Jun 2024 20:13:41 GMT
+  recorded_at: Fri, 21 Jun 2024 13:16:50 GMT
 recorded_with: VCR 6.2.0

--- a/spec/cassettes/Telephone_appointment_cancellations/Successfully_cancelling_the_appointment.yml
+++ b/spec/cassettes/Telephone_appointment_cancellations/Successfully_cancelling_the_appointment.yml
@@ -1,0 +1,52 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://localhost:3000/api/v1/appointments/181432/cancel
+    body:
+      encoding: UTF-8
+      string: '{"reference":"181432","date_of_birth":"1972-02-02"}'
+    headers:
+      User-Agent:
+      - PensionWise/1.0 (birdperson2; benlovell; 43338) ruby/3.2.2 (53; arm64-darwin22)
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-cache
+      Set-Cookie:
+      - _telephone_appointment_planner_session=1RW1I2SCLqht%2FNfeOlNDcF8uY8r9nHKK29IO%2FleWVMFYWHn7k44lrcaogB6uuewmj2QgXXRfTf86AOxccqhjuKCo%2BHjCYdSHJLyNGsAFi3b5Z2ge6T5EOcmVoEWD1kEmQ0VtTWZSQ4g02pJH4poyAjUtE8qY%2BwpcaK7tcVfSn95kybdfiq%2FaACwm7vumKmmziFaurqcMBR%2Bun1MtyTk%3D--8in5Wtd5KWQX1vxR--%2F%2BzJp6IAvAfVcIqSdzEEcQ%3D%3D;
+        path=/; HttpOnly; SameSite=Lax
+      X-Request-Id:
+      - 19bd1a96-fc2e-41d5-87f9-aaa06f8164ef
+      X-Runtime:
+      - '0.048463'
+      Content-Length:
+      - '0'
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Wed, 19 Jun 2024 20:13:41 GMT
+recorded_with: VCR 6.2.0

--- a/spec/features/telephone_appointment_cancellation_spec.rb
+++ b/spec/features/telephone_appointment_cancellation_spec.rb
@@ -57,6 +57,8 @@ RSpec.feature 'Telephone appointment cancellations' do
     expect(@page).to be_displayed
 
     # tee up the rebook from this original appointment
-    expect(@page.rebook_link[:href]).to eq('/en/telephone-appointments/new?rebooked_from=181437')
+    expect(@page.rebook_link[:href]).to eq(
+      '/en/telephone-appointments/new?rebooked_from=BAhJIgsxODE0MzcGOgZFVA==--24b5a0aac3366484c18b1780c4a1ac90886fb015'
+    )
   end
 end

--- a/spec/features/telephone_appointment_cancellation_spec.rb
+++ b/spec/features/telephone_appointment_cancellation_spec.rb
@@ -1,0 +1,61 @@
+require_relative '../../features/pages/telephone_appointment_cancellation'
+require_relative '../../features/pages/telephone_appointment_cancellation_success'
+require_relative '../../features/pages/telephone_appointment_cancellation_failure'
+
+RSpec.feature 'Telephone appointment cancellations' do
+  scenario 'Successfully cancelling the appointment', vcr: true do
+    given_the_customer_visits_the_cancellation_page
+    when_they_complete_their_appointment_details
+    then_they_see_the_cancellation_success_page
+  end
+
+  scenario 'Seeing validation errors when nothing is provided' do
+    given_the_customer_visits_the_cancellation_page
+    when_they_dont_complete_their_appointment_details
+    then_they_see_the_validation_errors
+  end
+
+  scenario 'Failing to cancel the appointment', vcr: true do
+    given_the_customer_visits_the_cancellation_page
+    when_they_complete_their_appointment_details
+    then_they_see_the_cancellation_failure_page
+  end
+
+  def then_they_see_the_cancellation_failure_page
+    @page = Pages::TelephoneAppointmentCancellationFailure.new
+    expect(@page).to be_displayed
+  end
+
+  def when_they_dont_complete_their_appointment_details
+    expect(@page).to be_displayed
+
+    @page.submit.click
+  end
+
+  def then_they_see_the_validation_errors
+    expect(@page).to have_errors
+  end
+
+  def given_the_customer_visits_the_cancellation_page
+    @page = Pages::TelephoneAppointmentCancellation.new
+    @page.load
+  end
+
+  def when_they_complete_their_appointment_details
+    expect(@page).to be_displayed
+
+    @page.booking_reference.set '181432'
+    @page.date_of_birth_day.set '2'
+    @page.date_of_birth_month.set '2'
+    @page.date_of_birth_year.set '1972'
+    @page.submit.click
+  end
+
+  def then_they_see_the_cancellation_success_page
+    @page = Pages::TelephoneAppointmentCancellationSuccess.new
+    expect(@page).to be_displayed
+
+    # tee up the rebook from this original appointment
+    expect(@page.rebook_link[:href]).to eq('/en/telephone-appointments/new?rebooked_from=181432')
+  end
+end

--- a/spec/features/telephone_appointment_cancellation_spec.rb
+++ b/spec/features/telephone_appointment_cancellation_spec.rb
@@ -44,10 +44,11 @@ RSpec.feature 'Telephone appointment cancellations' do
   def when_they_complete_their_appointment_details
     expect(@page).to be_displayed
 
-    @page.booking_reference.set '181432'
-    @page.date_of_birth_day.set '2'
-    @page.date_of_birth_month.set '2'
-    @page.date_of_birth_year.set '1972'
+    @page.booking_reference.set '181437'
+    @page.date_of_birth_day.set '1'
+    @page.date_of_birth_month.set '1'
+    @page.date_of_birth_year.set '1950'
+    @page.reason.select 'Inconvenient time'
     @page.submit.click
   end
 
@@ -56,6 +57,6 @@ RSpec.feature 'Telephone appointment cancellations' do
     expect(@page).to be_displayed
 
     # tee up the rebook from this original appointment
-    expect(@page.rebook_link[:href]).to eq('/en/telephone-appointments/new?rebooked_from=181432')
+    expect(@page.rebook_link[:href]).to eq('/en/telephone-appointments/new?rebooked_from=181437')
   end
 end

--- a/spec/features/telephone_appointment_spec.rb
+++ b/spec/features/telephone_appointment_spec.rb
@@ -1,6 +1,12 @@
 require_relative '../../features/pages/new_telephone_appointment'
 
 RSpec.feature 'Customer books a telephone appointment', type: :feature do
+  scenario 'When creating a booking from a cancellation referral' do
+    with_telephone_availability
+    when_the_customer_creates_a_booking_from_a_cancellation
+    then_the_booking_is_marked_as_referred
+  end
+
   scenario 'Viewing the widget frame' do
     with_telephone_availability
     when_the_widget_is_embedded
@@ -8,6 +14,15 @@ RSpec.feature 'Customer books a telephone appointment', type: :feature do
     and_the_skip_link_is_omitted
     and_the_cookie_banner_is_omitted
     and_the_frame_options_are_permissive
+  end
+
+  def when_the_customer_creates_a_booking_from_a_cancellation
+    @page = Pages::NewTelephoneAppointment.new
+    @page.load(locale: :en, query: { rebooked_from: '123456' })
+  end
+
+  def then_the_booking_is_marked_as_referred
+    expect(@page.response_headers['Set-Cookie']).to eq('rebooked_from_id=123456; path=/')
   end
 
   def when_the_widget_is_embedded

--- a/spec/features/telephone_appointment_spec.rb
+++ b/spec/features/telephone_appointment_spec.rb
@@ -18,11 +18,14 @@ RSpec.feature 'Customer books a telephone appointment', type: :feature do
 
   def when_the_customer_creates_a_booking_from_a_cancellation
     @page = Pages::NewTelephoneAppointment.new
-    @page.load(locale: :en, query: { rebooked_from: '123456' })
+    @page.load(
+      locale: :en,
+      query: { rebooked_from: 'BAhJIgsxODE0MzcGOgZFVA==--24b5a0aac3366484c18b1780c4a1ac90886fb015' }
+    )
   end
 
   def then_the_booking_is_marked_as_referred
-    expect(@page.response_headers['Set-Cookie']).to eq('rebooked_from_id=123456; path=/')
+    expect(@page.response_headers['Set-Cookie']).to eq('rebooked_from_id=181437; path=/')
   end
 
   def when_the_widget_is_embedded

--- a/spec/models/telephone_appointment_spec.rb
+++ b/spec/models/telephone_appointment_spec.rb
@@ -17,7 +17,8 @@ RSpec.describe TelephoneAppointment, type: :model do
       notes: 'meh',
       smarter_signposted: 'true',
       nudged: 'false',
-      embedded: 'false'
+      embedded: 'false',
+      rebooked_from_id: '1234567'
     )
   end
 

--- a/spec/models/telephone_cancellation_spec.rb
+++ b/spec/models/telephone_cancellation_spec.rb
@@ -1,0 +1,28 @@
+RSpec.describe TelephoneCancellation, type: :model do
+  subject do
+    described_class.new(
+      reference: '1234567',
+      date_of_birth_year: '1920',
+      date_of_birth_month: '01',
+      date_of_birth_day: '01'
+    )
+  end
+
+  describe 'validation' do
+    it 'is valid with valid attributes' do
+      expect(subject).to be_valid
+    end
+
+    it 'requires a valid booking reference' do
+      subject.reference = '12 09 09'
+
+      expect(subject).to be_invalid
+    end
+
+    it 'requires a valid date of birth' do
+      subject.date_of_birth_day = '99'
+
+      expect(subject).to be_invalid
+    end
+  end
+end

--- a/spec/models/telephone_cancellation_spec.rb
+++ b/spec/models/telephone_cancellation_spec.rb
@@ -4,7 +4,8 @@ RSpec.describe TelephoneCancellation, type: :model do
       reference: '1234567',
       date_of_birth_year: '1920',
       date_of_birth_month: '01',
-      date_of_birth_day: '01'
+      date_of_birth_day: '01',
+      reason: '32'
     )
   end
 
@@ -21,6 +22,12 @@ RSpec.describe TelephoneCancellation, type: :model do
 
     it 'requires a valid date of birth' do
       subject.date_of_birth_day = '99'
+
+      expect(subject).to be_invalid
+    end
+
+    it 'requires a valid reason' do
+      subject.reason = ''
 
       expect(subject).to be_invalid
     end


### PR DESCRIPTION
This journey in concert with a TAP API allows the customer to cancel an appointment by self-serve. The cancelled appointment is processed in TAP accordingly and rebooks issued after are linked to the original cancellation for reporting purposes.