### PR TITLE
Add cancellation reason for 'other'

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -17,6 +17,7 @@
 //= require components/CharacterLimit
 //= require components/ErrorSummary
 //= require components/CustomerAge
+//= require components/SelectToggle
 
 PWPG.clickTracker.init();
 PWPG.calculators.init();
@@ -79,4 +80,11 @@ $('[data-customer-age]').each(function() {
 
   var $component = $(this);
   new PWPG.CustomerAge($component);
+});
+
+$('[data-select-toggle]').each(function() {
+  'use strict';
+
+  var $component = $(this);
+  new PWPG.SelectToggle($component);
 });

--- a/app/assets/javascripts/components/SelectToggle.es6
+++ b/app/assets/javascripts/components/SelectToggle.es6
@@ -1,0 +1,33 @@
+{
+  'use strict';
+
+  class SelectToggle extends PWPG.BaseComponent {
+    constructor($component) {
+      super($component);
+      this.$select = $(this.$component.data('select'));
+      this.$target = $(this.$component.data('target'));
+      this.$match = this.$component.data('match').toString();
+
+      this.bindEvents();
+      this.selectChanged();
+    }
+
+    bindEvents() {
+      this.$select.on('change', this.selectChanged.bind(this));
+    }
+
+    selectChanged() {
+      if(this.$select.val() === this.$match)
+      {
+        this.$target.removeClass('js-hidden');
+      }
+      else
+      {
+        this.$target.addClass('js-hidden');
+      }
+    }
+  }
+
+  window.PWPG = window.PWPG || {};
+  window.PWPG.SelectToggle = SelectToggle;
+}

--- a/app/controllers/cancels_controller.rb
+++ b/app/controllers/cancels_controller.rb
@@ -36,7 +36,8 @@ class CancelsController < ApplicationController
         :date_of_birth_year,
         :date_of_birth_month,
         :date_of_birth_day,
-        :reason
+        :reason,
+        :other_reason
       )
   end
 end

--- a/app/models/telephone_cancellation.rb
+++ b/app/models/telephone_cancellation.rb
@@ -13,11 +13,12 @@ class TelephoneCancellation
     '40' => 'Other'
   }.freeze
 
-  attr_accessor :reference, :date_of_birth_year, :date_of_birth_month, :date_of_birth_day, :reason
+  attr_accessor :reference, :date_of_birth_year, :date_of_birth_month, :date_of_birth_day, :reason, :other_reason
 
   validates :reference, format: /\A\d+\z/
   validates :date_of_birth, presence: true
   validates :reason, inclusion: { in: CANCELLATION_REASONS.keys }
+  validates :other_reason, presence: true, length: { maximum: 160 }, if: :reason_is_other?
 
   def date_of_birth
     parts = [date_of_birth_year, date_of_birth_month, date_of_birth_day]
@@ -35,7 +36,12 @@ class TelephoneCancellation
     {
       reference: reference,
       date_of_birth: date_of_birth.to_s,
-      secondary_status: reason
+      secondary_status: reason,
+      other_reason: other_reason
     }
+  end
+
+  def reason_is_other?
+    reason == CANCELLATION_REASONS.keys.last
   end
 end

--- a/app/views/cancels/new.html.erb
+++ b/app/views/cancels/new.html.erb
@@ -124,14 +124,14 @@
       %>
     </div>
 
-    <div class="js-other-reason js-hidden form-group <%= 'form-group-error' if @cancellation.errors.include?(:other_reason) %>">
+    <div class="js-other-reason js-hidden form-group <%= 'form-group-error' if @cancellation.errors.include?(:other_reason) %>" data-character-limit>
       <%= f.label :reference, class: 'form-label-bold' do %>
         Specify a reason
       <% end %>
       <% if @cancellation.errors.include?(:other_reason) %>
         <span class="error-message" id="other_reason_error"><span class="visually-hidden">Error: </span><%= @cancellation.errors[:other_reason].to_sentence.capitalize %></span>
       <% end %>
-      <%= f.text_field :other_reason, aria: { required: true, describedby: 'other_reason_error' }, class: "t-other-reason form-control #{'form-control-error' if @cancellation.errors.include?(:other_reason)}" %>
+      <%= f.text_field :other_reason, maxlength: 160, aria: { required: true, describedby: 'other_reason_error' }, class: "t-other-reason js-character-limit-input form-control #{'form-control-error' if @cancellation.errors.include?(:other_reason)}", data: { maxlength: 160 } %>
     </div>
 
     <div class="form-group">

--- a/app/views/cancels/new.html.erb
+++ b/app/views/cancels/new.html.erb
@@ -9,7 +9,7 @@
 
       <ul class="error-summary-list">
         <% @cancellation.errors.each do |error| %>
-          <li><%= link_to "#{TelephoneCancellation.human_attribute_name error.attribute} – #{error.message}", "#cancellation_#{error.attribute}" %></li>
+          <li><%= link_to "#{TelephoneCancellation.human_attribute_name error.attribute} – #{error.message}", "#telephone_cancellation_#{error.attribute}" %></li>
         <% end %>
       </ul>
     </div>
@@ -105,7 +105,12 @@
       </fieldset>
     </div>
 
-    <div class="form-group <%= 'form-group-error' if @cancellation.errors.include?(:reason) %>">
+    <div class="form-group <%= 'form-group-error' if @cancellation.errors.include?(:reason) %>"
+       data-select-toggle
+       data-select=".js-reason"
+       data-target=".js-other-reason"
+       data-match="40"
+      >
       <%= f.label :reason, class: 'form-label-bold' do %>
         Why are you cancelling your Pension Wise appointment?
         <% if @cancellation.errors.include?(:reason) %>
@@ -115,8 +120,18 @@
       <%= f.select :reason,
             options_for_select(TelephoneCancellation::CANCELLATION_REASONS.invert.to_a, @cancellation.reason),
             { include_blank: true},
-            { aria: { describedby: 'error' }, class: "t-reason form-control #{'form-control-error' if @cancellation.errors.include?(:reason)}" }
+            { aria: { describedby: 'error' }, class: "js-reason t-reason form-control #{'form-control-error' if @cancellation.errors.include?(:reason)}" }
       %>
+    </div>
+
+    <div class="js-other-reason js-hidden form-group <%= 'form-group-error' if @cancellation.errors.include?(:other_reason) %>">
+      <%= f.label :reference, class: 'form-label-bold' do %>
+        Specify a reason
+      <% end %>
+      <% if @cancellation.errors.include?(:other_reason) %>
+        <span class="error-message" id="other_reason_error"><span class="visually-hidden">Error: </span><%= @cancellation.errors[:other_reason].to_sentence.capitalize %></span>
+      <% end %>
+      <%= f.text_field :other_reason, aria: { required: true, describedby: 'other_reason_error' }, class: "t-other-reason form-control #{'form-control-error' if @cancellation.errors.include?(:other_reason)}" %>
     </div>
 
     <div class="form-group">

--- a/spec/models/telephone_cancellation_spec.rb
+++ b/spec/models/telephone_cancellation_spec.rb
@@ -31,5 +31,15 @@ RSpec.describe TelephoneCancellation, type: :model do
 
       expect(subject).to be_invalid
     end
+
+    context 'when the reason is Other' do
+      it 'requires a valid other reason' do
+        subject.reason = '40' # Other
+        expect(subject).to be_invalid
+
+        subject.other_reason = 'Because my cat got sick!'
+        expect(subject).to be_valid
+      end
+    end
   end
 end


### PR DESCRIPTION
Allow the customer to specify a description when they choose the 'other' option for a reason during online cancellation.