### PR TITLE
Serve up the cloudflare 2fa reset identifier

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,6 +1,12 @@
 class HomeController < ApplicationController
   layout 'home'
 
+  skip_before_action :set_locale, only: :cloudflare
+
+  def cloudflare
+    render plain: 'jlr2ehvq75gph87j', layout: false
+  end
+
   def show
     expires_in Rails.application.config.cache_max_age, public: true
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 # rubocop:disable Metrics/BlockLength
 Rails.application.routes.draw do
+  get '/.well-known/cf-2fa-verify.txt', to: 'home#cloudflare'
+
   resources :booking_requests,
             only: %i[new create],
             path: '/cy/booking-requests',

--- a/spec/requests/cloudflare_spec.rb
+++ b/spec/requests/cloudflare_spec.rb
@@ -1,0 +1,7 @@
+RSpec.describe 'Cloudflare 2FA identification', type: :request do
+  it 'returns the identifier txt' do
+    get '/.well-known/cf-2fa-verify.txt'
+
+    expect(response.body).to eq('jlr2ehvq75gph87j')
+  end
+end


### PR DESCRIPTION
This is on request from cloudflare so we can reset the 2FA on the super-admin account that's being locked out.