### PR TITLE
Improve a11y contrast on selected day element

### DIFF
--- a/app/assets/stylesheets/components/slot-picker/_slot-picker-calendar.scss
+++ b/app/assets/stylesheets/components/slot-picker/_slot-picker-calendar.scss
@@ -96,6 +96,11 @@
   color: $color-white-supporting;
   cursor: default;
   font-weight: bold;
+
+  .slot-picker-calendar__day-text {
+    color: $color-white-supporting;
+    font-weight: bold;
+  }
 }
 
 .slot-picker-calendar__action--busy {


### PR DESCRIPTION
There was a bug whereby the selected day text would not present with enough contrast. This was picked up during an a11y check. The selected days now present a bold, white font over the magenta background.